### PR TITLE
Translate Czech comments in FTP worker

### DIFF
--- a/src/plugins/ftp/operatsa.cpp
+++ b/src/plugins/ftp/operatsa.cpp
@@ -19,16 +19,16 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
     char userBuf[USER_MAX_SIZE];
     unsigned short portBuf;
     CFTPQueueItemCopyMoveUploadExplore* curItem = (CFTPQueueItemCopyMoveUploadExplore*)CurItem;
-    CUploadListingItem* existingItem = NULL; // pro predavani dat o polozce listingu mezi ruznymi SubState
+    CUploadListingItem* existingItem = NULL; // for passing listing item data between different SubStates
     while (1)
     {
         BOOL nextLoop = FALSE;
         switch (SubState)
         {
-        case fwssWorkStartWork: // zjistime v jakem stavu je cilovy adresar
+        case fwssWorkStartWork: // determine the state of the target directory
         {
             if (ShouldStop)
-                handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                handleShouldStop = TRUE; // check whether the worker should stop
             else
             {
                 if (curItem->TgtDirState == UPLOADTGTDIRSTATE_UNKNOWN)
@@ -43,54 +43,54 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                                                       &notAccessible, &getListing, curItem->TgtName,
                                                       &existingItem, NULL))
                     {
-                        if (listingInProgress) // listovani prave probiha nebo ma ted probehnout
+                        if (listingInProgress) // the listing is currently running or is about to start
                         {
-                            if (getListing) // mame ziskat listing, a pak informovat pripadne ostatni cekajici workery
+                            if (getListing) // we should obtain the listing and then notify any other waiting workers
                             {
                                 UploadDirGetTgtPathListing = TRUE;
-                                postActivate = TRUE; // postneme si impulz pro zacatek stahovani listingu
+                                postActivate = TRUE; // post an event to start downloading the listing
                             }
                             else
                             {
-                                SubState = fwssWorkUploadWaitForListing; // mame cekat az jiny worker dokonci listovani
-                                reportWorkerChange = TRUE;               // worker vypisuje stav fwssWorkUploadWaitForListing do okna, takze je potreba prekreslit
+                                SubState = fwssWorkUploadWaitForListing; // we should wait until another worker finishes the listing
+                                reportWorkerChange = TRUE;               // the worker displays the fwssWorkUploadWaitForListing state in the window, so it needs to be redrawn
                             }
                         }
-                        else // listing je v cache hotovy nebo "neziskatelny"
+                        else // the listing in the cache is ready or marked as "unobtainable"
                         {
-                            if (notAccessible) // listing je cachovany, ale jen jako "neziskatelny"
+                            if (notAccessible) // the listing is cached, but only as "unobtainable"
                             {
                                 Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_UPLOADCANNOTLISTTGTPATH, 0, NULL, Oper);
                                 lookForNewWork = TRUE;
                             }
-                            else // mame listing k dispozici, zjistime pripadnou kolizi jmena adresare
+                            else // the listing is available; check for a target directory name collision
                             {
                                 BOOL nameValid = FTPMayBeValidNameComponent(curItem->TgtName, curItem->TgtPath, TRUE, pathType);
                                 nextLoop = TRUE;
-                                if (existingItem == NULL && nameValid) // bez kolize a validni jmeno -> zkusime vytvorit adresar
+                                if (existingItem == NULL && nameValid) // no collision and the name is valid -> try to create the directory
                                     SubState = fwssWorkUploadCreateDir;
                                 else
-                                {                                                         // je-li existingItem == NULL, je (!nameValid==TRUE), proto nejsou treba testy na existingItem != NULL
-                                    if (!nameValid || existingItem->ItemType == ulitFile) // invalidni jmeno nebo kolize se souborem -> "dir cannot be created"
+                                {                                                         // if existingItem == NULL then (!nameValid==TRUE), so there is no need to test for existingItem != NULL
+                                    if (!nameValid || existingItem->ItemType == ulitFile) // invalid name or a collision with a file -> "dir cannot be created"
                                         SubState = !nameValid ? fwssWorkUploadCantCreateDirInvName : fwssWorkUploadCantCreateDirFileEx;
                                     else
                                     {
-                                        if (existingItem->ItemType == ulitDirectory) // kolize s adresarem -> "dir already exists"
+                                        if (existingItem->ItemType == ulitDirectory) // collision with a directory -> "dir already exists"
                                             SubState = fwssWorkUploadDirExists;
-                                        else // (existingItem->ItemType == ulitLink): kolize s linkem -> zjistime co je link zac (soubor/adresar)
+                                        else // (existingItem->ItemType == ulitLink): collision with a link -> find out whether the link targets a file or directory
                                             SubState = fwssWorkUploadResolveLink;
                                     }
                                 }
                             }
                         }
                     }
-                    else // nedostatek pameti
+                    else // out of memory
                     {
                         Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_LOWMEM, 0, NULL, Oper);
                         lookForNewWork = TRUE;
                     }
                 }
-                else // cilovy adresar je jiz pripraveny, jdeme listovat uploadeny adresar na disku
+                else // the target directory is already prepared, proceed to list the uploaded directory on disk
                 {
                     SubState = fwssWorkUploadGetTgtPath;
                     nextLoop = TRUE;
@@ -99,80 +99,80 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadWaitForListing: // upload copy/move souboru: cekame az jiny worker dokonci listovani cilove cesty na serveru (pro zjisteni kolizi)
+        case fwssWorkUploadWaitForListing: // upload copy/move file: wait until another worker finishes listing the target path on the server (to detect collisions)
         {
             if (ShouldStop)
-                handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                handleShouldStop = TRUE; // check whether the worker should stop
             else
             {
-                if (event == fweTgtPathListingFinished) // povereny worker jiz svou praci dokoncil, zkusime novy listing pouzit
+                if (event == fweTgtPathListingFinished) // the designated worker has finished, try to use the new listing
                 {
                     SubState = fwssWorkStartWork;
-                    reportWorkerChange = TRUE; // worker vypisuje stav fwssWorkUploadWaitForListing do okna, takze je potreba prekreslit
+                    reportWorkerChange = TRUE; // the worker displays the fwssWorkUploadWaitForListing state in the window, so it needs to be redrawn
                     nextLoop = TRUE;
                 }
             }
             break;
         }
 
-        case fwssWorkUploadResolveLink: // upload copy/move souboru: zjistime co je link (soubor/adresar), jehoz jmeno koliduje se jmenem ciloveho adresare na serveru
+        case fwssWorkUploadResolveLink: // upload copy/move file: determine what the link is (file/directory) whose name collides with the target directory on the server
         {
             lstrcpyn(ftpPath, curItem->TgtPath, FTP_MAX_PATH);
             CFTPServerPathType type = Oper->GetFTPServerPathType(ftpPath);
             if (FTPPathAppend(type, ftpPath, FTP_MAX_PATH, curItem->TgtName, TRUE))
-            { // mame cestu, posleme na server CWD do zkoumaneho adresare
+            { // we have the path, send CWD to the examined directory on the server
                 _snprintf_s(errText, 200 + FTP_MAX_PATH, _TRUNCATE, LoadStr(IDS_LOGMSGRESOLVINGLINK), ftpPath);
                 Logs.LogMessage(LogUID, errText, -1, TRUE);
 
                 PrepareFTPCommand(buf, 200 + FTP_MAX_PATH, errBuf, 50 + FTP_MAX_PATH,
-                                  ftpcmdChangeWorkingPath, &cmdLen, ftpPath); // nemuze nahlasit chybu
+                                  ftpcmdChangeWorkingPath, &cmdLen, ftpPath); // cannot report an error
                 sendCmd = TRUE;
                 SubState = fwssWorkUploadResLnkWaitForCWDRes;
 
-                HaveWorkingPath = FALSE; // menime aktualni pracovni cestu na serveru
+                HaveWorkingPath = FALSE; // change the current working directory on the server
             }
-            else // chyba syntaxe cesty nebo by vznikla moc dlouha cesta
+            else // path syntax error or the path would become too long
             {
-                // chyba na polozce, zapiseme do ni tento stav
+                // error on the item; record this state
                 Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_INVALIDPATHTOLINK, NO_ERROR, NULL, Oper);
                 lookForNewWork = TRUE;
             }
             break;
         }
 
