### PR TITLE
Translate remaining FTP plugin comments

### DIFF
--- a/src/plugins/ftp/ctrlcon1.cpp
+++ b/src/plugins/ftp/ctrlcon1.cpp
@@ -1100,9 +1100,9 @@ RETRY_LABEL:
                                 params.Caption = LoadStr(IDS_FTPPLUGINTITLE);
                                 params.Text = LoadStr(IDS_WAITRETRESC);
                                 char aliasBtnNames[300];
-                                /* slouzi pro skript export_mnu.py, ktery generuje salmenu.mnu pro Translator
-   nechame pro tlacitka msgboxu resit kolize hotkeys tim, ze simulujeme, ze jde o menu
-MENU_TEMPLATE_ITEM MsgBoxButtons[] = 
+                                /* used by the script export_mnu.py, which generates salmenu.mnu for Translator
+   we let the message box buttons resolve hotkey collisions by simulating that this is a menu
+MENU_TEMPLATE_ITEM MsgBoxButtons[] =
 {
   {MNTT_PB, 0
   {MNTT_IT, IDS_WAITRETRESCABORTBTN
@@ -1746,7 +1746,7 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                                                     int err;
                                                     CCertificate* unverifiedCert;
                                                     if (!EncryptSocket(logUID, &err, &unverifiedCert, &errID, errBuf, 300,
-                                                                       NULL /* pro control connection je to vzdy NULL */))
+                                                                       NULL /* it's always NULL for the control connection */))
                                                     {
                                                         allBytesWritten = TRUE; // no longer important, the socket will be closed
                                                         if (errBuf[0] == 0)

--- a/src/plugins/ftp/dialogs3.cpp
+++ b/src/plugins/ftp/dialogs3.cpp
@@ -1398,8 +1398,8 @@ CEditServerTypeDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             HMENU menu = CreatePopupMenu();
             if (menu != NULL)
             {
-                /* slouzi pro skript export_mnu.py, ktery generuje salmenu.mnu pro Translator
-   udrzovat synchronizovane s volani AppendMenu() dole...
+                /* used by the script export_mnu.py, which generates salmenu.mnu for Translator
+   keep synchronized with the AppendMenu() calls below...
 MENU_TEMPLATE_ITEM EditServerTypeADCondMenu[] =
 {
   {MNTT_PB, 0

--- a/src/plugins/ftp/fs1.cpp
+++ b/src/plugins/ftp/fs1.cpp
@@ -153,8 +153,8 @@ void ReleaseFS()
 
     // terminate operation workers (they should already be finished, this is just in case of an error)
     FTPOperationsList.StopWorkers(SalamanderGeneral->GetMsgBoxParent(),
-                                  -1 /* vsechny operace */,
-                                  -1 /* vsechny workery */);
+                                  -1 /* all operations */,
+                                  -1 /* all workers */);
 
     if (!UnregisterClass(SAVEBITS_CLASSNAME, DLLInstance))
         TRACE_E("UnregisterClass(SAVEBITS_CLASSNAME) has failed");


### PR DESCRIPTION
## Summary
- translate the remaining Czech comments in the FTP plugin sources to English
- update dialog helper comments to explain their purpose for the export script
- clarify inline notes describing special parameter values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a9882b1083229293f44f3edd159b