-        case fwssWorkUploadResLnkWaitForCWDRes: // upload copy/move souboru: cekame na vysledek "CWD" (zmena cesty do zkoumaneho linku - podari-li se, je to link na adresar)
+        case fwssWorkUploadResLnkWaitForCWDRes: // upload copy/move file: wait for the "CWD" result (changing into the examined link; if it succeeds, the link is a directory)
         {
             switch (event)
             {
-            // case fweCmdInfoReceived:  // "1xx" odpovedi ignorujeme (jen se pisou do Logu)
+            // case fweCmdInfoReceived:  // we ignore "1xx" responses (they are only written to the log)
             case fweCmdReplyReceived:
             {
                 if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS ||
                     FTP_DIGIT_1(replyCode) == FTP_D1_ERROR)
                 {
                     if (ShouldStop)
-                        handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                        handleShouldStop = TRUE; // check whether the worker should stop
                     else
                     {
                         nextLoop = TRUE;
-                        if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS)  // uspech, link vede do adresare
-                            SubState = fwssWorkUploadDirExistsDirLink; // optimalizace fwssWorkUploadDirExists: CWD uz je hotove, udelame rovnou PWD
-                        else                                           // permanentni chyba, link vede nejspis na soubor (ale muze jit i o "550 Permission denied", bohuzel 550 je i "550 Not a directory", takze nerozlisitelne...)
+                        if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS)  // success, the link points to a directory
+                            SubState = fwssWorkUploadDirExistsDirLink; // optimization of fwssWorkUploadDirExists: CWD is already done, perform PWD immediately
+                        else                                           // permanent error, the link most likely points to a file (but it could also be "550 Permission denied"; unfortunately 550 is also "550 Not a directory", so it is indistinguishable...)
                             SubState = fwssWorkUploadCantCreateDirFileEx;
                     }
                 }
-                else // nastala nejaka chyba, vypiseme ji uzivateli a jdeme zpracovat dalsi polozku fronty
+                else // an error occurred; show it to the user and move on to the next queue item
                 {
                     CopyStr(errText, 200 + FTP_MAX_PATH, reply, replySize);
                     Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_UNABLETORESOLVELNK, NO_ERROR,
-                                           SalamanderGeneral->DupStr(errText) /* low memory = chyba bude bez detailu */,
+                                           SalamanderGeneral->DupStr(errText) /* low memory = the error will be without details */,
                                            Oper);
                     lookForNewWork = TRUE;
                 }
                 break;
             }
 
-            case fweCmdConClosed: // spojeni se zavrelo/timeoutlo (popis viz ErrorDescr) -> zkusime ho obnovit
+            case fweCmdConClosed: // the connection was closed/timed out (see ErrorDescr) -> try to restore it
             {
                 conClosedRetryItem = TRUE;
                 break;
@@ -181,51 +181,51 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadCreateDir: // upload copy/move souboru: vytvorime cilovy adresar na serveru - zacneme nastavenim cilove cesty
+        case fwssWorkUploadCreateDir: // upload copy/move file: create the target directory on the server - start by setting the target path
         {
             PrepareFTPCommand(buf, 200 + FTP_MAX_PATH, errBuf, 50 + FTP_MAX_PATH,
-                              ftpcmdChangeWorkingPath, &cmdLen, curItem->TgtPath); // nemuze nahlasit chybu
+                              ftpcmdChangeWorkingPath, &cmdLen, curItem->TgtPath); // cannot report an error
             sendCmd = TRUE;
             SubState = fwssWorkUploadCrDirWaitForCWDRes;
 
-            HaveWorkingPath = FALSE; // menime aktualni pracovni cestu na serveru
+            HaveWorkingPath = FALSE; // change the current working directory on the server
             break;
         }
 
-        case fwssWorkUploadCrDirWaitForCWDRes: // upload copy/move souboru: cekame na vysledek "CWD" (nastaveni cilove cesty)
+        case fwssWorkUploadCrDirWaitForCWDRes: // upload copy/move file: wait for the "CWD" result (setting the target path)
         {
             switch (event)
             {
-            // case fweCmdInfoReceived:  // "1xx" odpovedi ignorujeme (jen se pisou do Logu)
+            // case fweCmdInfoReceived:  // we ignore "1xx" responses (they are only written to the log)
             case fweCmdReplyReceived:
             {
-                if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS) // cilova cesta je nastavena, vytvorime cilovy adresar
+                if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS) // the target path is set, create the target directory
                 {
                     if (ShouldStop)
-                        handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                        handleShouldStop = TRUE; // check whether the worker should stop
                     else
                     {
                         _snprintf_s(errText, 200 + FTP_MAX_PATH, _TRUNCATE, LoadStr(IDS_LOGMSGCREATEDIR), curItem->TgtName);
                         Logs.LogMessage(LogUID, errText, -1, TRUE);
 
                         PrepareFTPCommand(buf, 200 + FTP_MAX_PATH, errBuf, 50 + FTP_MAX_PATH,
-                                          ftpcmdCreateDir, &cmdLen, curItem->TgtName); // nemuze nahlasit chybu
+                                          ftpcmdCreateDir, &cmdLen, curItem->TgtName); // cannot report an error
                         sendCmd = TRUE;
                         SubState = fwssWorkUploadCrDirWaitForMKDRes;
                     }
                 }
-                else // nastala nejaka chyba, vypiseme ji uzivateli a jdeme zpracovat dalsi polozku fronty
+                else // an error occurred; show it to the user and move on to the next queue item
                 {
                     CopyStr(errText, 200 + FTP_MAX_PATH, reply, replySize);
                     Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_UNABLETOCWDONLYPATH, NO_ERROR,
-                                           SalamanderGeneral->DupStr(errText) /* low memory = chyba bude bez detailu */,
+                                           SalamanderGeneral->DupStr(errText) /* low memory = the error will be without details */,
                                            Oper);
                     lookForNewWork = TRUE;
                 }
                 break;
             }
 
-            case fweCmdConClosed: // spojeni se zavrelo/timeoutlo (popis viz ErrorDescr) -> zkusime ho obnovit
+            case fweCmdConClosed: // the connection was closed/timed out (see ErrorDescr) -> try to restore it
             {
                 conClosedRetryItem = TRUE;
                 break;
@@ -234,32 +234,32 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadCrDirWaitForMKDRes: // upload copy/move souboru: cekame na vysledek "MKD" (vytvoreni ciloveho adresare)
+        case fwssWorkUploadCrDirWaitForMKDRes: // upload copy/move file: wait for the "MKD" result (creating the target directory)
         {
             switch (event)
             {
-            // case fweCmdInfoReceived:  // "1xx" odpovedi ignorujeme (jen se pisou do Logu)
+            // case fweCmdInfoReceived:  // we ignore "1xx" responses (they are only written to the log)
             case fweCmdReplyReceived:
             {
-                if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS) // cilovy adresar je vytvoreny (melo by byt 257)
+                if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS) // the target directory was created (should be 257)
                 {
                     Queue->UpdateUploadTgtDirState(curItem, UPLOADTGTDIRSTATE_READY);
 
-                    // pokud se cilovy adresar vytvoril, zmenime listing v cache
+                    // if the target directory was created, update the listing cache
                     Oper->GetUserHostPort(userBuf, hostBuf, &portBuf);
                     UploadListingCache.ReportCreateDirs(userBuf, hostBuf, portBuf, curItem->TgtPath,
                                                         Oper->GetFTPServerPathType(curItem->TgtPath),
                                                         curItem->TgtName, FALSE);
 
                     if (ShouldStop)
-                        handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                        handleShouldStop = TRUE; // check whether the worker should stop
                     else
                     {
                         SubState = fwssWorkUploadGetTgtPath;
                         nextLoop = TRUE;
                     }
                 }
-                else // nastala nejaka chyba, vypiseme ji uzivateli a jdeme zpracovat dalsi polozku fronty
+                else // an error occurred; show it to the user and move on to the next queue item
                 {
                     Oper->GetUserHostPort(userBuf, hostBuf, &portBuf);
                     CFTPServerPathType pathType = Oper->GetFTPServerPathType(curItem->TgtPath);
@@ -267,16 +267,16 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                     {
                         Queue->UpdateUploadTgtDirState(curItem, UPLOADTGTDIRSTATE_UNKNOWN);
                         UploadListingCache.InvalidatePathListing(userBuf, hostBuf, portBuf, curItem->TgtPath, pathType);
-                        Queue->UpdateItemState(CurItem, sqisWaiting, ITEMPR_OK, NO_ERROR, NULL, Oper); // aspon tento worker pujde hledat novou praci, takze o tuto polozku se jiste nejaky worker postara (netreba postit "new work available")
+                        Queue->UpdateItemState(CurItem, sqisWaiting, ITEMPR_OK, NO_ERROR, NULL, Oper); // at least this worker will look for new work, so some worker will certainly handle this item (no need to post "new work available")
                         lookForNewWork = TRUE;
                     }
                     else
                     {
                         CopyStr(errText, 200 + FTP_MAX_PATH, reply, replySize);
-                        if (CurItem->ForceAction == fqiaUseAutorename) // forcnuty autorename
+                        if (CurItem->ForceAction == fqiaUseAutorename) // forced autorename
                         {
                             if (ShouldStop)
-                                handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                                handleShouldStop = TRUE; // check whether the worker should stop
                             else
                             {
                                 SubState = fwssWorkUploadAutorenameDir;
@@ -290,7 +290,7 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                             case CANNOTCREATENAME_USERPROMPT:
                             {
                                 Queue->UpdateItemState(CurItem, sqisUserInputNeeded, ITEMPR_UPLOADCANNOTCREATETGTDIR, NO_ERROR,
-                                                       SalamanderGeneral->DupStr(errText) /* low memory = chyba bude bez detailu */,
+                                                       SalamanderGeneral->DupStr(errText) /* low memory = the error will be without details */,
                                                        Oper);
                                 lookForNewWork = TRUE;
                                 break;
@@ -299,7 +299,7 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                             case CANNOTCREATENAME_SKIP:
                             {
                                 Queue->UpdateItemState(CurItem, sqisSkipped, ITEMPR_UPLOADCANNOTCREATETGTDIR, NO_ERROR,
-                                                       SalamanderGeneral->DupStr(errText) /* low memory = chyba bude bez detailu */,
+                                                       SalamanderGeneral->DupStr(errText) /* low memory = the error will be without details */,
                                                        Oper);
                                 lookForNewWork = TRUE;
                                 break;
@@ -308,7 +308,7 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                             default: // case CANNOTCREATENAME_AUTORENAME:
                             {
                                 if (ShouldStop)
-                                    handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                                    handleShouldStop = TRUE; // check whether the worker should stop
                                 else
                                 {
                                     SubState = fwssWorkUploadAutorenameDir;
@@ -323,9 +323,9 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                 break;
             }
 
-            case fweCmdConClosed: // spojeni se zavrelo/timeoutlo (popis viz ErrorDescr) -> zkusime ho obnovit
+            case fweCmdConClosed: // the connection was closed/timed out (see ErrorDescr) -> try to restore it
             {
-                // pokud nevime jak dopadlo vytvoreni adresare, zneplatnime listing v cache
+                // if we do not know whether the directory creation succeeded, invalidate the listing cache
                 Oper->GetUserHostPort(userBuf, hostBuf, &portBuf);
                 UploadListingCache.ReportCreateDirs(userBuf, hostBuf, portBuf, curItem->TgtPath,
                                                     Oper->GetFTPServerPathType(curItem->TgtPath),
@@ -337,10 +337,10 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadCantCreateDirInvName: // upload copy/move souboru: resime chybu "target directory cannot be created" (invalid name)
-        case fwssWorkUploadCantCreateDirFileEx:  // upload copy/move souboru: resime chybu "target directory cannot be created" (name already used for file or link)
+        case fwssWorkUploadCantCreateDirInvName: // upload copy/move file: handle the "target directory cannot be created" error (invalid name)
+        case fwssWorkUploadCantCreateDirFileEx:  // upload copy/move file: handle the "target directory cannot be created" error (name already used for a file or link)
         {
-            if (CurItem->ForceAction == fqiaUseAutorename) // forcnuty autorename
+            if (CurItem->ForceAction == fqiaUseAutorename) // forced autorename
             {
                 SubState = fwssWorkUploadAutorenameDir;
                 nextLoop = TRUE;
@@ -378,20 +378,20 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadDirExistsDirLink: // stejny stav jako fwssWorkUploadDirExists: navic jen to, ze bylo prave provedeno CWD do ciloveho adresare (test jestli je link adresar nebo soubor)
-        case fwssWorkUploadDirExists:        // upload copy/move souboru: resime chybu "target directory already exists"
+        case fwssWorkUploadDirExistsDirLink: // same state as fwssWorkUploadDirExists; additionally, CWD to the target directory has just been performed (testing whether the link is a directory or a file)
+        case fwssWorkUploadDirExists:        // upload copy/move file: handle the "target directory already exists" error
         {
-            if (CurItem->ForceAction == fqiaUseAutorename) // forcnuty autorename
+            if (CurItem->ForceAction == fqiaUseAutorename) // forced autorename
             {
                 SubState = fwssWorkUploadAutorenameDir;
                 nextLoop = TRUE;
             }
             else
             {
-                if (CurItem->ForceAction == fqiaUseExistingDir) // forcnuty use-existing-dir
+                if (CurItem->ForceAction == fqiaUseExistingDir) // forced use-existing-dir
                 {
                     Queue->UpdateUploadTgtDirState(curItem, UPLOADTGTDIRSTATE_READY);
-                    Queue->UpdateForceAction(CurItem, fqiaNone); // vynucena akce timto prestava platit
+                    Queue->UpdateForceAction(CurItem, fqiaNone); // the forced action no longer applies
 
                     SubState = SubState == fwssWorkUploadDirExistsDirLink ? fwssWorkUploadGetTgtPathSendPWD : fwssWorkUploadGetTgtPath;
                     nextLoop = TRUE;
@@ -436,48 +436,48 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadAutorenameDir: // upload copy/move souboru: reseni chyby vytvareni ciloveho adresare - autorename - zacneme nastavenim cilove cesty
+        case fwssWorkUploadAutorenameDir: // upload copy/move file: handle the target directory creation error - autorename - start by setting the target path
         {
             PrepareFTPCommand(buf, 200 + FTP_MAX_PATH, errBuf, 50 + FTP_MAX_PATH,
-                              ftpcmdChangeWorkingPath, &cmdLen, curItem->TgtPath); // nemuze nahlasit chybu
+                              ftpcmdChangeWorkingPath, &cmdLen, curItem->TgtPath); // cannot report an error
             sendCmd = TRUE;
             SubState = fwssWorkUploadAutorenDirWaitForCWDRes;
 
-            HaveWorkingPath = FALSE; // menime aktualni pracovni cestu na serveru
+            HaveWorkingPath = FALSE; // change the current working directory on the server
             break;
         }
 
-        case fwssWorkUploadAutorenDirWaitForCWDRes: // upload copy/move souboru: autorename - cekame na vysledek "CWD" (nastaveni cilove cesty)
+        case fwssWorkUploadAutorenDirWaitForCWDRes: // upload copy/move file: autorename - wait for the "CWD" result (setting the target path)
         {
             switch (event)
             {
-            // case fweCmdInfoReceived:  // "1xx" odpovedi ignorujeme (jen se pisou do Logu)
+            // case fweCmdInfoReceived:  // we ignore "1xx" responses (they are only written to the log)
             case fweCmdReplyReceived:
             {
-                if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS) // cilova cesta je nastavena, zahajime generovani jmen ciloveho adresare
+                if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS) // the target path is set, begin generating target directory names
                 {
                     if (ShouldStop)
-                        handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                        handleShouldStop = TRUE; // check whether the worker should stop
                     else
                     {
-                        UploadAutorenamePhase = 0; // pocatek generovani jmen
+                        UploadAutorenamePhase = 0; // start of name generation
                         UploadAutorenameNewName[0] = 0;
                         SubState = fwssWorkUploadAutorenDirSendMKD;
                         nextLoop = TRUE;
                     }
                 }
-                else // nastala nejaka chyba, vypiseme ji uzivateli a jdeme zpracovat dalsi polozku fronty
+                else // an error occurred; show it to the user and move on to the next queue item
                 {
                     CopyStr(errText, 200 + FTP_MAX_PATH, reply, replySize);
                     Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_UNABLETOCWDONLYPATH, NO_ERROR,
-                                           SalamanderGeneral->DupStr(errText) /* low memory = chyba bude bez detailu */,
+                                           SalamanderGeneral->DupStr(errText) /* low memory = the error will be without details */,
                                            Oper);
                     lookForNewWork = TRUE;
                 }
                 break;
             }
 
-            case fweCmdConClosed: // spojeni se zavrelo/timeoutlo (popis viz ErrorDescr) -> zkusime ho obnovit
+            case fweCmdConClosed: // the connection was closed/timed out (see ErrorDescr) -> try to restore it
             {
                 conClosedRetryItem = TRUE;
                 break;
@@ -486,65 +486,65 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadAutorenDirSendMKD: // upload copy/move souboru: autorename - zkusi vygenerovat dalsi nove jmeno pro cilovy adresar a zkusi tento adresar vytvorit
+        case fwssWorkUploadAutorenDirSendMKD: // upload copy/move file: autorename - try to generate another new name for the target directory and attempt to create it
         {
             Oper->GetUserHostPort(userBuf, hostBuf, &portBuf);
             CFTPServerPathType pathType = Oper->GetFTPServerPathType(curItem->TgtPath);
             BOOL notAccessible, getListing, listingInProgress, nameExists;
             int index = 0;
-            int usedUploadAutorenamePhase = UploadAutorenamePhase; // pro pripad kolize jmen - faze ve ktere mame zkusit vygenerovat dalsi jmeno
+            int usedUploadAutorenamePhase = UploadAutorenamePhase; // in case of a name collision - the phase in which we should try generating another name
             while (1)
             {
                 FTPGenerateNewName(&UploadAutorenamePhase, UploadAutorenameNewName, &index,
                                    curItem->TgtName, pathType, TRUE, FALSE);
-                // mame nove jmeno, overime jestli nekoliduje s nejakym jmenem z listingu cilove cesty
+                // we have a new name; verify that it does not collide with any name from the target path listing
                 if (UploadListingCache.GetListing(userBuf, hostBuf, portBuf, curItem->TgtPath,
                                                   pathType, Msg, UID, &listingInProgress,
                                                   &notAccessible, &getListing,
                                                   UploadAutorenameNewName, NULL, &nameExists))
                 {
-                    if (listingInProgress) // listovani prave probiha nebo ma ted probehnout
+                    if (listingInProgress) // the listing is currently running or is about to start
                     {
-                        if (getListing) // mame ziskat listing, a pak informovat pripadne ostatni cekajici workery
+                        if (getListing) // we should obtain the listing and then notify any other waiting workers
                         {
                             UploadDirGetTgtPathListing = TRUE;
                             SubState = fwssWorkStartWork;
-                            postActivate = TRUE; // postneme si impulz pro zacatek stahovani listingu
+                            postActivate = TRUE; // post an event to start downloading the listing
                         }
                         else
                         {
-                            SubState = fwssWorkUploadWaitForListing; // mame cekat az jiny worker dokonci listovani
-                            reportWorkerChange = TRUE;               // worker vypisuje stav fwssWorkUploadWaitForListing do okna, takze je potreba prekreslit
+                            SubState = fwssWorkUploadWaitForListing; // we should wait until another worker finishes the listing
+                            reportWorkerChange = TRUE;               // the worker displays the fwssWorkUploadWaitForListing state in the window, so it needs to be redrawn
                         }
                         break;
                     }
-                    else // listing je v cache hotovy nebo "neziskatelny"
+                    else // the listing in the cache is ready or marked as "unobtainable"
                     {
-                        if (notAccessible) // listing je cachovany, ale jen jako "neziskatelny" (hodne nepravdepodobne, pred chvilkou byl listing jeste "ready")
+                        if (notAccessible) // the listing is cached, but only as "unobtainable" (highly unlikely, it was "ready" just moments ago)
                         {
                             Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_UPLOADCANNOTLISTTGTPATH, 0, NULL, Oper);
                             lookForNewWork = TRUE;
                             break;
                         }
-                        else // mame listing k dispozici, zjistime pripadnou kolizi jmena adresare
+                        else // the listing is available; check for a target directory name collision
                         {
-                            if (!nameExists) // bez kolize -> zkusime vytvorit cilovy adresar
+                            if (!nameExists) // no collision -> try to create the target directory
                             {
                                 _snprintf_s(errText, 200 + FTP_MAX_PATH, _TRUNCATE, LoadStr(IDS_LOGMSGCREATEDIR), UploadAutorenameNewName);
                                 Logs.LogMessage(LogUID, errText, -1, TRUE);
 
                                 PrepareFTPCommand(buf, 200 + FTP_MAX_PATH, errBuf, 50 + FTP_MAX_PATH,
-                                                  ftpcmdCreateDir, &cmdLen, UploadAutorenameNewName); // nemuze nahlasit chybu
+                                                  ftpcmdCreateDir, &cmdLen, UploadAutorenameNewName); // cannot report an error
                                 sendCmd = TRUE;
                                 SubState = fwssWorkUploadAutorenDirWaitForMKDRes;
                                 break;
                             }
-                            else // kolize jmen (se souborem/linkem/adresarem) - zkusime dalsi jmeno ve stejne fazi autorenamu
+                            else // name collision (with a file/link/directory) - try another name in the same autorename phase
                                 UploadAutorenamePhase = usedUploadAutorenamePhase;
                         }
                     }
                 }
-                else // nedostatek pameti
+                else // out of memory
                 {
                     Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_LOWMEM, 0, NULL, Oper);
                     lookForNewWork = TRUE;
@@ -554,16 +554,16 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadAutorenDirWaitForMKDRes: // upload copy/move souboru: autorename - cekame na vysledek "MKD" (vytvoreni ciloveho adresare pod novym jmenem)
+        case fwssWorkUploadAutorenDirWaitForMKDRes: // upload copy/move file: autorename - wait for the "MKD" result (creating the target directory under the new name)
         {
             switch (event)
             {
-            // case fweCmdInfoReceived:  // "1xx" odpovedi ignorujeme (jen se pisou do Logu)
+            // case fweCmdInfoReceived:  // we ignore "1xx" responses (they are only written to the log)
             case fweCmdReplyReceived:
             {
-                if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS) // cilovy adresar je vytvoreny (melo by byt 257)
+                if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS) // the target directory was created (should be 257)
                 {
-                    // pokud se cilovy adresar vytvoril, zmenime listing v cache
+                    // if the target directory was created, update the listing cache
                     Oper->GetUserHostPort(userBuf, hostBuf, &portBuf);
                     UploadListingCache.ReportCreateDirs(userBuf, hostBuf, portBuf, curItem->TgtPath,
                                                         Oper->GetFTPServerPathType(curItem->TgtPath),
@@ -572,15 +572,15 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                     char* newName = SalamanderGeneral->DupStr(UploadAutorenameNewName);
                     if (newName != NULL)
                     {
-                        if (CurItem->ForceAction != fqiaNone) // vynucena akce timto prestava platit
+                        if (CurItem->ForceAction != fqiaNone) // the forced action no longer applies
                             Queue->UpdateForceAction(CurItem, fqiaNone);
 
                         Queue->UpdateUploadTgtDirState(curItem, UPLOADTGTDIRSTATE_READY);
                         Queue->UpdateTgtName(curItem, newName);
-                        Oper->ReportItemChange(CurItem->UID); // pozadame o redraw polozky
+                        Oper->ReportItemChange(CurItem->UID); // request a redraw of the item
 
                         if (ShouldStop)
-                            handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                            handleShouldStop = TRUE; // check whether the worker should stop
                         else
                         {
                             SubState = fwssWorkUploadGetTgtPath;
@@ -594,23 +594,23 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                         lookForNewWork = TRUE;
                     }
                 }
-                else // nastala chyba pri vytvareni adresare
+                else // an error occurred while creating the directory
                 {
-                    if (UploadAutorenamePhase != -1) // jdeme zkusit nagenerovat jeste jine jmeno
+                    if (UploadAutorenamePhase != -1) // try to generate another name
                     {
                         if (ShouldStop)
-                            handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                            handleShouldStop = TRUE; // check whether the worker should stop
                         else
                         {
                             SubState = fwssWorkUploadAutorenDirSendMKD;
                             nextLoop = TRUE;
                         }
                     }
-                    else // uz nevime jake jine jmeno by se dalo vytvorit, takze ohlasime chybu
+                    else // no other name can be generated, so report an error
                     {
                         CopyStr(errText, 200 + FTP_MAX_PATH, reply, replySize);
                         Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_UPLOADCRDIRAUTORENFAILED, NO_ERROR,
-                                               SalamanderGeneral->DupStr(errText) /* low memory = chyba bude bez detailu */,
+                                               SalamanderGeneral->DupStr(errText) /* low memory = the error will be without details */,
                                                Oper);
                         lookForNewWork = TRUE;
                     }
@@ -618,9 +618,9 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                 break;
             }
 
-            case fweCmdConClosed: // spojeni se zavrelo/timeoutlo (popis viz ErrorDescr) -> zkusime ho obnovit
+            case fweCmdConClosed: // the connection was closed/timed out (see ErrorDescr) -> try to restore it
             {
-                // pokud nevime jak dopadlo vytvoreni adresare, zneplatnime listing v cache
+                // if we do not know whether the directory creation succeeded, invalidate the listing cache
                 Oper->GetUserHostPort(userBuf, hostBuf, &portBuf);
                 UploadListingCache.ReportCreateDirs(userBuf, hostBuf, portBuf, curItem->TgtPath,
                                                     Oper->GetFTPServerPathType(curItem->TgtPath),
@@ -632,46 +632,46 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadGetTgtPath: // upload copy/move souboru: zjistime cestu do ciloveho adresare na serveru - zacneme zmenou cesty do nej
+        case fwssWorkUploadGetTgtPath: // upload copy/move file: determine the path to the target directory on the server - start by changing into it
         {
             lstrcpyn(ftpPath, curItem->TgtPath, FTP_MAX_PATH);
             CFTPServerPathType type = Oper->GetFTPServerPathType(ftpPath);
             if (FTPPathAppend(type, ftpPath, FTP_MAX_PATH, curItem->TgtName, TRUE))
-            { // mame cestu, posleme na server CWD do zkoumaneho adresare
+            { // we have the path, send CWD to the examined directory on the server
                 PrepareFTPCommand(buf, 200 + FTP_MAX_PATH, errBuf, 50 + FTP_MAX_PATH,
-                                  ftpcmdChangeWorkingPath, &cmdLen, ftpPath); // nemuze nahlasit chybu
+                                  ftpcmdChangeWorkingPath, &cmdLen, ftpPath); // cannot report an error
                 sendCmd = TRUE;
                 SubState = fwssWorkUploadGetTgtPathWaitForCWDRes;
 
-                HaveWorkingPath = FALSE; // menime aktualni pracovni cestu na serveru
+                HaveWorkingPath = FALSE; // change the current working directory on the server
             }
-            else // chyba syntaxe cesty nebo by vznikla moc dlouha cesta
+            else // path syntax error or the path would become too long
             {
-                // chyba na polozce, zapiseme do ni tento stav
+                // error on the item; record this state
                 Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_INVALIDPATHTODIR, NO_ERROR, NULL, Oper);
                 lookForNewWork = TRUE;
             }
             break;
         }
 
-        case fwssWorkUploadGetTgtPathWaitForCWDRes: // upload copy/move souboru: cekame na vysledek "CWD" (nastaveni cesty do ciloveho adresare)
+        case fwssWorkUploadGetTgtPathWaitForCWDRes: // upload copy/move file: wait for the "CWD" result (setting the path to the target directory)
         {
             switch (event)
             {
-            // case fweCmdInfoReceived:  // "1xx" odpovedi ignorujeme (jen se pisou do Logu)
+            // case fweCmdInfoReceived:  // we ignore "1xx" responses (they are only written to the log)
             case fweCmdReplyReceived:
             {
-                if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS) // cesta do ciloveho adresare je nastavena, posleme PWD
+                if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS) // the path to the target directory is set; send PWD
                 {
                     if (ShouldStop)
-                        handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                        handleShouldStop = TRUE; // check whether the worker should stop
                     else
                     {
                         nextLoop = TRUE;
                         SubState = fwssWorkUploadGetTgtPathSendPWD;
                     }
                 }
-                else // nastala nejaka chyba, vypiseme ji uzivateli a jdeme zpracovat dalsi polozku fronty
+                else // an error occurred; show it to the user and move on to the next queue item
                 {
                     Oper->GetUserHostPort(userBuf, hostBuf, &portBuf);
                     CFTPServerPathType pathType = Oper->GetFTPServerPathType(curItem->TgtPath);
@@ -679,13 +679,13 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                     {
                         Queue->UpdateUploadTgtDirState(curItem, UPLOADTGTDIRSTATE_UNKNOWN);
                         UploadListingCache.InvalidatePathListing(userBuf, hostBuf, portBuf, curItem->TgtPath, pathType);
-                        Queue->UpdateItemState(CurItem, sqisWaiting, ITEMPR_OK, NO_ERROR, NULL, Oper); // aspon tento worker pujde hledat novou praci, takze o tuto polozku se jiste nejaky worker postara (netreba postit "new work available")
+                        Queue->UpdateItemState(CurItem, sqisWaiting, ITEMPR_OK, NO_ERROR, NULL, Oper); // at least this worker will look for new work, so some worker will certainly handle this item (no need to post "new work available")
                     }
                     else
                     {
                         CopyStr(errText, 200 + FTP_MAX_PATH, reply, replySize);
                         Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_UNABLETOCWD, NO_ERROR,
-                                               SalamanderGeneral->DupStr(errText) /* low memory = chyba bude bez detailu */,
+                                               SalamanderGeneral->DupStr(errText) /* low memory = the error will be without details */,
                                                Oper);
                     }
                     lookForNewWork = TRUE;
@@ -693,7 +693,7 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                 break;
             }
 
-            case fweCmdConClosed: // spojeni se zavrelo/timeoutlo (popis viz ErrorDescr) -> zkusime ho obnovit
+            case fweCmdConClosed: // the connection was closed/timed out (see ErrorDescr) -> try to restore it
             {
                 conClosedRetryItem = TRUE;
                 break;
@@ -702,48 +702,48 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadGetTgtPathSendPWD: // upload copy/move souboru: posleme "PWD" (zjisteni cesty do ciloveho adresare)
+        case fwssWorkUploadGetTgtPathSendPWD: // upload copy/move file: send "PWD" (determine the path to the target directory)
         {
             PrepareFTPCommand(buf, 200 + FTP_MAX_PATH, errBuf, 50 + FTP_MAX_PATH,
-                              ftpcmdPrintWorkingPath, &cmdLen); // nemuze nahlasit chybu
+                              ftpcmdPrintWorkingPath, &cmdLen); // cannot report an error
             sendCmd = TRUE;
             SubState = fwssWorkUploadGetTgtPathWaitForPWDRes;
             break;
         }
 
-        case fwssWorkUploadGetTgtPathWaitForPWDRes: // upload copy/move souboru: cekame na vysledek "PWD" (zjisteni cesty do ciloveho adresare)
+        case fwssWorkUploadGetTgtPathWaitForPWDRes: // upload copy/move file: wait for the "PWD" result (determining the path to the target directory)
         {
             switch (event)
             {
-            // case fweCmdInfoReceived:  // "1xx" odpovedi ignorujeme (jen se pisou do Logu)
+            // case fweCmdInfoReceived:  // we ignore "1xx" responses (they are only written to the log)
             case fweCmdReplyReceived:
             {
                 if (FTP_DIGIT_1(replyCode) == FTP_D1_SUCCESS &&
                     FTPGetDirectoryFromReply(reply, replySize, ftpPath, FTP_MAX_PATH))
-                { // uspech, mame working path
+                { // success, we have the working path
                     lstrcpyn(WorkingPath, ftpPath, FTP_MAX_PATH);
                     HaveWorkingPath = TRUE;
 
                     if (ShouldStop)
-                        handleShouldStop = TRUE; // zkontrolujeme jestli se nema stopnout worker
+                        handleShouldStop = TRUE; // check whether the worker should stop
                     else
                     {
                         nextLoop = TRUE;
                         SubState = fwssWorkUploadListDiskDir;
                     }
                 }
-                else // nastala nejaka chyba, vypiseme ji uzivateli a jdeme zpracovat dalsi polozku fronty
+                else // an error occurred; show it to the user and move on to the next queue item
                 {
                     CopyStr(errText, 200 + FTP_MAX_PATH, reply, replySize);
                     Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_UNABLETOPWD, NO_ERROR,
-                                           SalamanderGeneral->DupStr(errText) /* low memory = chyba bude bez detailu */,
+                                           SalamanderGeneral->DupStr(errText) /* low memory = the error will be without details */,
                                            Oper);
                     lookForNewWork = TRUE;
                 }
                 break;
             }
 
-            case fweCmdConClosed: // spojeni se zavrelo/timeoutlo (popis viz ErrorDescr) -> zkusime ho obnovit
+            case fweCmdConClosed: // the connection was closed/timed out (see ErrorDescr) -> try to restore it
             {
                 conClosedRetryItem = TRUE;
                 break;
@@ -752,9 +752,9 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadListDiskDir: // upload copy/move souboru: jdeme vylistovat uploadovany adresar na disku
+        case fwssWorkUploadListDiskDir: // upload copy/move file: list the uploaded directory on disk
         {
-            // zkusime vylistovat zdrojovy adresar na disku
+            // try to list the source directory on disk
             if (DiskWorkIsUsed)
                 TRACE_E("Unexpected situation in CFTPWorker::HandleEventInWorkingState4(): DiskWorkIsUsed may not be TRUE here!");
             InitDiskWork(WORKER_DISKWORKLISTFINISHED, fdwtListDir, CurItem->Path, CurItem->Name,
@@ -762,9 +762,9 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             if (FTPDiskThread->AddWork(&DiskWork))
             {
                 DiskWorkIsUsed = TRUE;
-                SubState = fwssWorkUploadListDiskWaitForDisk; // pockame si na vysledek
+                SubState = fwssWorkUploadListDiskWaitForDisk; // wait for the result
             }
-            else // nelze vylistovat zdrojovy adresar, nelze pokracovat v provadeni polozky
+            else // unable to list the source directory, cannot continue processing the item
             {
                 Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_LOWMEM, NO_ERROR, NULL, Oper);
                 lookForNewWork = TRUE;
@@ -772,29 +772,29 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
             break;
         }
 
-        case fwssWorkUploadListDiskWaitForDisk:        // upload copy/move souboru: cekame na dokonceni diskove operace (listovani adresare)
-        case fwssWorkUploadListDiskWaitForDiskAftQuit: // upload copy/move souboru: po poslani prikazu "QUIT" + cekame na dokonceni diskove operace (listovani adresare)
+        case fwssWorkUploadListDiskWaitForDisk:        // upload copy/move file: wait for the disk operation (directory listing) to finish
+        case fwssWorkUploadListDiskWaitForDiskAftQuit: // upload copy/move file: after sending the "QUIT" command, wait for the disk operation (directory listing) to finish
         {
-            if (event == fweWorkerShouldStop && ShouldStop) // mame ukoncit workera
+            if (event == fweWorkerShouldStop && ShouldStop) // we should terminate the worker
             {
                 if (SubState != fwssWorkUploadListDiskWaitForDiskAftQuit && !SocketClosed)
                 {
-                    SubState = fwssWorkUploadListDiskWaitForDiskAftQuit; // abychom neposilali "QUIT" vicekrat
-                    sendQuitCmd = TRUE;                                  // mame koncit + mame otevrenou connectionu -> posleme serveru prikaz "QUIT" (odpoved ignorujeme, kazdopadne by mela vest k zavreni spojeni a o nic jineho ted nejde)
+                    SubState = fwssWorkUploadListDiskWaitForDiskAftQuit; // prevent sending "QUIT" multiple times
+                    sendQuitCmd = TRUE;                                  // we are finishing and the connection is open -> send the server the "QUIT" command (ignore the reply; it should lead to closing the connection and nothing else matters now)
                 }
             }
             else
             {
-                if (event == fweDiskWorkListFinished) // mame vysledek diskove operace (listing adresare)
+                if (event == fweDiskWorkListFinished) // we have the result of the disk operation (directory listing)
                 {
                     DiskWorkIsUsed = FALSE;
-                    ReportWorkerMayBeClosed(); // ohlasime dokonceni prace workera (pro ostatni cekajici thready)
+                    ReportWorkerMayBeClosed(); // report the completion of the worker's job (for other waiting threads)
 
-                    // pokud uz jsme QUIT poslali, musime zamezit dalsimu poslani QUIT z noveho stavu
+                    // if QUIT has already been sent, prevent sending another QUIT from the new state
                     quitCmdWasSent = SubState == fwssWorkUploadListDiskWaitForDiskAftQuit;
 
                     if (DiskWork.State == sqisNone)
-                    { // adresar se podarilo vylistovat
+                    { // the directory listing succeeded
                         if (!HaveWorkingPath)
                             TRACE_E("Unexpected situation in CFTPWorker::HandleEventInWorkingState4(): HaveWorkingPath is FALSE!");
                         if (DiskWork.DiskListing == NULL)
@@ -803,13 +803,13 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                         TIndirectArray<CFTPQueueItem>* ftpQueueItems = new TIndirectArray<CFTPQueueItem>(100, 500);
                         int transferMode = Oper->GetTransferMode();
                         BOOL copy = CurItem->Type == fqitUploadCopyExploreDir;
-                        CQuadWord totalSize(0, 0); // celkova velikost (v bytech)
+                        CQuadWord totalSize(0, 0); // total size (in bytes)
                         char sourcePath[MAX_PATH];
                         lstrcpyn(sourcePath, CurItem->Path, MAX_PATH);
 
                         BOOL err = ftpQueueItems == NULL || !HaveWorkingPath || DiskWork.DiskListing == NULL ||
-                                   !SalamanderGeneral->SalPathAppend(sourcePath, CurItem->Name, MAX_PATH) /* always true - error by hlasilo uz DoListDirectory() */;
-                        if (!err) // napridavame do fronty polozky pro soubory/adresare z listingu
+                                   !SalamanderGeneral->SalPathAppend(sourcePath, CurItem->Name, MAX_PATH) /* always true - an error would already have been reported by DoListDirectory() */;
+                        if (!err) // add queue items for files/directories from the listing
                         {
                             BOOL ok = TRUE;
                             CFTPServerPathType workingPathType = Oper->GetFTPServerPathType(WorkingPath);
@@ -833,14 +833,14 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                                 CFTPQueueItem* item = CreateItemForCopyOrMoveUploadOperation(lstItem->Name, lstItem->IsDir,
                                                                                              &lstItem->Size, &type,
                                                                                              transferMode, Oper, copy,
-                                                                                             WorkingPath, tgtName, // jsme v podadresari, tady uz se jmena nevyrabi z operacni masky
+                                                                                             WorkingPath, tgtName, // we are in a subdirectory; names are no longer generated from the operation mask here
                                                                                              &totalSize, workingPathType == ftpsptOpenVMS);
                                 if (item != NULL)
                                 {
                                     if (ok)
                                     {
                                         item->SetItem(-1, type, sqisWaiting, ITEMPR_OK, sourcePath, lstItem->Name);
-                                        ftpQueueItems->Add(item); // pridani operace do fronty
+                                        ftpQueueItems->Add(item); // add the operation to the queue
                                         if (!ftpQueueItems->IsGood())
                                         {
                                             ftpQueueItems->ResetState();
@@ -855,7 +855,7 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                                     TRACE_E(LOW_MEMORY);
                                     ok = FALSE;
                                 }
-                                // zjistime jestli ma cenu pokracovat (pokud neni chyba)
+                                // determine whether it makes sense to continue (assuming no error)
                                 if (!ok)
                                 {
                                     err = TRUE;
@@ -863,16 +863,16 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                                 }
                             }
                         }
-                        BOOL parentItemAdded = FALSE;       // TRUE = na konci ftpQueueItems je "parent" polozka (smazani zdrojoveho adresare)
-                        int parentUID = CurItem->ParentUID; // parent-UID pro polozky vznikle expanzi adresare
-                        if (!err && !copy)                  // je-li potreba, pridame jeste polozku pro smazani zdrojoveho adresare (spusti se az se presune cely obsah adresare)
+                        BOOL parentItemAdded = FALSE;       // TRUE = the last item in ftpQueueItems is the "parent" item (deleting the source directory)
+                        int parentUID = CurItem->ParentUID; // parent UID for items created by expanding the directory
+                        if (!err && !copy)                  // if needed, add an item to delete the source directory (runs after the entire directory contents are moved)
                         {
                             CFTPQueueItem* item = new CFTPQueueItemDir;
                             if (item != NULL && ((CFTPQueueItemDir*)item)->SetItemDir(0, 0, 0, 0))
                             {
                                 item->SetItem(CurItem->ParentUID, fqitUploadMoveDeleteDir, sqisWaiting,
                                               ITEMPR_OK, CurItem->Path, CurItem->Name);
-                                ftpQueueItems->Add(item); // pridani operace do fronty
+                                ftpQueueItems->Add(item); // add the operation to the queue
                                 if (!ftpQueueItems->IsGood())
                                 {
                                     ftpQueueItems->ResetState();
@@ -899,79 +899,79 @@ void CFTPWorker::HandleEventInWorkingState4(CFTPWorkerEvent event, BOOL& sendQui
                             int count = ftpQueueItems->Count - (parentItemAdded ? 1 : 0);
                             int childItemsNotDone = count;
                             int i;
-                            for (i = 0; i < count; i++) // nastavime parenty pro polozky vznikle explorem
+                            for (i = 0; i < count; i++) // set the parent for items created by the explore
                             {
                                 CFTPQueueItem* actItem = ftpQueueItems->At(i);
                                 actItem->ParentUID = parentUID;
                             }
 
-                            // pokud pridavame "parent" polozku, nastavime do ni pocty Skipped+Failed+NotDone
+                            // if we add the "parent" item, set its Skipped+Failed+NotDone counters
                             if (parentItemAdded)
                             {
-                                CFTPQueueItemDir* parentItem = (CFTPQueueItemDir*)(ftpQueueItems->At(ftpQueueItems->Count - 1)); // musi byt nutne potomek CFTPQueueItemDir (kazda "parent" polozka ma pocty Skipped+Failed+NotDone)
+                                CFTPQueueItemDir* parentItem = (CFTPQueueItemDir*)(ftpQueueItems->At(ftpQueueItems->Count - 1)); // must be a descendant of CFTPQueueItemDir (every "parent" item has Skipped+Failed+NotDone counts)
                                 parentItem->SetStateAndNotDoneSkippedFailed(childItemsNotDone, 0, 0, 0);
-                                // nyni uz vsechny nove polozky reprezentuje jen "parent" polozka -> ulozime nove
-                                // NotDone pouze pro tuto polozku
+                                // at this point all new items are represented only by the "parent" item -> store the new
+                                // NotDone count only for this item
                                 childItemsNotDone = 1;
                             }
 
                             int curItemParent = CurItem->ParentUID;
 
-                            // probiha vice operaci nad daty, ostatni musi pockat az se provedou vsechny,
-                            // jinak budou pracovat s nekonzistentnimi daty
+                            // multiple operations on the data are in progress; others must wait until all of them finish,
+                            // otherwise they would work with inconsistent data
                             Queue->LockForMoreOperations();
 
                             if (Queue->ReplaceItemWithListOfItems(CurItem->UID, ftpQueueItems->GetData(),
                                                                   ftpQueueItems->Count))
-                            { // CurItem uz je dealokovana, byla nahrazena seznamem polozek ftpQueueItems
+                            { // CurItem has already been deallocated; it was replaced with the ftpQueueItems list
                                 CurItem = NULL;
-                                ftpQueueItems->DetachMembers(); // polozky uz jsou ve fronte, musime je vyhodit z pole, jinak se dealokuji
+                                ftpQueueItems->DetachMembers(); // the items are now in the queue; remove them from the array so they are not deallocated
 
-                                // polozce/operaci CurItem->ParentUID snizime o jednu NotDone (za CurItem ve stavu
-                                // sqisProcessing) a zvysime NotDone podle childItemsNotDone
-                                childItemsNotDone--; // snizeni o jednu za CurItem
+                                // for the item/operation CurItem->ParentUID subtract one NotDone (for CurItem in the
+                                // sqisProcessing state) and increase NotDone according to childItemsNotDone
+                                childItemsNotDone--; // subtract one for CurItem
                                 Oper->AddToItemOrOperationCounters(curItemParent, childItemsNotDone, 0, 0, 0, FALSE);
 
                                 Queue->UnlockForMoreOperations();
 
-                                // zvysime celkovou velikost prenasenych dat o velikost z novych polozek
+                                // increase the total transferred data size by the size of the new items
                                 Oper->AddToTotalSize(totalSize, TRUE);
 
-                                Oper->ReportItemChange(-1); // pozadame o redraw vsech polozek
+                                Oper->ReportItemChange(-1); // request a redraw of all items
 
-                                // tento worker si bude muset najit dalsi praci
-                                State = fwsLookingForWork;                                 // neni nutne volat Oper->OperationStatusMaybeChanged(), nemeni stav operace (neni paused a nebude ani po teto zmene)
-                                SubState = quitCmdWasSent ? fwssLookFWQuitSent : fwssNone; // pripadne predame do fwsLookingForWork, ze QUIT uz byl poslany
-                                postActivate = TRUE;                                       // postneme si aktivaci pro dalsi stav workera
+                                // this worker will need to look for additional work
+                                State = fwsLookingForWork;                                 // no need to call Oper->OperationStatusMaybeChanged(); it does not change the operation state (it is not paused and will not be after this change)
+                                SubState = quitCmdWasSent ? fwssLookFWQuitSent : fwssNone; // optionally pass to fwsLookingForWork that QUIT has already been sent
+                                postActivate = TRUE;                                       // post an activation for the next worker state
                                 reportWorkerChange = TRUE;
 
-                                // informujeme vsechny pripadne spici workery, ze se objevila nova prace
+                                // notify all potentially sleeping workers that new work has appeared
                                 HANDLES(LeaveCriticalSection(&WorkerCritSect));
-                                // vzhledem k tomu, ze uz v sekci CSocketsThread::CritSect jsme, je tohle volani
-                                // mozne i ze sekce CSocket::SocketCritSect (nehrozi dead-lock)
+                                // since we are already in CSocketsThread::CritSect, this call is also possible
+                                // from within CSocket::SocketCritSect (no deadlock threat)
                                 Oper->PostNewWorkAvailable(FALSE);
                                 HANDLES(EnterCriticalSection(&WorkerCritSect));
                             }
                             else
                             {
-                                err = TRUE; // nedostatek pameti -> vepiseme chybu do polozky
+                                err = TRUE; // out of memory -> write the error into the item
                                 Queue->UnlockForMoreOperations();
                             }
                         }
                         if (err)
-                        { // chyba na polozce, zapiseme do ni tento stav
+                        { // error on the item; record this state
                             Queue->UpdateItemState(CurItem, sqisFailed, ITEMPR_LOWMEM, NO_ERROR, NULL, Oper);
-                            lookForNewWork = TRUE; // quitCmdWasSent uz je nastaveny
+                            lookForNewWork = TRUE; // quitCmdWasSent is already set
                         }
                         if (ftpQueueItems != NULL)
                             delete ftpQueueItems;
                     }
-                    else // pri vytvareni adresare nastala chyba nebo doslo ke skipnuti polozky
+                    else // an error occurred while creating the directory or the item was skipped
                     {
                         Queue->UpdateItemState(CurItem, DiskWork.State, DiskWork.ProblemID, DiskWork.WinError, NULL, Oper);
-                        lookForNewWork = TRUE; // quitCmdWasSent uz je nastaveny
+                        lookForNewWork = TRUE; // quitCmdWasSent is already set
                     }
-                    if (DiskWork.DiskListing != NULL) // pokud mame listing, dealokujeme ho zde (mel by existovat jen pri uspesnem vylistovani)
+                    if (DiskWork.DiskListing != NULL) // if a listing exists, deallocate it here (it should exist only after a successful listing)
                     {
                         delete DiskWork.DiskListing;
                         DiskWork.DiskListing = NULL;


### PR DESCRIPTION
## Summary
- translate Czech inline comments in `CFTPWorker::HandleEventInWorkingState4` to English for clarity
- update cached listing and autorename handling remarks to match the surrounding code behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df64ab34c88322be1836e1a10b341f