### PR TITLE
filecomp Translate remaining viewer comments

### DIFF
--- a/src/plugins/filecomp/controls.cpp
+++ b/src/plugins/filecomp/controls.cpp
@@ -7,10 +7,10 @@
 
 #include <Shlwapi.h>
 
-//#pragma comment(lib, "Shlwapi.lib")  // Petr: ve VC2008 mi neslape, davam to do projektu
+//#pragma comment(lib, "Shlwapi.lib")  // Petr: it does not work for me in VC2008, so I add it to the project
 
-HFONT EnvFont;     // font prostredi (edit, toolbar, header, status)
-int EnvFontHeight; // vyska fontu
+HFONT EnvFont;     // environment font (edit, toolbar, header, status)
+int EnvFontHeight; // font height
 HBRUSH HDitheredBrush = NULL;
 
 // ****************************************************************************
@@ -63,7 +63,7 @@ CFileHeaderWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         HDC dc = BeginPaint(HWindow, &ps);
         HFONT oldFont = (HFONT)SelectObject(dc, EnvFont);
 
-        // zajistime aby jsme meli vzdy aktualni barvu brushe
+        // ensure we always have the current brush color
         COLORREF oldBk = BkColor;
         BkColor = SG->GetCurrentColor(SALCOL_INACTIVE_CAPTION_BK);
         if (BkColor != oldBk)
@@ -83,8 +83,8 @@ CFileHeaderWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         r.left++;
         r.right--;
 
-        // DT_PATH_ELLIPSIS nefunguje na nekterych retezcich, dochazi pak vytisteni oclipovaneho textu
-        // PathCompactPath() sice potrebuje kopii do lokalniho bufferu, ale neclipuje texty
+        // DT_PATH_ELLIPSIS does not work on some strings, which results in printing clipped text
+        // PathCompactPath() does need a copy into a local buffer, but it does not clip text
         char buff[2 * MAX_PATH];
         strncpy_s(buff, _countof(buff), Text, _TRUNCATE);
         PathCompactPath(dc, buff, r.right - r.left);
@@ -184,7 +184,7 @@ CSplitBarWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CAPTURECHANGED:
         if (!Tracking)
             return 0;
-        // pokracujem dal ...
+        // continue further ...
 
     case WM_LBUTTONUP:
     {
@@ -371,7 +371,7 @@ CToolTipWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         GetWindowText(HWindow, Text, 10);
 
-        // zmerime delku stringu
+        // measure the string length
         HDC hdc = GetDC(NULL);
         HFONT oldFont = (HFONT)SelectObject(hdc, EnvFont);
         SIZE s;
@@ -387,7 +387,7 @@ CToolTipWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_ERASEBKGND:
     {
-        // podmazeme a soucasne vykreslime text
+        // underpaint and draw the text at the same time
         HDC hDC = (HDC)wParam;
         RECT r;
         GetClientRect(HWindow, &r);
@@ -404,7 +404,7 @@ CToolTipWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_PAINT:
     {
-        // nedelame nic - vse je zarizeno v WM_ERASEBKGND
+        // do nothing - everything is handled in WM_ERASEBKGND
         PAINTSTRUCT ps;
         BeginPaint(HWindow, &ps);
         EndPaint(HWindow, &ps);
@@ -416,7 +416,7 @@ CToolTipWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         lstrcpyn(Text, (char*)lParam, 10);
         TextLen = int(strlen(Text));
 
-        // zjistime delku textu
+        // determine the text length
         HDC hdc = GetDC(NULL);
         HFONT oldFont = (HFONT)SelectObject(hdc, EnvFont);
         SIZE s;
@@ -424,7 +424,7 @@ CToolTipWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SelectObject(hdc, oldFont);
         ReleaseDC(NULL, hdc);
 
-        // nastavime rozmery okna
+        // set the window dimensions
         SetWindowPos(HWindow, 0, 0, 0, s.cx + 6, EnvFontHeight + 4,
                      SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOOWNERZORDER |
                          SWP_NOREPOSITION | SWP_NOZORDER);
@@ -581,7 +581,7 @@ CComboBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         RECT cr;
         GetClientRect(HWindow, &cr);
-        // zajistime, aby dvoubodovy ramecek kolem comba nebyl smeten behem paintu
+        // ensure the double-line frame around the combo is not wiped during painting
         RECT r;
         r.left = 0;
         r.top = 0;
@@ -604,7 +604,7 @@ CComboBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         r.bottom = cr.bottom - 2;
         ValidateRect(HWindow, &r);
 
-        // nakreslime si vlastni (jeden vnejsi sedivy a vnitrni promackly)
+        // draw our own one (outer gray and inner sunken)
         HDC hDC = GetDC(HWindow);
         HPEN hOldPen = (HPEN)SelectObject(hDC, BtnFacePen);
         SelectObject(hDC, GetStockObject(NULL_BRUSH));
@@ -625,7 +625,7 @@ CComboBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             break;
         }
 
-        // zajistime, aby dvoubodovy ramecek kolem tlacitka nebyl smeten behem paintu
+        // ensure the double-line frame around the button is not wiped during painting
         int sbWidth = GetSystemMetrics(SM_CXVSCROLL);
         r.left = cr.right - 2 - sbWidth;
         r.top = 2;
@@ -648,7 +648,7 @@ CComboBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         r.bottom = cr.bottom - 2;
         ValidateRect(HWindow, &r);
 
-        // nakreslime vlastni ramecek kolem tlacitka
+        // draw a custom frame around the button
         HPEN leftTopPen;
         HPEN bottomRightPen;
         POINT pos;
@@ -659,14 +659,14 @@ CComboBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             pos.y > cr.top + 1 &&
             pos.y < cr.bottom - 2)
         {
-            // nakreslime promackly ramecek
+            // draw a sunken frame
             leftTopPen = BtnShadowPen;
             //bottomRightPen = BtnHilightPen;
             bottomRightPen = BtnShadowPen;
         }
         else
         {
-            // nakreslime normalni ramecek
+            // draw a normal frame
             leftTopPen = BtnHilightPen;
             bottomRightPen = BtnShadowPen;
         }
@@ -703,14 +703,14 @@ BOOL CRebar::InsertBand(UINT uIndex, LPREBARBANDINFO lprbbi)
 
     if (lprbbi->fMask & RBBIM_TEXT)
     {
-        // vyhodime prefix
+        // remove the prefix
         char buffer[512];
         strcpy(buffer, lprbbi->lpText);
         char* prefix = strchr(buffer, '&');
         if (prefix)
             strcpy(prefix, prefix + 1);
 
-        // zmerime delku stringu
+        // measure the string length
         HDC hdc = GetDC(NULL);
         HFONT oldFont = (HFONT)SelectObject(hdc, EnvFont);
         SIZE s;
@@ -794,7 +794,7 @@ CRebar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_PAINT:
     {
         int bandCount = int(SendMessage(HWindow, RB_GETBANDCOUNT, 0, 0));
-        // zajistime vykresleni podtrzitek u textu s prefixem (napr &Differences)
+        // ensure drawing of underlines for text with a prefix (e.g. &Differences)
         int i;
         for (i = 0; i < bandCount; i++)
         {
@@ -818,22 +818,22 @@ CRebar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 r.top = r.top + (r.bottom - r.top - EnvFontHeight) / 2 - 1;
                 r.bottom = r.top + EnvFontHeight + 1;
 
-                // zajistime, aby nas text nebyl smeten behem paintu
+                // ensure our text is not wiped during paint
                 ValidateRect(HWindow, &r);
                 r.right -= 13;
 
-                // nakreslime vlastni text
+                // draw our own text
                 HDC hdc = GetDC(HWindow);
                 HFONT oldFont = (HFONT)SelectObject(hdc, (HFONT)EnvFont);
                 SetBkColor(hdc, GetSysColor(COLOR_BTNFACE));
                 DrawText(hdc, text, -1, &r, DT_SINGLELINE | DT_TOP);
 
-                // linka pod textem
+                // line under the text
                 r.top += EnvFontHeight;
                 FillRect(hdc, &r, (HBRUSH)(COLOR_BTNFACE + 1));
                 r.top -= EnvFontHeight;
 
-                // plocha za textem
+                // area behind the text
                 r.left = r.right;
                 r.right += 13;
                 FillRect(hdc, &r, (HBRUSH)(COLOR_BTNFACE + 1));

--- a/src/plugins/filecomp/controls.h
+++ b/src/plugins/filecomp/controls.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-extern HFONT EnvFont;     // font prostredi (edit, toolbar, header, status)
-extern int EnvFontHeight; // vyska fontu
+extern HFONT EnvFont;     // environment font (edit, toolbar, header, status)
+extern int EnvFontHeight; // font height
 extern HBRUSH HDitheredBrush;
 
 // ****************************************************************************

--- a/src/plugins/filecomp/cwbase.cpp
+++ b/src/plugins/filecomp/cwbase.cpp
@@ -21,7 +21,7 @@ CFilecompCoWorkerBase<CChar>::CFilecompCoWorkerBase(HWND mainWindow,
 template <class CChar>
 void CFilecompCoWorkerBase<CChar>::ReadFilesAndFindLines(CTextFileReader (&reader)[2], bool& binaryIdentical)
 {
-    // nacteme soubory
+    // load the files
     int i;
     for (i = 0; i < 2; i++)
     {
@@ -30,7 +30,7 @@ void CFilecompCoWorkerBase<CChar>::ReadFilesAndFindLines(CTextFileReader (&reade
         Files[i].End = Files[i].Begin + Files[i].Length;
     }
 
-    // nejsou nahodou shodne?
+    // are they identical by any chance?
     binaryIdentical = false;
     if (reader[0].HasMD5() && reader[1].HasMD5())
     {
@@ -41,7 +41,7 @@ void CFilecompCoWorkerBase<CChar>::ReadFilesAndFindLines(CTextFileReader (&reade
         binaryIdentical = memcmp(md5_1, md5_2, 16) == 0;
     }
 
-    // najdeme zacatky radku
+    // find the starts of lines
     for (i = 0; i < 2; i++)
     {
         CChar* lineStart = Files[i].Begin;
@@ -60,11 +60,11 @@ void CFilecompCoWorkerBase<CChar>::ReadFilesAndFindLines(CTextFileReader (&reade
             else
                 ++iterator;
         }
-        // ukazatel za posledni radku
+        // pointer to the line after the last line
         Files[i].Lines.push_back(lineStart);
     }
 
-    // jen pro klid duse
+    // just for peace of mind
     if (Files[i].Lines.size() >= size_t(CLineSpec::MaxLines()))
         CFilecompWorker::CException::Raise(IDS_MAXLINES, 0);
 }
@@ -203,10 +203,10 @@ void CFilecompCoWorkerBase<CChar>::ScrictCompare(
     if (d == -1)
         CFilecompWorker::CException::Raise(IDS_INTERNALERROR, 0);
 
-    // TODO az budu implementovat strict, tak tohle by se melo osetrit
+    // TODO once I implement strict, this should be handled
     // if (d == 0)
 
-    // shift-boundaries se vola pred RemoveSingleCharMatches
+    // shift-boundaries is called before RemoveSingleCharMatches
     ShiftBoundaries(Strict.EditScript, Strict.CompareData);
 
     // remove sigle char matches
@@ -226,11 +226,10 @@ void CFilecompCoWorkerBase<CChar>::ScrictCompare(
         Strict.Changes[i].clear();
     }
 
-    // NOTE prefixy i suffixy mohou byt ruzne dlouhe -- jinak zalamany stejny
-    // text
+    // NOTE prefixes and suffixes can have different lengths -- otherwise the wrapped text is the same
     for (CEditScript::iterator esi = Strict.EditScript.begin();; ++esi)
     {
-        // zpracujeme spolecnou cast
+        // process the common part
         mstart = cdi[0];
         mend = esi >= Strict.EditScript.end() ? Strict.CompareData[0].end() : Strict.CompareData[0].begin() + esi->DeletePos;
         // break condition is at the loop end
@@ -262,7 +261,7 @@ void CFilecompCoWorkerBase<CChar>::ScrictCompare(
             {
                 if (lineChanged[i] && script[i].size() < script[1 - i].size())
                 {
-                    // dorovname
+                    // align
                     fill_n(back_inserter(script[i]),
                            script[1 - i].size() - script[i].size(),
                            CLineSpec(CLineSpec::lcBlank));
@@ -274,12 +273,12 @@ void CFilecompCoWorkerBase<CChar>::ScrictCompare(
                 break;
             ++cdi[0], ++cdi[1];
         }
-        // konec?
+        // end?
         if (esi >= Strict.EditScript.end())
             break;
         if (CancelFlag)
             throw CFilecompWorker::CAbortByUserException();
-        // zpracujeme rozdilnou cast
+        // process the differing part
         for (i = 0; i < 2; ++i)
         {
             if (cdi[i] >= Strict.CompareData[i].end())
@@ -289,19 +288,19 @@ void CFilecompCoWorkerBase<CChar>::ScrictCompare(
             if (endline > line[i])
             {
                 _ASSERT(cdi[i]->CharLine == line[i]);
-                // skript pro aktualni radku
+                // script for the current line
                 Strict.Changes[i].push_back((int)(cdi[i]->Position - Files[i].Lines[line[i]]));
                 Strict.Changes[i].push_back(
                     (int)(Files[i].Lines[line[i] + 1] - Files[i].Lines[line[i]] - 1));
                 script[i].push_back(CLineSpec(CLineSpec::lcChange, int(line[i]), Strict.Changes[i]));
                 Strict.Changes[i].clear();
-                // doplnime radkama ktere jsou ciste zmeny
+                // add lines that are pure changes
                 while (endline > ++line[i])
                     script[i].push_back(CLineSpec(CLineSpec::lcChange, int(line[i]), 0,
                                                   int(Files[i].Lines[line[i] + 1] - Files[i].Lines[line[i]]) - 1));
                 if (cdi[i] + esi->Length[i] < Strict.CompareData[i].end())
                 {
-                    // zahajime skript pro posledni radku zmeny
+                    // start the script for the last line of the change
                     Strict.Changes[i].push_back(0);
                     Strict.Changes[i].push_back(
                         (int)((cdi[i] + esi->Length[i])->Position - Files[i].Lines[line[i]]));
@@ -310,7 +309,7 @@ void CFilecompCoWorkerBase<CChar>::ScrictCompare(
             else
             {
                 _ASSERT(cdi[i] + esi->Length[i] < Strict.CompareData[i].end());
-                // zmena zustava v aktualni radce
+                // the change remains in the current line
                 Strict.Changes[i].push_back((int)(cdi[i]->Position - Files[i].Lines[line[i]]));
                 Strict.Changes[i].push_back(
                     (int)((cdi[i] + esi->Length[i])->Position - Files[i].Lines[line[i]]));
@@ -332,7 +331,7 @@ void CFilecompCoWorkerBase<CChar>::ScrictCompare(
             script[i].push_back(CLineSpec(lcCommon, int(line[i])));
     }
 
-    // // doplnime do plneho poctu radku
+    // // add enough to reach the full number of lines
     // int i;
     // for (i = 0; i < 2; ++i)
     // {
@@ -343,7 +342,7 @@ void CFilecompCoWorkerBase<CChar>::ScrictCompare(
     //   }
     // }
 
-    // dorovname kratsi script
+    // align the shorter script
     int s = script[0].size() < script[1].size() ? 0 : 1;
     fill_n(back_inserter(script[s]),
            script[1 - s].size() - script[s].size(),
@@ -393,8 +392,8 @@ void CFilecompCoWorkerBase<CChar>::ShiftBoundaries(CEditScript& editScript, CCom
 {
     //CCounterDriver sb(::ShiftBoundaries);
 
-    // TODO na vektoru tohle muze byt dost pomale, overit, zda se nevyplati
-    // to docasne prekopirovat do listu
+    // TODO on a vector this could be quite slow; check whether it is worthwhile
+    // to temporarily copy it into a list
     int f;
     for (f = 0; f < 2; ++f)
     {

--- a/src/plugins/filecomp/cwbase.h
+++ b/src/plugins/filecomp/cwbase.h
@@ -44,9 +44,9 @@ protected:
     };
     typedef std::vector<CCharProxy<CChar>> CStrictCompareData;
 
-    HWND MainWindow; // okno, ktere dostane WM_USER_WORKERNOTIFIES
+    HWND MainWindow; // window that receives WM_USER_WORKERNOTIFIES
     CCompareOptions& Options;
-    const int& CancelFlag; // 0 ... jedeme dal, jinak konec
+    const int& CancelFlag; // 0 ... keep going, otherwise stop
     CFCFileData Files[2];
 
     // work buffers for StrictCompare are to prevent offten re-allocation when

--- a/src/plugins/filecomp/cwoptim.cpp
+++ b/src/plugins/filecomp/cwoptim.cpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-#if (_MSC_VER < 1910) // MSVC 2017 rve kvuli nestandardnimu namespace std::tr1 (deprecated), jde zrejme jen o unordered_map, ktere drive bylo jen v std::tr1 a ted je primo v std
+#if (_MSC_VER < 1910) // MSVC 2017 complains about the nonstandard namespace std::tr1 (deprecated), apparently only because of unordered_map, which used to be in std::tr1 and is now directly in std
 using namespace std::tr1;
 #endif
 
@@ -147,7 +147,7 @@ void CFilecompCoWorkerOptimized<CChar>::IdentifyLines(CFilecompCoWorkerBase<CCha
     int i;
     for (i = 0; i < 2; ++i)
     {
-        // rezerve space
+        // reserve space
         compareData[i].resize(files[i].Lines.size() - 1);
         // indentify each line
         typename CLineBuffer::iterator line = files[i].Lines.begin();
@@ -237,7 +237,7 @@ void CFilecompCoWorkerOptimized<CChar>::Compare(CTextFileReader (&reader)[2])
       }
     }*/
 
-        // shift-boundaries, volat pred RemoveSingleCharMatches
+        // shift-boundaries, call before RemoveSingleCharMatches
         this->ShiftBoundaries(editScript, compareData);
     }
 
@@ -267,19 +267,19 @@ void CFilecompCoWorkerOptimized<CChar>::Compare(CTextFileReader (&reader)[2])
 
     for (CEditScript::iterator esi = editScript.begin();; ++esi)
     {
-        // zpracujeme spolecnou cast
+        // process the common part
         mend = esi >= editScript.end() ? this->Files[0].Lines.size() - 1 : esi->DeletePos;
         for (; li[0] < mend; li[0]++, li[1]++)
         {
             script[0].push_back(CLineSpec(CLineSpec::lcCommon, int(li[0])));
             script[1].push_back(CLineSpec(CLineSpec::lcCommon, int(li[1])));
         }
-        // konec?
+        // end?
         if (esi >= editScript.end())
             break;
         if (this->CancelFlag)
             throw CFilecompWorker::CAbortByUserException();
-        // zpracujeme rozdilnou cast
+        // process the differing part
         if ((this->Options.IgnoreSpaceChange || this->Options.IgnoreAllSpace) &&
             IsChangeIgnorable(*esi))
         {
@@ -295,7 +295,7 @@ void CFilecompCoWorkerOptimized<CChar>::Compare(CTextFileReader (&reader)[2])
         else
         {
             changes.push_back(*esi);
-            changesToLines.push_back((int)script[0].size()); // oba by tu meli byt stejne dlouhe
+            changesToLines.push_back((int)script[0].size()); // both should have the same length here
             if (esi->Length[0] && esi->Length[1] && this->Options.DetailedDifferences)
             {
                 this->ScrictCompare(esi->Position, esi->Length, script, CLineSpec::lcChange);
@@ -315,7 +315,7 @@ void CFilecompCoWorkerOptimized<CChar>::Compare(CTextFileReader (&reader)[2])
             changesLengths.push_back(
                 (int)max(script[0].size(), script[1].size()) - changesToLines.back());
         }
-        // dorovname kratsi script
+        // align the shorter script
         int s = script[0].size() < script[1].size() ? 0 : 1;
         fill_n(back_inserter(script[s]),
                script[1 - s].size() - script[s].size(),

--- a/src/plugins/filecomp/dialogs.cpp
+++ b/src/plugins/filecomp/dialogs.cpp
@@ -10,7 +10,7 @@ ComDlgHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
                         lParam);
     if (uiMsg == WM_INITDIALOG)
     {
-        // SalamanderGUI->ArrangeHorizontalLines(hdlg);  // pro Windows common dialogy tohle nedelame
+        // SalamanderGUI->ArrangeHorizontalLines(hdlg);  // we do not do this for Windows common dialogs
         CenterWindow(hdlg);
         return 1;
     }
@@ -22,7 +22,7 @@ ComDlgHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
 // CCompareFilesDialog
 //
 
-// historie pro kombace
+// history for combo boxes
 
 TCHAR CBHistory[MAX_HISTORY_ENTRIES][MAX_PATH];
 int CBHistoryEntries;
@@ -32,7 +32,7 @@ void AddToHistory(LPCTSTR path)
     CALL_STACK_MESSAGE2(_T("AddToHistory(%s)"), path);
     int toMove = __min(CBHistoryEntries, MAX_HISTORY_ENTRIES - 1);
     int enlarge = 1;
-    // podivame jestli uz stejna cesta neni v historii
+    // check whether the same path is already in the history
     int i;
     for (i = 0; i < CBHistoryEntries; i++)
     {
@@ -43,7 +43,7 @@ void AddToHistory(LPCTSTR path)
             break;
         }
     }
-    // vytvorime misto pro cestu kterou budeme ukladat
+    // make room for the path we will store
     int j;
     for (j = toMove; j > 0; j--)
         _tcscpy(CBHistory[j], CBHistory[j - 1]);
@@ -119,7 +119,7 @@ OFNHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
   CALL_STACK_MESSAGE4("OFNHookProc(, 0x%X, 0x%IX, 0x%IX)", uiMsg, wParam, lParam);
   if (uiMsg == WM_INITDIALOG)
   {
-    // SalamanderGUI->ArrangeHorizontalLines(hdlg);  // pro Windows common dialogy tohle nedelame
+    // SalamanderGUI->ArrangeHorizontalLines(hdlg);  // we do not do this for Windows common dialogs
     HWND hwnd = GetParent(hdlg);
     CenterWindow(hdlg);
     return 1;
@@ -167,8 +167,8 @@ CCompareFilesDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         HWND hWnd1 = GetDlgItem(HWindow, IDE_PATH1), hWnd2 = GetDlgItem(HWindow, IDE_PATH2);
 
-        SG->InstallWordBreakProc(hWnd1); // instalujeme WordBreakProc do comboboxu
-        SG->InstallWordBreakProc(hWnd2); // instalujeme WordBreakProc do comboboxu
+        SG->InstallWordBreakProc(hWnd1); // install WordBreakProc into the combo box
+        SG->InstallWordBreakProc(hWnd2); // install WordBreakProc into the combo box
 
         // I believe OldEditProc1 and OldEditProc2 are equal. But I am rather paranoic...
         OldEditProc1 = (WNDPROC)GetWindowLongPtr(hWnd1, GWLP_WNDPROC);
@@ -180,11 +180,11 @@ CCompareFilesDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         SetWindowPos(HWindow, AlwaysOnTop ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 
-        // incializujeme historii
+        // initialize the history
         int i = 0;
         if (CBHistoryEntries > 1)
         {
-            // v druhem kombaci ulozime prvni dve cesty v obracenem poradi
+            // store the first two paths in the second combo in reverse order
             for (; i < 2; i++)
             {
                 SendMessage(GetDlgItem(HWindow, IDE_PATH1), CB_ADDSTRING, 0, (LPARAM)CBHistory[i]);

--- a/src/plugins/filecomp/dialogs.h
+++ b/src/plugins/filecomp/dialogs.h
@@ -63,17 +63,17 @@ protected:
 
 struct CColorsCfgButton
 {
-    int TextID;         // nazev tlacitka
-    int ColorLineNumFG; // index FG barvy pro 1. tlacitko nebo -1 (FG nelze konfigurovat)
-    int ColorLineNumBK; // index BK barvy pro 1. tlacitko nebo -1 (tlaciko nebude videt)
-    int ColorTextFG;    // index FG barvy pro 2. tlacitko nebo -1 (FG nelze konfigurovat)
-    int ColorTextBK;    // index BK barvy pro 2. tlacitko nebo -1 (tlaciko nebude videt)
+    int TextID;         // button caption
+    int ColorLineNumFG; // index of the FG color for the first button or -1 (FG cannot be configured)
+    int ColorLineNumBK; // index of the BK color for the first button or -1 (the button would not be visible)
+    int ColorTextFG;    // index of the FG color for the second button or -1 (FG cannot be configured)
+    int ColorTextBK;    // index of the BK color for the second button or -1 (the button would not be visible)
 };
 
 struct CColorsCfgItem
 {
-    int TextID;       // nazev polozky
-    int ButtonsCount; // pocet pouzitych tlacitek
+    int TextID;       // item caption
+    int ButtonsCount; // number of buttons used
     CColorsCfgButton* Buttons;
 };
 
@@ -181,7 +181,7 @@ protected:
 //
 // CTextArrowButton
 //
-// klasicky text, za kterym je jeste sipka - slouzi pro rozbaleni menu
+// classic text followed by an arrow - used to expand the menu
 //
 
 // class CTextArrowButton : public CButton
@@ -197,7 +197,7 @@ protected:
 //
 // CColorArrowButton
 //
-// pozadi s textem, za kterym je jeste sipka - slouzi pro rozbaleni menu
+// background with text followed by an arrow - used to expand the menu
 //
 
 // class CColorArrowButton : public CButton

--- a/src/plugins/filecomp/dialogs2.cpp
+++ b/src/plugins/filecomp/dialogs2.cpp
@@ -188,20 +188,20 @@ void CPropPageColors::ChooseColor(int item, int colorFG, int colorBK, const RECT
     HMENU hMenu, hSubMenu;
     if (colorFG == -1)
     {
-        // vybirame jen jednu barvu
+        // select only one color
         hMenu = LoadMenu(HLanguage, MAKEINTRESOURCE(IDM_CTX_1COLOR_MENU));
         hSubMenu = GetSubMenu(hMenu, 0);
     }
     else
     {
-        // vybirame dve barvy
+        // select two colors
         hMenu = LoadMenu(HLanguage, MAKEINTRESOURCE(IDM_CTX_2COLOR_MENU));
         hSubMenu = GetSubMenu(hMenu, 0);
         automatic = GetFValue(TempColors[colorFG]) & SCF_DEFAULT;
         CheckMenuItem(hSubMenu, CM_CUSTOMTEXT, MF_BYCOMMAND | (automatic ? MF_UNCHECKED : MF_CHECKED));
         CheckMenuItem(hSubMenu, CM_AUTOTEXT, MF_BYCOMMAND | (automatic ? MF_CHECKED : MF_UNCHECKED));
 
-        // podivame se, zda existuje defaultni hodnota k teto barve
+        // check whether there is a default value for this color
         automatic = GetFValue(DefaultColors[colorFG]) & SCF_DEFAULT;
         EnableMenuItem(hSubMenu, CM_AUTOTEXT, MF_BYCOMMAND | (automatic ? MF_ENABLED : MF_GRAYED));
     }
@@ -209,7 +209,7 @@ void CPropPageColors::ChooseColor(int item, int colorFG, int colorBK, const RECT
     CheckMenuItem(hSubMenu, CM_CUSTOMBACKGROUND, MF_BYCOMMAND | (automatic ? MF_UNCHECKED : MF_CHECKED));
     CheckMenuItem(hSubMenu, CM_AUTOBACKGROUND, MF_BYCOMMAND | (automatic ? MF_CHECKED : MF_UNCHECKED));
 
-    // podivame se, zda existuje defaultni hodnota k teto barve
+    // check whether there is a default value for this color
     automatic = GetFValue(DefaultColors[colorBK]) & SCF_DEFAULT;
     EnableMenuItem(hSubMenu, CM_AUTOBACKGROUND, MF_BYCOMMAND | (automatic ? MF_ENABLED : MF_GRAYED));
 
@@ -221,7 +221,7 @@ void CPropPageColors::ChooseColor(int item, int colorFG, int colorBK, const RECT
                              btnRect->right, btnRect->top, HWindow, &tpmPar))
     {
     case CM_CUSTOMTEXT:
-        color = colorFG; // jedeme dal...
+        color = colorFG; // continue...
     case CM_CUSTOMBACKGROUND:
     {
         CHOOSECOLOR cc;
@@ -276,10 +276,10 @@ CPropPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             ColorButtons[i][LINENUM_COLOR_BTN] = SalGUI->AttachColorArrowButton(HWindow, LineNumIDs[i], TRUE);
             ColorButtons[i][TEXT_COLOR_BTN] = SalGUI->AttachColorArrowButton(HWindow, TextIDs[i], TRUE);
-            // #pragma message(__FILE__ "(280) : Honzo, az tohle implementujes, tak nasledujici kod odkomentuj. Dik, Lukas.")
-            // j.r. FIXME: zatim jsem na to nemel cas, hazim pragmu do komentare, at nestrasi v buildu
-            // l.c., 13.2.2011 jen jsem na zkousku tu pragmu zas odkomentoval, estli jsi to nahodou mezitim nenakodil:)
-            // j.r., 23.3.2011 nizka priorita, zatim nebudeme resit
+            // #pragma message(__FILE__ "(280) : Honza, once you implement this, uncomment the following code. Thanks, Lukas.")
+            // j.r. FIXME: I have not had time for it yet, so I am moving the pragma into a comment so it does not haunt the build
+            // l.c., 13.2.2011 I only uncommented the pragma for a test, in case you happened to code it in the meantime :)
+            // j.r., 23.3.2011 low priority, we will not address it for now
             // ColorButtons[i][LINENUM_COLOR_BTN]->SetPalette(&HPalette, &UsePalette);
             // ColorButtons[i][TEXT_COLOR_BTN]->SetPalette(&HPalette, &UsePalette);
         }
@@ -359,9 +359,9 @@ CPropPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_NOTIFY:
     {
-        if (((NMHDR*)lParam)->code == PSN_SETACTIVE) // aktivace stranky
+        if (((NMHDR*)lParam)->code == PSN_SETACTIVE) // page activation
         {
-            // nastavime font pro preview
+            // set the font for the preview
             Preview1->SetFont(PageGeneral->GetCurrentFont());
             Preview2->SetFont(PageGeneral->GetCurrentFont());
             break;
@@ -372,10 +372,10 @@ CPropPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         LRESULT i = SendMessage(GetDlgItem(HWindow, IDC_ITEMS), CB_GETCURSEL, 0, 0);
         UpdateColors(int(i));
-        // #pragma message(__FILE__ "(375) : Honzo, az overis, ze se v CGUIColorArrowButton obnovuji pera automaticky, tak nasleduji komentar vymaz (nezamenovat s odkomentuj:). Dik Lukas")
-        // j.r. FIXME: zatim jsem na to nemel cas, hazim pragmu do komentare, at nestrasi v buildu
-        // l.c., 13.2.2011 jen jsem na zkousku tu pragmu zas odkomentoval, estli jsi to nahodou mezitim nenakodil:)
-        // j.r., 23.3.2011 nizka priorita, zatim nebudeme resit
+        // #pragma message(__FILE__ "(375) : Honza, once you verify that CGUIColorArrowButton automatically refreshes the pens, delete the following comment (do not confuse it with uncommenting). Thanks, Lukas")
+        // j.r. FIXME: I have not had time for it yet, so I am moving the pragma into a comment so it does not haunt the build
+        // l.c., 13.2.2011 I only uncommented the pragma for a test, in case you happened to code it in the meantime :)
+        // j.r., 23.3.2011 low priority, we will not address it for now
         // for (i = 0; i < 3; i++)
         // {
         //   ColorButtons[i][LINENUM_COLOR_BTN]->ColorsChanged();
@@ -522,7 +522,7 @@ void CPreviewWindow::RePaint()
 void CPreviewWindow::SetFont(LOGFONT* font)
 {
     CALL_STACK_MESSAGE1("CPreviewWindow::SetFont()");
-    // nacteme font
+    // load the font
     if (HFont)
         DeleteObject(HFont);
     HDC hdc = GetDC(NULL);
@@ -560,11 +560,11 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         IntersectClipRect(dc, cr.left, cr.top, cr.right, cr.bottom);
 
-        RECT r1; // cislo radky
+        RECT r1; // line number
         r1.left = 0;
         r1.right = (2 + 1) * FontWidth + BORDER_WIDTH;
-        r1.bottom = 0; // abychom meli pozdeji platna data, kdyby kreslici smycka vubec neprobehla
-        RECT r2;       // vlastni radek textu
+        r1.bottom = 0; // to have valid data later, in case the drawing loop does not run at all
+        RECT r2;       // the actual line of text
         r2.left = r1.right;
         r2.right = cr.right;
         int text_y;
@@ -582,12 +582,12 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (PreviewScript[i].TextColor == TEXT_FG_LEFT_CHANGE_FOCUSED ||
                 i > 0 && PreviewScript[i - 1].TextColor == TEXT_FG_LEFT_FOCUSED)
             {
-                // vykreslime cast ohraniceni aktivni difference na hornim okraji radku
-                // hrana ve sloupci s cisly radek
+                // draw part of the outline of the active difference on the top edge of the line
+                // edge in the column with line numbers
                 hOldPen = (HPEN)SelectObject(dc, HLineNumBorderPen);
                 MoveToEx(dc, r1.left, r1.top, NULL);
                 LineTo(dc, r1.right, r1.top);
-                // hrana ve casti s textem souboru
+                // edge in the part with the file text
                 (HPEN) SelectObject(dc, HBorderPen);
                 LineTo(dc, r2.right, r1.top);
                 SelectObject(dc, hOldPen);
@@ -595,14 +595,14 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 r2.top++;
             }
 
-            // nakreslime cislo radky
+            // draw the line number
             char num[2 + 1];
             sprintf(num, "%*d", 2, lineNum);
             SetTextColor(dc, GetPALETTERGB(Colors[PreviewScript[i].LineNumFGColor + side]));
             SetBkColor(dc, GetPALETTERGB(Colors[PreviewScript[i].LineNumBKColor + side]));
             ExtTextOut(dc, BORDER_WIDTH, text_y, ETO_OPAQUE | ETO_CLIPPED, &r1, num, 2, NULL);
 
-            // nakreslime text
+            // draw the text
             SetTextColor(dc, GetPALETTERGB(Colors[PreviewScript[i].TextColor + side]));
             SetBkColor(dc, GetPALETTERGB(Colors[PreviewScript[i].BkgndColor + side]));
             char* text = LoadStr(PreviewScript[i].TextID);
@@ -886,22 +886,22 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //       {
 //         clR.right--;
 //         clR.bottom--;
-//         // svetla vlevo a nahore
+//         // highlight on the left and top
 //         HPEN hOldPen = (HPEN)SelectObject(dc, BtnHilightPen);
 //         MoveToEx(dc, clR.left, clR.bottom - 1, NULL);
 //         LineTo(dc, clR.left, clR.top);
 //         LineTo(dc, clR.right, clR.top);
-//         // trochu tmavsi uvnitr
+//         // slightly darker inside
 //         SelectObject(dc, Btn3DLightPen);
 //         MoveToEx(dc, clR.left + 1, clR.bottom - 2, NULL);
 //         LineTo(dc, clR.left + 1, clR.top + 1);
 //         LineTo(dc, clR.right - 1, clR.top + 1);
-//         // tmava vpravo a dole
+//         // dark on the right and bottom
 //         SelectObject(dc, BtnShadowPen);
 //         MoveToEx(dc, clR.right - 1, clR.top + 1, NULL);
 //         LineTo(dc, clR.right - 1, clR.bottom - 1);
 //         LineTo(dc, clR.left, clR.bottom - 1);
-//         // nejtmavsi uplne venku
+//         // the darkest completely on the outside
 //         SelectObject(dc, WndFramePen);
 //         MoveToEx(dc, clR.left, clR.bottom, NULL);
 //         LineTo(dc, clR.right, clR.bottom);
@@ -1081,7 +1081,7 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //
 // CTextArrowButton
 //
-// klasicky text, za kterym je jeste sipka - slouzi pro rozbaleni menu
+// standard text with an arrow afterward - used to expand the menu
 //
 
 // CTextArrowButton::CTextArrowButton(HWND hDlg, int ctrlID, CObjectOrigin origin)
@@ -1095,11 +1095,11 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //   CALL_STACK_MESSAGE_NONE
 //   RECT r = *rect;
 //
-//   // vytahnu text tlacitka
+//   // fetch the button text
 //   char buff[200];
 //   GetWindowText(HWindow, buff, 199);
 //
-//   // vytahnu aktualni font
+//   // fetch the current font
 //   HFONT hFont = (HFONT)SendMessage(HWindow, WM_GETFONT, 0, 0);
 //
 //   r.right -= 8;
@@ -1122,7 +1122,7 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //
 // CColorArrowButton
 //
-// pozadi s textem, za kterym je jeste sipka - slouzi pro rozbaleni menu
+// background with text followed by an arrow - used to expand the menu
 //
 
 // CColorArrowButton::CColorArrowButton(HWND hDlg, int ctrlID, HPALETTE &hPalette, CObjectOrigin origin)
@@ -1174,11 +1174,11 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //
 //   RECT r = *rect;
 //
-//   // vytahnu text tlacitka
+//   // fetch the button text
 //   char buff[200];
 //   GetWindowText(HWindow, buff, 199);
 //
-//   // vytahnu aktualni font
+//   // fetch the current font
 //   HFONT hFont = (HFONT)SendMessage(HWindow, WM_GETFONT, 0, 0);
 //
 //   r.right -= 8;

--- a/src/plugins/filecomp/dialogs4.cpp
+++ b/src/plugins/filecomp/dialogs4.cpp
@@ -86,11 +86,11 @@ void CPropPageGeneral::LoadControls(BOOL initCombo)
 {
     CALL_STACK_MESSAGE2("CPropPageGeneral::LoadControls(%d)", initCombo);
 
-    // inicializuje edit linu pro ukazku fontu
+    // initialize the edit line for the font preview
     HWND hEdit = GetDlgItem(HWindow, IDE_FONT);
     LOGFONT logFont;
     logFont = LogFont;
-    logFont.lfHeight = SalGUI->GetWindowFontHeight(hEdit); // pro prezentaci fontu v edit line pouzijeme jeji velikost fontu
+    logFont.lfHeight = SalGUI->GetWindowFontHeight(hEdit); // for presenting the font in the edit line we use its font size
     if (HFont)
         DeleteObject(HFont);
     HFont = CreateFontIndirect(&logFont);
@@ -103,7 +103,7 @@ void CPropPageGeneral::LoadControls(BOOL initCombo)
             LogFont.lfFaceName);
     SetWindowText(hEdit, logFont.lfFaceName);
 
-    // inicializuje comba pro vyber znaku
+    // initialize combos for selecting characters
     HWND whiteSpace = GetDlgItem(HWindow, IDC_WHITESPACE);
     SendMessage(whiteSpace, WM_SETFONT, (WPARAM)HFont, FALSE);
     if (initCombo)
@@ -202,7 +202,7 @@ CPropPageGeneral::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 // CConfigurationDialog
 //
 
-// pomocny objekt pro centrovani konfiguracniho dialogu k parentovi
+// helper object to center the configuration dialog relative to the parent
 class CCenteredPropertyWindow : public CWindow
 {
 protected:
@@ -218,10 +218,10 @@ protected:
             break;
         }
 
-        case WM_APP + 1000: // mame se odpojit od dialogu (uz je vycentrovano)
+        case WM_APP + 1000: // we should detach from the dialog (already centered)
         {
             DetachWindow();
-            delete this; // trochu prasarna, ale uz se 'this' nikdo ani nedotkne, takze pohoda
+            delete this; // a bit of a hack, but no one will touch 'this' anymore, so it's fine
             return 0;
         }
         }
@@ -247,25 +247,25 @@ typedef struct DLGTEMPLATEEX
 #include <poppack.h>
 #endif // LPDLGTEMPLATEEX
 
-// pomocny call-back pro centrovani konfiguracniho dialogu k parentovi a vyhozeni '?' buttonku z captionu
+// helper callback to center the configuration dialog relative to the parent and remove the '?' button from the caption
 int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
 {
     CALL_STACK_MESSAGE3("CenterCallback(, 0x%X, 0x%IX)", uMsg, lParam);
-    if (uMsg == PSCB_INITIALIZED) // pripojime se na dialog
+    if (uMsg == PSCB_INITIALIZED) // attach to the dialog
     {
         CCenteredPropertyWindow* wnd = new CCenteredPropertyWindow;
         if (wnd != NULL)
         {
             wnd->AttachToWindow(HWindow);
             if (wnd->HWindow == NULL)
-                delete wnd; // okno neni pripojeny, zrusime ho uz tady
+                delete wnd; // the window is not attached, so dispose of it right here
             else
             {
-                PostMessage(wnd->HWindow, WM_APP + 1000, 0, 0); // pro odpojeni CCenteredPropertyWindow od dialogu
+                PostMessage(wnd->HWindow, WM_APP + 1000, 0, 0); // to detach CCenteredPropertyWindow from the dialog
             }
         }
     }
-    if (uMsg == PSCB_PRECREATE) // odstraneni '?' buttonku z headeru property sheetu
+    if (uMsg == PSCB_PRECREATE) // removal of the '?' button from the property sheet header
     {
         // Remove the DS_CONTEXTHELP style from the dialog box template
         if (((LPDLGTEMPLATEEX)lParam)->signature == 0xFFFF)

--- a/src/plugins/filecomp/dlg_com.cpp
+++ b/src/plugins/filecomp/dlg_com.cpp
@@ -3,12 +3,12 @@
 
 #include "precomp.h"
 
-SALCOLOR Colors[NUMBER_OF_COLORS]; // aktualni barvy
+SALCOLOR Colors[NUMBER_OF_COLORS]; // current colors
 
-// standartni barvy
+// standard colors
 SALCOLOR DefaultColors[NUMBER_OF_COLORS] =
     {
-        // barvy textu ve sloupci s cisly radek
+        // colors of the text in the column with line numbers
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_FG_NORMAL
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_FG_LEFT_CHANGE
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_FG_RIGHT_CHANGE
@@ -20,11 +20,11 @@ SALCOLOR DefaultColors[NUMBER_OF_COLORS] =
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_BK_LEFT_CHANGE_FOCUSED
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_BK_RIGHT_CHANGE_FOCUSED
 
-        // ramecek kolem aktualni zmeny ve sloupci s cisly radek
+        // frame around the current change in the column with line numbers
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_LEFT_BORDER
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_RIGHT_BORDER
 
-        // barvy zobrazeneho obsahu souboru
+        // colors of the displayed file content
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_FG_NORMAL
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_FG_LEFT_FOCUSED
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_FG_RIGHT_FOCUSED
@@ -40,11 +40,11 @@ SALCOLOR DefaultColors[NUMBER_OF_COLORS] =
         RGBF(10, 128, 240, 0),      // TEXT_BK_LEFT_CHANGE_FOCUSED
         RGBF(255, 120, 120, 0),     // TEXT_BK_RIGHT_CHANGE_FOCUSED
 
-        // ramecek kolem aktualni zmeny v zobrazenem obsahu souboru
+        // frame around the current change in the displayed file content
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_LEFT_BORDER
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_RIGHT_BORDER
 
-        // barva vybraneho bloku textu
+        // color of the selected text block
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_FG_SELECTION
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_BK_SELECTION
 };
@@ -86,9 +86,9 @@ CCommonDialog::CCommonDialog(int resID, HWND hParent, CObjectOrigin origin)
     {
     case WM_INITDIALOG:
     {
-        // horizontalni i vertikalni vycentrovani dialogu k parentu
+        // horizontally and vertically center the dialog relative to the parent
         CenterWindow(HWindow);
-        break; // chci focus od DefDlgProc
+        break; // want focus from DefDlgProc
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);
@@ -199,7 +199,7 @@ CreateColorPallete()
 void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
 {
     CALL_STACK_MESSAGE1("UpdateDefaultColors(, )");
-    // barvy textu ve sloupci s cisly radek
+    // colors of the text in the column with line numbers
     if (GetFValue(colors[LINENUM_FG_NORMAL]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_FG_NORMAL], GetSysColor(COLOR_WINDOWTEXT));
     //if (GetFValue(colors[LINENUM_FG_FOCUSED]) & SCF_DEFAULT)
@@ -214,7 +214,7 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
     if (GetFValue(colors[LINENUM_FG_RIGHT_CHANGE_FOCUSED]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_FG_RIGHT_CHANGE_FOCUSED], GetCOLORREF(colors[LINENUM_FG_RIGHT_CHANGE]));
 
-    // barvy pozadi ve sloupci s cisly radek
+    // colors of the background in the column with line numbers
     if (GetFValue(colors[LINENUM_BK_NORMAL]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_BK_NORMAL], GetScrollbarColor());
     //if (GetFValue(colors[LINENUM_BK_FOCUSED]) & SCF_DEFAULT)
@@ -232,13 +232,13 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
     //GetAverageColor(GetCOLORREF(colors[LINENUM_BK_RIGHT_CHANGE]), 9,
     //                GetCOLORREF(colors[LINENUM_FG_RIGHT_CHANGE]), 1));
 
-    // barva ramecku kolem vybrane zmeny ve sloupci s cisly radek
+    // color of the frame around the selected change in the column with line numbers
     if (GetFValue(colors[LINENUM_LEFT_BORDER]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_LEFT_BORDER], GetSysColor(COLOR_BTNSHADOW));
     if (GetFValue(colors[LINENUM_RIGHT_BORDER]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_RIGHT_BORDER], GetSysColor(COLOR_BTNSHADOW));
 
-    // barvy textu zobrazeneho obsahu souboru
+    // colors of the text in the displayed file content
     if (GetFValue(colors[TEXT_FG_NORMAL]) & SCF_DEFAULT)
         SetRGBPart(&colors[TEXT_FG_NORMAL], SG->GetCurrentColor(SALCOL_VIEWER_FG_NORMAL));
     if (GetFValue(colors[TEXT_FG_LEFT_FOCUSED]) & SCF_DEFAULT)
@@ -254,7 +254,7 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
     //if (GetFValue(colors[TEXT_FG_RIGHT_CHANGE_FOCUSED]) & SCF_DEFAULT)
     //  SetRGBPart(&colors[TEXT_FG_RIGHT_CHANGE_FOCUSED], GetCOLORREF(colors[TEXT_FG_RIGHT_CHANGE]));
 
-    // barvy pozadi zobrazeneho obsahu souboru
+    // colors of the background in the displayed file content
     if (GetFValue(colors[TEXT_BK_NORMAL]) & SCF_DEFAULT)
         SetRGBPart(&colors[TEXT_BK_NORMAL], SG->GetCurrentColor(SALCOL_VIEWER_BK_NORMAL));
     if (GetFValue(colors[TEXT_BK_LEFT_FOCUSED]) & SCF_DEFAULT)
@@ -338,13 +338,13 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
   }
   */
 
-    // barva ramecku kolem vybrane zmeny
+    // color of the frame around the selected change
     if (GetFValue(colors[TEXT_LEFT_BORDER]) & SCF_DEFAULT)
         SetRGBPart(&colors[TEXT_LEFT_BORDER], GetSysColor(COLOR_BTNSHADOW));
     if (GetFValue(colors[TEXT_RIGHT_BORDER]) & SCF_DEFAULT)
         SetRGBPart(&colors[TEXT_RIGHT_BORDER], GetSysColor(COLOR_BTNSHADOW));
 
-    // barva vybraneho bloku textu
+    // color of the selected text block
     if (GetFValue(colors[TEXT_FG_SELECTION]) & SCF_DEFAULT)
     {
         if (GetFValue(colors[TEXT_FG_NORMAL]) & SCF_DEFAULT)
@@ -404,7 +404,7 @@ BOOL CreateEnvFont()
         return FALSE;
     }
 
-    // zjistime si vysku
+    // determine the height
     HDC dc = GetDC(NULL);
     HFONT oldFont = (HFONT)SelectObject(dc, EnvFont);
     TEXTMETRIC tm;

--- a/src/plugins/filecomp/dlg_com.h
+++ b/src/plugins/filecomp/dlg_com.h
@@ -3,24 +3,24 @@
 
 #pragma once
 
-// pro okno filecompu; WM_USER_WORKERNOTIFIES informuje o ukonceni porovnavani
-// a predava vysledky pokud window proc vrati TRUE je okno zodpovedne za
-// deallokaci predanych bufferu
+// for the filecomp window; WM_USER_WORKERNOTIFIES reports that the comparison finished
+// and passes the results; if the window proc returns TRUE the window is responsible for
+// deallocating the supplied buffers
 #define WM_USER_WORKERNOTIFIES (WM_APP + 1)
 
 // wParam:
 enum
 {
-    WN_ERROR,                // (const char *)lParam obsahuje text chyby
-    WN_NO_DIFFERENCE,        // lParam je ignorovan
-    WN_NO_ALL_DIFFS_IGNORED, // lParam je ignorovan
-    WN_BINARY_FILES_DIFFER,  // (CBinaryCompareResults *)lParam obsahuje vysledky diffovani
-    WN_TEXT_FILES_DIFFER,    // (CTextCompareResults<char> *)lParam obsahuje vysledky diffovani
-    WN_UNICODE_FILES_DIFFER, // (CCTextCompareesults<wchar_t> *)lParam obsahuje vysledky diffovani
-    WN_WORKER_CANCELED,      // lParam je ignorovan
-    WN_SETCHANGES,           // (CBinaryChanges *) lParam je pole zmen
-    WN_CBINIT_FINISHED,      // combo box byl upsesne inicializovan
-    WN_CALCULATING_DETAILS,  // pocitaji se podrobne difference
+    WN_ERROR,                // (const char*) lParam contains the error text
+    WN_NO_DIFFERENCE,        // lParam is ignored
+    WN_NO_ALL_DIFFS_IGNORED, // lParam is ignored
+    WN_BINARY_FILES_DIFFER,  // (CBinaryCompareResults*) lParam contains the comparison results
+    WN_TEXT_FILES_DIFFER,    // (CTextCompareResults<char>*) lParam contains the comparison results
+    WN_UNICODE_FILES_DIFFER, // (CTextCompareResults<wchar_t>*) lParam contains the comparison results
+    WN_WORKER_CANCELED,      // lParam is ignored
+    WN_SETCHANGES,           // (CBinaryChanges*) lParam is an array of changes
+    WN_CBINIT_FINISHED,      // the combo box was successfully initialized
+    WN_CALCULATING_DETAILS,  // detailed differences are being calculated
     WN_COMPARE_FINISHED,     // comparison finishes
     WN_GET_CHANGESCOMBO,     // queries HWND of the Change combobox
     WN_SET_PROGRESS,         // sets progress MAKELPARAM(percent, changesCnt)
@@ -30,20 +30,20 @@ enum
 #define WM_USER_VSCROLL (WM_APP + 2)
 #define WM_USER_HSCROLL (WM_APP + 3)
 #define WM_USER_SLITPOSCHANGED (WM_APP + 4)
-#define WM_USER_MOUSEWHEEL (WM_APP + 5)     // [wParam, lParam] z WM_MOUSEWHEEL
-#define WM_USER_ACTIVATEWINDOW (WM_APP + 6) // [wParam, lParam] z WM_MOUSEWHEEL
+#define WM_USER_MOUSEWHEEL (WM_APP + 5)     // [wParam, lParam] from WM_MOUSEWHEEL
+#define WM_USER_ACTIVATEWINDOW (WM_APP + 6) // [wParam, lParam] from WM_MOUSEWHEEL
 #define WM_USER_CREATE (WM_APP + 7)
 #define WM_USER_HANDLEFILEERROR (WM_APP + 8)
-#define WM_USER_SETCURSOR (WM_APP + 9) //jako WM_SETCURSOR
+#define WM_USER_SETCURSOR (WM_APP + 9) // same as WM_SETCURSOR
 #define WM_USER_CLEARHISTORY (WM_APP + 10)
 #define WM_USER_GETREBARHEIGHT (WM_APP + 11)
 #define WM_USER_GETHEADERHEIGHT (WM_APP + 12)
 #define WM_USER_AUTOCOPY_CHANGED (WM_APP + 13)
 
-// [wParam, (HWND) lParam] - pro otevrena okna pluginu: konfigurace pluginu se zmenila
+// [wParam, (HWND) lParam] - for open plugin windows: the plugin configuration changed
 #define WM_USER_CFGCHNG (WM_APP + 3246)
 
-// wParam: kombinace nasledujicich hodnot
+// wParam: combination of the following values
 #define CC_FONT 0x01
 #define CC_COLORS 0x02
 #define CC_DEFOPTIONS 0x04
@@ -53,9 +53,9 @@ enum
 #define CC_HAVEHWND 0x40
 #define CC_ALL (CC_FONT | CC_COLORS | CC_DEFOPTIONS | CC_CONTEXT | CC_TABSIZE | CC_CHAR)
 
-// barvy
+// colors
 
-#define LINENUM_FG_NORMAL 0 // barvy textu ve sloupci s cisly radek
+#define LINENUM_FG_NORMAL 0 // colors of the text in the column with line numbers
 #define LINENUM_FG_LEFT_CHANGE 1
 #define LINENUM_FG_RIGHT_CHANGE 2
 #define LINENUM_FG_LEFT_CHANGE_FOCUSED 3
@@ -66,10 +66,10 @@ enum
 #define LINENUM_BK_LEFT_CHANGE_FOCUSED 8
 #define LINENUM_BK_RIGHT_CHANGE_FOCUSED 9
 
-#define LINENUM_LEFT_BORDER 10 // ramecek kolem aktualni zmeny
+#define LINENUM_LEFT_BORDER 10 // frame around the current change
 #define LINENUM_RIGHT_BORDER 11
 
-#define TEXT_FG_NORMAL 12 // barvy zobrazeneho obsahu souboru
+#define TEXT_FG_NORMAL 12 // colors of the displayed file content
 #define TEXT_FG_LEFT_FOCUSED 13
 #define TEXT_FG_RIGHT_FOCUSED 14
 #define TEXT_FG_LEFT_CHANGE 15
@@ -84,19 +84,19 @@ enum
 #define TEXT_BK_LEFT_CHANGE_FOCUSED 24
 #define TEXT_BK_RIGHT_CHANGE_FOCUSED 25
 
-#define TEXT_LEFT_BORDER 26 // ramecek kolem aktualni zmeny
+#define TEXT_LEFT_BORDER 26 // frame around the current change
 #define TEXT_RIGHT_BORDER 27
 
-#define TEXT_FG_SELECTION 28 // barva vybraneho bloku textu
+#define TEXT_FG_SELECTION 28 // color of the selected text block
 #define TEXT_BK_SELECTION 29
 
-#define NUMBER_OF_COLORS 30 // pocet barev ve schematu
+#define NUMBER_OF_COLORS 30 // number of colors in the scheme
 
-// interni drzak barvy, ktery navic obsahuje flag
+// internal color holder that also carries a flag
 typedef DWORD SALCOLOR;
 
 // SALCOLOR flags
-#define SCF_DEFAULT 0x01 // barevna slozka se ignoruje a pouzije se default hodnota
+#define SCF_DEFAULT 0x01 // the color component is ignored and the default value is used
 
 #define GetCOLORREF(rgbf) ((COLORREF)rgbf & 0x00ffffff)
 #define GetPALETTERGB(rgbf) (0x02000000 | (COLORREF)rgbf & 0x00ffffff) // viz PALETTERGB ve wingdi.h
@@ -116,9 +116,9 @@ inline void SetRGBPart(SALCOLOR* salColor, COLORREF rgb)
     *salColor = rgb & 0x00ffffff | (((DWORD)(BYTE)((BYTE)((*salColor) >> 24))) << 24);
 }
 
-extern SALCOLOR Colors[NUMBER_OF_COLORS];        // aktualni barvy
-extern SALCOLOR DefaultColors[NUMBER_OF_COLORS]; // standardni barvy
-extern COLORREF CustomColors[16];                // custom colors pro ChooseColor dialog
+extern SALCOLOR Colors[NUMBER_OF_COLORS];        // current colors
+extern SALCOLOR DefaultColors[NUMBER_OF_COLORS]; // standard colors
+extern COLORREF CustomColors[16];                // custom colors for the ChooseColor dialog
 
 #if (WINVER < 0x0600)
 typedef enum _NORM_FORM
@@ -142,7 +142,7 @@ extern TNormalizeString PNormalizeString;
 
 enum CFileViewMode
 {
-    fvmStandard = 0, // nemenit hodnoty
+    fvmStandard = 0, // do not change values
     fvmOnlyDifferences = 1
 };
 
@@ -196,7 +196,7 @@ extern int CaretWidth;
 //
 // CCommonDialog
 //
-// Dialog centrovany k parentu
+// Dialog centered to the parent
 //
 
 class CCommonDialog : public CDialog

--- a/src/plugins/filecomp/filecomp.cpp
+++ b/src/plugins/filecomp/filecomp.cpp
@@ -5,15 +5,15 @@
 
 #pragma comment(lib, "UxTheme.lib")
 
-// zapina vypis bloku ktere zustaly alokovane na heapu po skonceni pluginu
+// enables logging of blocks that remained allocated on the heap after the plugin ends
 // #define DUMP_MEM
 
-// objekt interfacu pluginu, jeho metody se volaji ze Salamandera
+// plugin interface object, its methods are called from Salamander
 CPluginInterface PluginInterface;
-// cast interfacu CPluginInterface pro menu
+// part of the CPluginInterface interface for the menu
 CPluginInterfaceForMenu InterfaceForMenu;
 
-CWindowQueue MainWindowQueue("FileComp Windows"); // seznam vsech oken pluginu
+CWindowQueue MainWindowQueue("FileComp Windows"); // list of all plugin windows
 CThreadQueue ThreadQueue("FileComp Windows, Workers, and Remote Control");
 CMappedFontFactory MappedFontFactory;
 HINSTANCE hNormalizDll = NULL;
@@ -91,7 +91,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
         PNormalizeString = (TNormalizeString)GetProcAddress(hNormalizDll, "NormalizeString"); // Min: Vista
     }
 
-    // nastavime zakladni informace o pluginu
+    // set the basic information about the plugin
     salamander->SetBasicPluginData(LoadStr(IDS_PLUGINNAME),
                                    FUNCTION_LOADSAVECONFIGURATION | FUNCTION_CONFIGURATION,
                                    VERSINFO_VERSION_NO_PLATFORM,
@@ -101,9 +101,10 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     salamander->SetPluginHomePageURL("www.altap.cz");
 
-    // musi byt az za salamander->SetBasicPluginData, protoze pri startu threadu se pouziva
-    // verze pluginu a tu salamander->SetBasicPluginData meni (padalo to obcas prave diky
-    // tomu, ze se verze realokovala, a pak se pouzival dealokovany retezec)
+    // must come after salamander->SetBasicPluginData, because when the thread starts it
+    // uses the plugin version, and salamander->SetBasicPluginData modifies that (it used
+    // to crash occasionally because the version string was reallocated and then a freed
+    // string was used)
     CRemoteComparator::CreateRemoteComparator();
 
     return &PluginInterface;
@@ -173,7 +174,7 @@ void CPluginInterface::LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRe
 {
     CALL_STACK_MESSAGE1("CPluginInterface::LoadConfiguration(, , )");
 
-    // nastavime defaultni hodnoty
+    // set default values
 
     // configuration
     ::Configuration.ConfirmSelection = TRUE;
@@ -191,7 +192,7 @@ void CPluginInterface::LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRe
     SG->GetConfigParameter(SALCFG_AUTOCOPYSELTOCLIPBOARD, &::Configuration.AutoCopy,
                            sizeof(::Configuration.AutoCopy), NULL);
 
-    // barvy
+    // colors
     memcpy(Colors, DefaultColors, sizeof(SALCOLOR) * NUMBER_OF_COLORS);
     BandsParams[0].Width = -1;
     memset(CustomColors, 0, 16 * sizeof(COLORREF));
@@ -202,7 +203,7 @@ void CPluginInterface::LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRe
     // historie
     CBHistoryEntries = 0;
 
-    // posledni navstivena stranka v konfiguraci
+    // the last visited page in the configuration
     LastCfgPage = 0;
 
     if (regKey != NULL) // load z registry
@@ -212,7 +213,7 @@ void CPluginInterface::LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRe
         if ((configVersion == CURRENT_CONFIG_VERSION) || (configVersion == CURRENT_CONFIG_VERSION_NORECOMPAREBUTTON) || (configVersion == CURRENT_CONFIG_VERSION_PRESEPARATEOPTIONS))
         {
             CRegBLOBConfiguration blob;
-            // nacteme konfiguraci z registru
+            // load the configuration from the registry
             if (registry->GetValue(regKey, CONFIG_CONFIGURATION, REG_BINARY, &blob, sizeof(blob)))
             { // Configuration as stored in binary form in registry
                 ::Configuration.ConfirmSelection = blob.ConfirmSelection;
@@ -226,7 +227,7 @@ void CPluginInterface::LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRe
                 ::Configuration.DetailedDifferences = blob.DetailedDifferences;
             }
 
-            // nacteme barvy
+            // load the colors
             registry->GetValue(regKey, CONFIG_COLORS, REG_BINARY, Colors, sizeof(SALCOLOR) * NUMBER_OF_COLORS);
             registry->GetValue(regKey, CONFIG_CUSTOMCOLORS, REG_BINARY, CustomColors, 16 * sizeof(COLORREF));
             // default compare options
@@ -281,7 +282,7 @@ void CPluginInterface::LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRe
                 if (registry->GetValue(regKey, CONFIG_NORMALIZATION_FORM, REG_DWORD, &dw, sizeof(DWORD)))
                     DefCompareOptions.NormalizationForm = dw ? TRUE : FALSE;
             }
-            // historie pouzitych souboru
+            // history of used files
             TCHAR buf[32];
             for (; CBHistoryEntries < MAX_HISTORY_ENTRIES; CBHistoryEntries++)
             {
@@ -295,7 +296,7 @@ void CPluginInterface::LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRe
                 // and thus the toolbar could be partially covered by Differences
                 registry->GetValue(regKey, CONFIG_REBARBANDSLAYOUT, REG_BINARY, BandsParams, sizeof(CBandParams) * 2);
             }
-            // posledni navstivena stranka v konfiguraci
+            // the last visited page in the configuration
             registry->GetValue(regKey, CONFIG_LASTCFGPAGE, REG_DWORD, &LastCfgPage, sizeof(DWORD));
             // load on start flag
             DWORD dw;
@@ -325,11 +326,11 @@ void CPluginInterface::SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRe
 {
     CALL_STACK_MESSAGE1("CPluginInterface::SaveConfiguration(, , )");
 
-    // verze
+    // version
     DWORD dw = CURRENT_CONFIG_VERSION;
     registry->SetValue(regKey, CONFIG_VERSION, REG_DWORD, &dw, sizeof(DWORD));
 
-    // konfigurace
+    // configuration
     CRegBLOBConfiguration blob;
     // Configuration is stored in binary form in registry
     blob.ConfirmSelection = ::Configuration.ConfirmSelection;
@@ -343,7 +344,7 @@ void CPluginInterface::SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRe
     blob.DetailedDifferences = ::Configuration.DetailedDifferences;
     registry->SetValue(regKey, CONFIG_CONFIGURATION, REG_BINARY, &blob, sizeof(blob));
 
-    // barvy
+    // colors
     registry->SetValue(regKey, CONFIG_COLORS, REG_BINARY, Colors, sizeof(SALCOLOR) * NUMBER_OF_COLORS);
     registry->SetValue(regKey, CONFIG_CUSTOMCOLORS, REG_BINARY, CustomColors, 16 * sizeof(COLORREF));
     // default compare options
@@ -365,7 +366,7 @@ void CPluginInterface::SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRe
     registry->SetValue(regKey, CONFIG_INPUTENCTABLE1, REG_SZ, DefCompareOptions.ASCII8InputEncTableName[1], int(strlen(DefCompareOptions.ASCII8InputEncTableName[1])));
     dw = DefCompareOptions.NormalizationForm;
     registry->SetValue(regKey, CONFIG_NORMALIZATION_FORM, REG_DWORD, &dw, sizeof(DWORD));
-    // historie pouzitych souboru
+    // history of used files
     BOOL b;
     if (SG->GetConfigParameter(SALCFG_SAVEHISTORY, &b, sizeof(BOOL), NULL) && b)
     {
@@ -379,7 +380,7 @@ void CPluginInterface::SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRe
     }
     else
     {
-        //podrizneme historii
+        // trim the history
         char buf[32];
         int i;
         for (i = 0; i < MAX_HISTORY_ENTRIES; i++)
@@ -390,7 +391,7 @@ void CPluginInterface::SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRe
     }
     // layout rebary
     registry->SetValue(regKey, CONFIG_REBARBANDSLAYOUT, REG_BINARY, BandsParams, sizeof(CBandParams) * 2);
-    // posledni navstivena stranka v konfiguraci
+    // the last visited page in the configuration
     registry->SetValue(regKey, CONFIG_LASTCFGPAGE, REG_DWORD, &LastCfgPage, sizeof(DWORD));
     dw = LoadOnStart;
     registry->SetValue(regKey, CONFIG_LOADONSTART, REG_DWORD, &dw, sizeof(DWORD));
@@ -416,8 +417,8 @@ void CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* salamand
 {
     CALL_STACK_MESSAGE1("CPluginInterface::Connect(,)");
 
-    /* slouzi pro skript export_mnu.py, ktery generuje salmenu.mnu pro Translator
-   udrzovat synchronizovane s volani salamander->AddMenuItem() dole...
+    /* used by the export_mnu.py script that generates salmenu.mnu for Translator
+   keep it synchronized with the calls to salamander->AddMenuItem() below...
 MENU_TEMPLATE_ITEM PluginMenu[] = 
 {
   {MNTT_PB, 0
@@ -427,7 +428,7 @@ MENU_TEMPLATE_ITEM PluginMenu[] =
 */
     salamander->AddMenuItem(-1, LoadStr(IDS_COMPAREFILES), SALHOTKEY('C', HOTKEYF_CONTROL | HOTKEYF_SHIFT), MID_COMPAREFILES, FALSE,
                             MENU_EVENT_DISK, 0, MENU_SKILLLEVEL_ALL);
-    // nastavime ikonku pluginu
+    // set the plugin icon
     HBITMAP hBmp = (HBITMAP)LoadImage(DLLInstance, MAKEINTRESOURCE(IDB_FILECOMP),
                                       IMAGE_BITMAP, 16, 16, LR_DEFAULTCOLOR);
     salamander->SetBitmapWithIcons(hBmp);
@@ -443,14 +444,14 @@ CPluginInterface::GetInterfaceForMenuExt()
     return &InterfaceForMenu;
 }
 
-void CPluginInterface::Event(int event, DWORD param) // FIXME_X64 - staci zde jen 32b DWORD?
+void CPluginInterface::Event(int event, DWORD param) // FIXME_X64 - is a 32-bit DWORD sufficient here?
 {
     CALL_STACK_MESSAGE2("CPluginInterface::Event(, 0x%X)", param);
     switch (event)
     {
     case PLUGINEVENT_COLORSCHANGED:
     {
-        // mohla se zmenit barva textu
+        // the text color might have changed
         MainWindowQueue.BroadcastMessage(WM_USER_CFGCHNG, CC_COLORS, 0);
         break;
     }
@@ -459,7 +460,7 @@ void CPluginInterface::Event(int event, DWORD param) // FIXME_X64 - staci zde je
     {
         // Cache the value for use in Config dialog
         SG->GetConfigParameter(SALCFG_VIEWERFONT, &::Configuration.InternalViewerFont, sizeof(LOGFONT), NULL);
-        // mohl se zmenit font vieweru
+        // the viewer font might have changed
         if (::Configuration.UseViewerFont)
         {
             ::Configuration.FileViewLogFont = ::Configuration.InternalViewerFont;
@@ -509,26 +510,26 @@ BOOL CPluginInterfaceForMenu::ExecuteMenuItem(CSalamanderForOperationsAbstract* 
         fd1 = SG->GetPanelSelectedItem(PANEL_SOURCE, &index, &isDir);
 
         if (fd1 && isDir)
-            goto SELECTION_FINISHED; // adresare neberem
+            goto SELECTION_FINISHED; // skip directories
 
         if (fd1)
         {
-            // mame prvni soubor ze selektu zkusime najit druhy ze source panelu
+            // we have the first file from the selection; try to find the second in the source panel
             fd2 = SG->GetPanelSelectedItem(PANEL_SOURCE, &index, &isDir);
 
             if (fd2 && isDir)
-                goto SELECTION_FINISHED; // adresare neberem
+                goto SELECTION_FINISHED; // skip directories
 
             if (!fd2)
             {
-                // jeden je selektly a druhy berem z fokusu nebo ze
-                // selection v target panelu
+                // one is selected and we take the second from the focus or from
+                // the selection in the target panel
                 index = 0;
                 fd2 = SG->GetPanelSelectedItem(PANEL_TARGET, &index, &isDir);
                 if (!tgtPanelIsDisk || !fd2 || SG->GetPanelSelectedItem(PANEL_TARGET, &index, &isDir))
                 {
-                    // v target panelu je 0 nebo vice nez 1 selektlych souboru
-                    // berem fokus v source panelu
+                    // the target panel has 0 or more than 1 selected files
+                    // take the focused file in the source panel
                     fd2 = SG->GetPanelFocusedItem(PANEL_SOURCE, &isDir);
                 }
                 else
@@ -536,33 +537,33 @@ BOOL CPluginInterfaceForMenu::ExecuteMenuItem(CSalamanderForOperationsAbstract* 
             }
             else
             {
-                // mame dva selektle soubory jeste se podivame, zda neni vybrany treti
-                // tri vybrane soubory neberem
+                // we have two selected files; also check whether a third is selected
+                // do not accept three selected files
                 if (SG->GetPanelSelectedItem(PANEL_SOURCE, &index, &isDir))
                     goto SELECTION_FINISHED;
             }
         }
         else
         {
-            // zadny vybrany soubor, berem tedy fokus
+            // no file selected, so take the focused one
             fd1 = SG->GetPanelFocusedItem(PANEL_SOURCE, &isDir);
 
             if (fd1 && isDir)
-                goto SELECTION_FINISHED; // adresare neberem
+                goto SELECTION_FINISHED; // skip directories
         }
 
         if (fd1 == NULL)
-            goto SELECTION_FINISHED; // prazdny panel
+            goto SELECTION_FINISHED; // empty panel
 
-        // ulozime si jmeno prvniho souboru
+        // store the name of the first file
         if (!SG->GetPanelPath(PANEL_SOURCE, file1, MAX_PATH, NULL, NULL))
             return NULL;
         SG->SalPathAppend(file1, fd1->Name, MAX_PATH);
 
         if (fd2 &&
-            !isDir && fd2 != fd1) // pro pripad, ze berem soubor z fokusu
+            !isDir && fd2 != fd1) // in case we take the file from the focus
         {
-            // ulozime jmeno druheho souboru
+            // store the name of the second file
             SG->GetPanelPath(PANEL_SOURCE, file2, MAX_PATH, NULL, NULL);
             SG->SalPathAppend(file2, fd2->Name, MAX_PATH);
             secondFromSource = TRUE;
@@ -571,13 +572,13 @@ BOOL CPluginInterfaceForMenu::ExecuteMenuItem(CSalamanderForOperationsAbstract* 
         {
             if (tgtPanelIsDisk)
             {
-                // jeste musime vybrat druhy soubor s target panelu
+                // still need to choose the second file from the target panel
                 index = 0;
                 fd2 = SG->GetPanelSelectedItem(PANEL_TARGET, &index, &isDir);
 
                 if (!fd2 || isDir || SG->GetPanelSelectedItem(PANEL_TARGET, &index, &isDir))
                 {
-                    // najdeme soubor se stejnym jmenem jako prvni
+                    // find the file with the same name as the first one
                     index = 0;
                     while ((fd2 = SG->GetPanelItem(PANEL_TARGET, &index, &isDir)) != 0)
                     {
@@ -588,7 +589,7 @@ BOOL CPluginInterfaceForMenu::ExecuteMenuItem(CSalamanderForOperationsAbstract* 
 
                 if (fd2)
                 {
-                    // ulozime jmeno druheho souboru
+                    // store the name of the second file
                     if (!SG->GetPanelPath(PANEL_TARGET, file2, MAX_PATH, NULL, NULL))
                         return NULL;
                     SG->SalPathAppend(file2, fd2->Name, MAX_PATH);
@@ -605,9 +606,9 @@ BOOL CPluginInterfaceForMenu::ExecuteMenuItem(CSalamanderForOperationsAbstract* 
             return Error((HWND)-1, IDS_LOWMEM);
         if (!d->Create(ThreadQueue))
             delete d;
-        SG->SetUserWorkedOnPanelPath(PANEL_SOURCE); // tento prikaz povazujeme za praci s cestou (objevi se v Alt+F12)
+        SG->SetUserWorkedOnPanelPath(PANEL_SOURCE); // treat this command as working with the path (shows up in Alt+F12)
         if (!secondFromSource && file2[0])
-            SG->SetUserWorkedOnPanelPath(PANEL_TARGET); // pridame jeste target
+            SG->SetUserWorkedOnPanelPath(PANEL_TARGET); // add the target as well
 
         return FALSE;
     }
@@ -688,22 +689,22 @@ CFilecompThread::Body()
         }
 
         if (!dialogBox || !succes)
-            break; // ukoncime message loopu
+            break; // end the message loop
 
     LLAUNCHFC:
 
         WINDOWPLACEMENT wp;
         wp.length = sizeof(wp);
         GetWindowPlacement(SG->GetMainWindowHWND(), &wp);
-        // GetWindowPlacement cti Taskbar, takze pokud je Taskbar nahore nebo vlevo,
-        // jsou hodnoty posunute o jeho rozmery. Provedeme korekci.
+        // GetWindowPlacement reads the taskbar, so if the taskbar is at the top or on the left,
+        // the values are offset by its size. Apply a correction.
         RECT monitorRect;
         RECT workRect;
         SG->MultiMonGetClipRectByRect(&wp.rcNormalPosition, &workRect, &monitorRect);
         OffsetRect(&wp.rcNormalPosition, workRect.left - monitorRect.left,
                    workRect.top - monitorRect.top);
 
-        // pokud je hlavni okno je minimalizovane, nechceme minimalizovany File Comparator
+        // if the main window is minimized, we do not want the File Comparator minimized
         CMainWindow* win = new CMainWindow(Path1, Path2, &options,
                                            wp.showCmd == SW_SHOWMAXIMIZED ? SW_SHOWMAXIMIZED : SW_SHOW);
         if (!win)
@@ -733,7 +734,7 @@ CFilecompThread::Body()
 LBODYFINAL:
     if (*ReleaseEvent)
     {
-        // pustime dal filecomp.exe
+        // continue running filecomp.exe
         HANDLE event = OpenEvent(EVENT_MODIFY_STATE, FALSE, ReleaseEvent);
         SetEvent(event);
         CloseHandle(event);

--- a/src/plugins/filecomp/filecomp.h
+++ b/src/plugins/filecomp/filecomp.h
@@ -3,14 +3,14 @@
 
 #pragma once
 
-// definice IDs do menu
+// menu ID definitions
 #define MID_COMPAREFILES 1
 
 #define CURRENT_CONFIG_VERSION_PRESEPARATEOPTIONS 6
 #define CURRENT_CONFIG_VERSION_NORECOMPAREBUTTON 7
 #define CURRENT_CONFIG_VERSION 8
 
-// objekt interfacu pluginu, jeho metody se volaji ze Salamandera
+// plugin interface object, its methods are called from Salamander
 class CPluginInterface;
 extern CPluginInterface PluginInterface;
 extern BOOL AlwaysOnTop;
@@ -19,7 +19,7 @@ extern BOOL LoadOnStart;
 
 // ****************************************************************************
 //
-// Interface pluginu
+// plugin interface
 //
 
 class CPluginInterface : public CPluginInterfaceAbstract
@@ -51,18 +51,17 @@ public:
 class CPluginInterfaceForMenu : public CPluginInterfaceForMenuExtAbstract
 {
 public:
-    // vraci stav polozky menu s identifikacnim cislem 'id'; navratova hodnota je kombinaci
-    // flagu (viz MENU_ITEM_STATE_XXX); 'eventMask' viz CSalamanderConnectAbstract::AddMenuItem
+    // returns the state of the menu item with identifier 'id'; the return value is a combination
+    // of flags (see MENU_ITEM_STATE_XXX); 'eventMask' see CSalamanderConnectAbstract::AddMenuItem
     virtual DWORD WINAPI GetMenuItemState(int id, DWORD eventMask) { return 0; }
 
-    // spousti prikaz menu s identifikacnim cislem 'id', 'eventMask' viz
-    // CSalamanderConnectAbstract::AddMenuItem, 'salamander' je sada pouzitelnych metod
-    // Salamandera pro provadeni operaci, 'parent' je parent messageboxu, vraci TRUE pokud
-    // ma byt v panelu zruseno oznaceni (nebyl pouzit Cancel, mohl byt pouzit Skip), jinak
-    // vraci FALSE (neprovede se odznaceni);
-    // POZOR: Pokud prikaz zpusobi zmeny na nejake ceste (diskove/FS), mel by pouzit
-    //        CSalamanderGeneralAbstract::PostChangeOnPathNotification pro informovani
-    //        panelu bez automatickeho refreshe a otevrene FS (aktivni i odpojene)
+    // runs the menu command identified by 'id'; see CSalamanderConnectAbstract::AddMenuItem for 'eventMask'.
+    // 'salamander' is the set of usable Salamander methods for performing operations, 'parent' is the
+    // parent of the message box. Returns TRUE if the panel selection should be cleared (Cancel was not
+    // used, Skip might have been), otherwise returns FALSE (do not clear the selection);
+    // NOTE: If the command makes changes on any path (disk/FS), it should call
+    //       CSalamanderGeneralAbstract::PostChangeOnPathNotification to notify panels without automatic refresh
+    //       and open FS (both active and detached)
     virtual BOOL WINAPI ExecuteMenuItem(CSalamanderForOperationsAbstract* salamander, HWND parent,
                                         int id, DWORD eventMask);
     virtual BOOL WINAPI HelpForMenuItem(HWND parent, int id);
@@ -94,5 +93,5 @@ public:
     virtual unsigned Body();
 };
 
-extern CWindowQueue MainWindowQueue; // seznam vsech oken filecompu
-extern CThreadQueue ThreadQueue;     // seznam vsech oken+workeru filecompu + remote control
+extern CWindowQueue MainWindowQueue; // list of all filecomp windows
+extern CThreadQueue ThreadQueue;     // list of all filecomp windows and workers plus remote control

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -12,8 +12,8 @@ using namespace std;
 
 HCURSOR HWaitCursor;
 
-HPALETTE Palette = NULL; // paleta pro 256-ti barevny display
-BOOL UsePalette = FALSE; // TRUE pokud mame jen 256 barev
+HPALETTE Palette = NULL; // palette for a 256-color display
+BOOL UsePalette = FALSE; // TRUE if we only have 256 colors
 
 CBandParams BandsParams[2];
 
@@ -169,10 +169,10 @@ BOOL CMainWindow::Init()
         return FALSE;
     }
 
-    // nechceme vizualni styly pro rebar
+    // we do not want visual styles for the rebar
     if (SalGUI->DisableWindowVisualStyles(Rebar->HWindow))
     {
-        // vynutime si WS_BORDER, ktery se nekam "ztratil"
+        // force WS_BORDER, which somehow "disappeared"
         DWORD style = GetWindowLong(Rebar->HWindow, GWL_STYLE);
         style |= WS_BORDER;
         SetWindowLong(Rebar->HWindow, GWL_STYLE, style);
@@ -219,7 +219,7 @@ BOOL CMainWindow::Init()
 
     RebarHeight = LONG(SendMessage(Rebar->HWindow, RB_GETBARHEIGHT, 0, 0)) + 4 + REBAR_BORDER;
 
-    // vytvorime caption okna
+    // create the window caption
     LeftHeader = new CFileHeaderWindow("");
     if (!LeftHeader)
         return Error(HWND(NULL), IDS_LOWMEM);
@@ -254,7 +254,7 @@ BOOL CMainWindow::Init()
         return FALSE;
     }
 
-    // vytvorime file view okna
+    // create the file view windows
     LeftFileViewHWnd = CreateWindowEx(WS_EX_STATICEDGE,
                                       FILEVIEWWINDOW_CLASSNAME,
                                       "",
@@ -285,11 +285,11 @@ BOOL CMainWindow::Init()
         return FALSE;
     }
 
-    // disablujem scrollbary
+    // disable the scroll bars
     EnableScrollBar(LeftFileViewHWnd, SB_BOTH, ESB_DISABLE_BOTH);
     EnableScrollBar(RightFileViewHWnd, SB_BOTH, ESB_DISABLE_BOTH);
 
-    // vytvorime splitbaru
+    // create the split bar
     SplitBar = new CSplitBarWindow(Configuration.HorizontalView ? sbHorizontal : sbVertical);
     if (!SplitBar)
         return Error(HWND(NULL), IDS_LOWMEM);
@@ -313,10 +313,10 @@ BOOL CMainWindow::Init()
 
     Initialized = TRUE;
 
-    // zajistime spusteni workeru
+    // ensure the worker is started
     PostMessage(HWindow, WM_COMMAND, CM_RECOMPARE, 0);
 
-    // aktivujeme hlavni okno
+    // activate the main window
     PostMessage(HWindow, WM_USER_ACTIVATEWINDOW, 0, 0);
 
     return TRUE;
@@ -332,7 +332,7 @@ void CMainWindow::EnableInput(BOOL enable)
     UpdateToolbarButtons(UTB_ALL | (enable ? 0 : UTB_FORCEDISABLE));
     if (enable)
         SetFocus(LeftFileViewHWnd);
-    // disablovane okno nebude akceptovat drag&drop pozadavky
+    // a disabled window will not accept drag & drop requests
     DragAcceptFiles(HWindow, enable);
 }
 
@@ -508,7 +508,7 @@ void CMainWindow::SelectDifferenceByOffset(QWORD offset, BOOL center)
         {
             OutOfRange = FALSE;
             SelectDifference(mid, 0, TRUE, center);
-            return; // nasli jsme
+            return; // found it
         }
         if (Changes[mid].Offset < offset)
             l = mid + 1;
@@ -528,7 +528,7 @@ int CMainWindow::FindDifference(QWORD offset)
     int r = int(Changes.size()) - 1;
     int mid;
 
-    // vime ze tam je, hledame dokud nenajdem
+    // we know it is there; keep searching until we find it
     while (1)
     {
         mid = ((l + r) / 2);
@@ -696,7 +696,7 @@ BOOL CMainWindow::RebuildFileViewScripts(BOOL& cancel)
         if (SelectedDifference != -1)
             SelectDifference(SelectedDifference);
 
-        // zajistime prekresleni vsech oken
+        // ensure all windows are repainted
         InvalidateRect(LeftFileViewHWnd, NULL, FALSE);
         UpdateWindow(LeftFileViewHWnd);
         InvalidateRect(RightFileViewHWnd, NULL, FALSE);
@@ -708,8 +708,8 @@ BOOL CMainWindow::RebuildFileViewScripts(BOOL& cancel)
         return TRUE; // ok
     }
 
-    // nekde se stala chyba
-    FileView[fviLeft]->InvalidateData(); // zajistime prekresleni oken
+    // an error occurred somewhere
+    FileView[fviLeft]->InvalidateData(); // ensure the windows are repainted
     FileView[fviRight]->InvalidateData();
     LeftHeader->SetText("");
     RightHeader->SetText("");
@@ -780,7 +780,7 @@ void CMainWindow::ResetComboBox(BOOL* cancel)
 
             if ((GetAsyncKeyState(VK_ESCAPE) & 0x8001) && GetForegroundWindow() == HWindow)
             {
-                MSG msg; // vyhodime nabufferovany ESC
+                MSG msg; // discard the queued ESC
                 while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                     ;
                 if (cancel)
@@ -797,9 +797,9 @@ void CMainWindow::ResetComboBox(BOOL* cancel)
 void CMainWindow::SaveRebarLayout()
 {
     CALL_STACK_MESSAGE1("CMainWindow::SaveRebarLayout()");
-    // ulozime informace o bandu s toolbarou
+    // store information about the toolbar band
     Rebar->GetBandParams(IDC_TOOLBAR, BandsParams + BI_TOOLBAR);
-    // ulozime informace o bandu s combacem
+    // store information about the combo box band
     Rebar->GetBandParams(IDC_DIFFLIST, BandsParams + BI_DIFFLIST);
 }
 
@@ -808,8 +808,8 @@ void CMainWindow::RestoreRebarLayout()
     CALL_STACK_MESSAGE1("CMainWindow::RestoreRebarLayout()");
     if (BandsParams[0].Width == -1)
     {
-        // rozmery nejsou ulozene v konfiguraci
-        // nastavime defaultni layout a rozmery napocitame
+        // dimensions are not stored in the configuration
+        // set the default layout and compute the dimensions
         SIZE size;
         RECT r, r2;
         LRESULT index = SendMessage(Rebar->HWindow, RB_IDTOINDEX, IDC_TOOLBAR, 0);
@@ -817,7 +817,7 @@ void CMainWindow::RestoreRebarLayout()
         SendMessage(Rebar->HWindow, RB_GETBANDBORDERS, (WPARAM)index, (LPARAM)&r);
         GetClientRect(HWindow, &r2);
         r2.right -= r2.left;
-        // Petr: upraveno, aby pri default konfiguraci zabiral Differences band co nejvetsi casy rebaru (az na toolbaru a jeji spacer)
+        // Petr: adjusted so that with the default configuration the Differences band occupies as much rebar time as possible (except for the toolbar and its spacer)
         BandsParams[BI_TOOLBAR].Width = size.cx + r.left + 50 /* spacer */;
         BandsParams[BI_TOOLBAR].Style = 0;
         BandsParams[BI_TOOLBAR].Index = 0;
@@ -833,9 +833,9 @@ void CMainWindow::RestoreRebarLayout()
         BandsParams[BI_DIFFLIST].Style = 0;
         BandsParams[BI_DIFFLIST].Index = 1;
     }
-    // band s toolbarou
+    // band with the toolbar
     Rebar->SetBandParams(IDC_TOOLBAR, BandsParams + BI_TOOLBAR);
-    // band s combacem
+    // band with the combo box
     Rebar->SetBandParams(IDC_DIFFLIST, BandsParams + BI_DIFFLIST);
 }
 
@@ -846,7 +846,7 @@ void CMainWindow::SpawnWorker(const char* path1, const char* path2,
 
     Recompare = recompare;
 
-    // v pripade, ze jeste bezi worker, ukoncime ho
+    // if a worker is still running, stop it
     CancelWorker = CW_SILENT;
     TRACE_I("SpawnWorker: waiting 'til worker finished");
     while (1)
@@ -880,7 +880,7 @@ void CMainWindow::SpawnWorker(const char* path1, const char* path2,
         if (!worker->Create(ThreadQueue))
         {
             delete worker;
-            SetEvent(WorkerEvent); // aby jsme na nej marne necekali
+            SetEvent(WorkerEvent); // so we do not wait for it in vain
             TRACE_I("Nepovedlo se spustit diff worker thread.");
         }
         else
@@ -904,7 +904,7 @@ void CMainWindow::SetWait(BOOL wait)
         POINT pt;
         GetCursorPos(&pt);
 
-        // zajistime spravne prekresli kursoru
+        // ensure the cursor is redrawn correctly
         if (Wait)
             SetCursor(HWaitCursor);
         else
@@ -917,7 +917,7 @@ bool CMainWindow::TextFilesDiffer(CTextCompareResults<CChar>* res, char* message
 {
     DataValid = FALSE;
 
-    // ulozime vysledky
+    // store the results
     LinesToChanges.clear();
     ChangesToLines[0].clear();
     ChangesToLines[1].clear();
@@ -925,7 +925,7 @@ bool CMainWindow::TextFilesDiffer(CTextCompareResults<CChar>* res, char* message
     res->ChangesLengths.swap(ChangesLengths);
     res->Changes.swap(TextChanges);
 
-    // zajistime spravny typ file view controlu
+    // ensure we use the correct type of file view control
     if (FileView[fviLeft])
     {
         FileView[fviLeft]->DetachWindow();
@@ -935,10 +935,10 @@ bool CMainWindow::TextFilesDiffer(CTextCompareResults<CChar>* res, char* message
     if (!FileView[fviLeft])
     {
         strcpy(message, LoadStr(IDS_LOWMEM));
-        return FALSE; // nebudeme deallokovat buffery predane v CTextCompareResults
+        return FALSE; // do not deallocate buffers passed in CTextCompareResults
     }
     FileView[fviLeft]->AttachToWindow(LeftFileViewHWnd);
-    // zajistime incializaci okna
+    // ensure the window is initialized
     SendMessage(LeftFileViewHWnd, WM_USER_CREATE, 0, 0);
 
     if (FileView[fviRight])
@@ -950,10 +950,10 @@ bool CMainWindow::TextFilesDiffer(CTextCompareResults<CChar>* res, char* message
     if (!FileView[fviRight])
     {
         strcpy(message, LoadStr(IDS_LOWMEM));
-        return FALSE; // nebudeme deallokovat buffery predane v CTextCompareResults
+        return FALSE; // do not deallocate buffers passed in CTextCompareResults
     }
     FileView[fviRight]->AttachToWindow(RightFileViewHWnd);
-    // zajistime incializaci okna
+    // ensure the window is initialized
     SendMessage(RightFileViewHWnd, WM_USER_CREATE, 0, 0);
 
     FileView[fviLeft]->SetSiblink(FileView[fviRight]);
@@ -962,8 +962,8 @@ bool CMainWindow::TextFilesDiffer(CTextCompareResults<CChar>* res, char* message
     TTextFileViewWindow<CChar>* leftFileView = (TTextFileViewWindow<CChar>*)FileView[fviLeft];
     TTextFileViewWindow<CChar>* rightFileView = (TTextFileViewWindow<CChar>*)FileView[fviRight];
 
-    // prebiram data, odted uz jsem zodpovedny za dealokaci dat
-    // predanych v CTextCompareResults
+    // taking over the data; from now on I am responsible for deallocating the data
+    // supplied in CTextCompareResults
     leftFileView->SetData(res->Files[0].Text, res->Files[0].Lines, res->Files[0].LineScript);
     rightFileView->SetData(res->Files[1].Text, res->Files[1].Lines, res->Files[1].LineScript);
 
@@ -1003,7 +1003,7 @@ bool CMainWindow::TextFilesDiffer(CTextCompareResults<CChar>* res, char* message
         DataValid = FALSE;
         LeftHeader->SetText("");
         RightHeader->SetText("");
-        leftFileView->InvalidateData(); // zajistime prekresleni oken
+        leftFileView->InvalidateData(); // ensure the windows are repainted
         rightFileView->InvalidateData();
     }
 
@@ -1041,13 +1041,13 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         RECT r1, r2, r3;
         GetClientRect(HWindow, &r1);
         GetClientRect(LeftHeader->HWindow, &r2);
-        // vykreslime mezeru mezi rebarou a headerem
+        // draw the gap between the rebar and the header
         r3.top = RebarHeight - REBAR_BORDER;
         r3.bottom = RebarHeight;
         r3.left = 0;
         r3.right = r1.right;
         FillRect(dc, &r3, (HBRUSH)(COLOR_BTNFACE + 1));
-        // vykreslime mezeru mezi headerem a textovym oknem
+        // draw the gap between the header and the text window
         r3.top = RebarHeight + r2.bottom + 2;
         r3.bottom = r3.top + 2;
         FillRect(dc, &r3, (HBRUSH)(COLOR_BTNFACE + 1));
@@ -1076,7 +1076,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_TIMER:
     {
-        if (wParam == 666) // mame si poslat CM_EXIT, blokujici dialog uz je snad sestreleny
+        if (wParam == 666) // we should send CM_EXIT; the blocking dialog should already be closed
         {
             KillTimer(HWindow, 666);
             PostMessage(HWindow, WM_COMMAND, CM_EXIT, 0);
@@ -1132,10 +1132,10 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 return 0;
             }
         }
-            // jedeme dal ...
+            // keep going ...
         case CM_EXIT:
             if (!IsWindowEnabled(HWindow))
-            { // zavreme postupne vsechny dialogy nad timto dialogem (posleme jim WM_CLOSE, a pak sem posleme znovu CM_EXIT)
+            { // close all dialogs above this one (send them WM_CLOSE and then post CM_EXIT here again)
                 SG->CloseAllOwnedEnabledDialogs(HWindow);
                 SetTimer(HWindow, 666, 100, NULL);
                 return 0;
@@ -1167,12 +1167,12 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             UINT state = GetMenuState(GetMenu(HWindow), CM_PREVDIFF, MF_BYCOMMAND);
             if (state & (MF_DISABLED | MF_GRAYED))
             {
-                if (DifferencesCount > 0) // Petr: kdyz odroluju view kamsi pryc, chci na Alt+sipku focus difference (hledat ji rucne je oser), kdyz je jen jedna neslo to vubec, jinak to slo pres prepnuti dalsi/predchozi
+                if (DifferencesCount > 0) // Petr: when I scroll the view somewhere else, Alt+arrow should focus the difference (hunting for it manually is a pain). With only one difference it did not work at all; otherwise it worked via next/previous.
                     SelectDifference(SelectedDifference, CM_PREVDIFF);
                 return 0;
             }
         }
-            // jedeme dal
+            // keep going
 
         case CM_PREVDIFF:
             if (DataValid)
@@ -1198,16 +1198,16 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             UINT state = GetMenuState(GetMenu(HWindow), CM_NEXTDIFF, MF_BYCOMMAND);
             if (state & (MF_DISABLED | MF_GRAYED))
             {
-                if (DifferencesCount > 0) // Petr: kdyz odroluju view kamsi pryc, chci na Alt+sipku focus difference (hledat ji rucne je oser), kdyz je jen jedna neslo to vubec, jinak to slo pres prepnuti predchozi/dalsi
+                if (DifferencesCount > 0) // Petr: when I scroll the view somewhere else, Alt+arrow should focus the difference (hunting for it manually is a pain). With only one difference it did not work; otherwise it worked via previous/next.
                     SelectDifference(SelectedDifference, CM_NEXTDIFF);
                 return 0;
             }
         }
-            // jedeme dal
+            // keep going
 
         case CM_NEXTDIFF:
             if (DataValid)
-                SelectDifference(SelectedDifference + 1, CM_NEXTDIFF); // test na DifferencesCount ohlidame pozdeji
+                SelectDifference(SelectedDifference + 1, CM_NEXTDIFF); // we will check DifferencesCount later
             return 0;
 
         case CM_LASTDIFF:
@@ -1244,7 +1244,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 if (OptionsChanged)
                 {
-                    // zeptame, zda chce pouzit nove volby
+                    // ask whether to use the new options
                     int ret = SG->SalMessageBox(HWindow, LoadStr(IDS_OPTIONSCHANGED), LoadStr(IDS_PLUGINNAME),
                                                 MB_YESNOCANCEL | MB_ICONQUESTION | MB_DEFBUTTON2);
                     switch (ret)
@@ -1263,7 +1263,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     }
                 }
 
-                // pustime workera
+                // start the worker
                 SpawnWorker(Path1, Path2, TRUE, Options);
             }
             return 0;
@@ -1280,7 +1280,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 ::Configuration.ViewMode = ViewMode;
                 CheckMenuItem(GetMenu(HWindow), CM_ONLYDIFFERENCES, MF_BYCOMMAND | (ViewMode == fvmStandard ? MF_UNCHECKED : MF_CHECKED));
 
-                // postavime znova skripty
+                // rebuild the scripts
                 SetWait(TRUE);
                 BOOL cancel;
                 if (!RebuildFileViewScripts(cancel))
@@ -1309,7 +1309,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 ((CTextFileViewWindowBase*)FileView[fviRight])->SetShowWhiteSpace(ShowWhiteSpace);
             }
 
-            // prekreslime obrazovku
+            // repaint the screen
             InvalidateRect(LeftFileViewHWnd, NULL, FALSE);
             UpdateWindow(LeftFileViewHWnd);
             InvalidateRect(RightFileViewHWnd, NULL, FALSE);
@@ -1357,7 +1357,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 CheckMenuItem(GetMenu(HWindow), CM_DETAILDIFF, MF_BYCOMMAND | (DetailedDifferences ? MF_CHECKED : MF_UNCHECKED));
 
-                // prekreslime obrazovku
+                // repaint the screen
                 InvalidateRect(LeftFileViewHWnd, NULL, FALSE);
                 UpdateWindow(LeftFileViewHWnd);
                 InvalidateRect(RightFileViewHWnd, NULL, FALSE);
@@ -1446,7 +1446,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         case CM_HELP:
         {
             SG->OpenHtmlHelp(HWindow, HHCDisplayContext, IDH_INTRODUCTION, TRUE);
-            SG->OpenHtmlHelp(HWindow, HHCDisplayTOC, 0, FALSE); // nechceme dva messageboxy za sebou
+            SG->OpenHtmlHelp(HWindow, HHCDisplayTOC, 0, FALSE); // avoid two message boxes in a row
             return 0;
         }
 
@@ -1573,7 +1573,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     view = 1;
             }
 
-            // kolik souboru nam hodili
+            // how many files were dropped on us
             count = DragQueryFile(drop, 0xFFFFFFFF, NULL, 0);
             if (count < 1)
                 goto LDROPERROR;
@@ -1606,10 +1606,10 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         strcpy(path2, path1);
                         strcpy(path1, Path1);
                     }
-                    // operace je podobna recompare tak pouzijeme aktuali nastaveni,
-                    // pokud ovsem uzivatem mezitim nezmenil defaultni nastaveni v
-                    // konfiguraci, aby ho nematlo, ze neporovnava podle
-                    // nokonfigurovanych hodnot
+                    // the operation is similar to recompare, so reuse the current settings,
+                    // unless the user changed the default settings in
+                    // the configuration in the meantime, so they are not confused about
+                    // comparing with non-configured values
                     if (!OptionsChanged)
                         options = Options;
                 }
@@ -1620,7 +1620,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             BOOL succes = FALSE;
             if (count > 2 || *path2 == 0)
             {
-                // nechame potvrdit uzivatelem
+                // let the user confirm it
                 CCompareFilesDialog dlg(HWindow, path1, path2, succes, &options);
                 dlg.Execute();
             }
@@ -1640,7 +1640,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_HELP:
     {
         SG->OpenHtmlHelp(HWindow, HHCDisplayContext, IDH_INTRODUCTION, FALSE);
-        SG->OpenHtmlHelp(HWindow, HHCDisplayTOC, 0, TRUE); // nechceme dva messageboxy za sebou
+        SG->OpenHtmlHelp(HWindow, HHCDisplayTOC, 0, TRUE); // avoid two message boxes in a row
         return TRUE;
     }
 
@@ -1711,7 +1711,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_SYSCHAR:
     {
-        // aby nam system nepipal, kdyz se prepina na kombac
+        // keep the system from beeping when switching to the combo box
         if ((wParam == 'd' || wParam == 'D') && InputEnabled)
             return 0;
         break;
@@ -1742,8 +1742,8 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_SETTINGCHANGE:
     {
-        // mohli se zmenit rozmery scrollbar, zajistime, aby si kombac
-        // napocital nove rozmery tlacitka
+        // the scrollbar dimensions might have changed; ensure the combo box
+        // recomputes the button dimensions
         RECT r;
         GetWindowRect(ComboBox->HWindow, &r);
         SetWindowPos(ComboBox->HWindow, 0, 0, 0,
@@ -1888,7 +1888,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
             DataValid = FALSE;
 
-            // file view data musi byt zrusena drive
+            // the file view data must be destroyed earlier
             if (FileView[fviLeft])
                 FileView[fviLeft]->DestroyData();
             if (FileView[fviRight])
@@ -1901,7 +1901,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             TextChanges.clear();
             Changes.clear();
 
-            // zajistime spravny typ file view controlu
+            // ensure we use the correct type of file view control
             if (FileView[fviLeft] && !FileView[fviLeft]->Is(fvtHex))
             {
                 FileView[fviLeft]->DetachWindow();
@@ -1913,12 +1913,12 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 FileView[fviLeft] = new CHexFileViewWindow(fviLeft);
                 if (!FileView[fviLeft])
                 {
-                    ret = FALSE; // nebudeme deallokovat buffery predane v CDiffResults
+                    ret = FALSE; // do not deallocate buffers passed in CDiffResults
                     _tcscpy(message, LoadStr(IDS_LOWMEM));
                     break;
                 }
                 FileView[fviLeft]->AttachToWindow(LeftFileViewHWnd);
-                // zajistime incializaci okna
+                // ensure the window is initialized
                 SendMessage(LeftFileViewHWnd, WM_USER_CREATE, 0, 0);
             }
 
@@ -1933,12 +1933,12 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 FileView[fviRight] = new CHexFileViewWindow(fviRight);
                 if (!FileView[fviRight])
                 {
-                    ret = FALSE; // nebudeme deallokovat buffery predane v CDiffResults
+                    ret = FALSE; // do not deallocate buffers passed in CDiffResults
                     _tcscpy(message, LoadStr(IDS_LOWMEM));
                     break;
                 }
                 FileView[fviRight]->AttachToWindow(RightFileViewHWnd);
-                // zajistime incializaci okna
+                // ensure the window is initialized
                 SendMessage(RightFileViewHWnd, WM_USER_CREATE, 0, 0);
             }
 
@@ -1959,7 +1959,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 ResetComboBox();
 
-                // zajistime prekresleni vsech oken
+                // ensure all windows are repainted
                 InvalidateRect(LeftFileViewHWnd, NULL, FALSE);
                 UpdateWindow(LeftFileViewHWnd);
                 InvalidateRect(RightFileViewHWnd, NULL, FALSE);
@@ -1979,9 +1979,9 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 LeftHeader->SetText("");
                 RightHeader->SetText("");
-                FileView[fviLeft]->InvalidateData(); // zajistime prekresleni oken
+                FileView[fviLeft]->InvalidateData(); // ensure the windows are repainted
                 FileView[fviRight]->InvalidateData();
-                ret = FALSE; // nebudeme hledat difference
+                ret = FALSE; // do not look for differences
             }
 
             break;
@@ -1989,7 +1989,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         case WN_SETCHANGES:
         {
-            // tady to schvalne kopirujem, nevolame swap
+            // deliberately copy here; do not call swap
             Changes = *(CBinaryChanges*)lParam;
             if (Changes.size() < MaxBinChanges)
                 DifferencesCount = int(Changes.size());
@@ -2100,7 +2100,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (DataValid)
         {
             //        if (DifferencesCount || (WN_NO_DIFFERENCE == wParam))
-            //        { // je-li 0, nastavime caption pozdeji, az najdeme vsechny binarni difference
+            //        { // if it is 0, set the caption later after we find all binary differences
             TCHAR fmt[128];
             if (DifferencesCount)
             {
@@ -2182,7 +2182,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
                 else
                 {
-                    OptionsChanged = TRUE; // aby pri nasledujicim recompare, zeptal na naloadeni novych options
+                    OptionsChanged = TRUE; // prompt to load new options during the next recompare
                 }
             }
 
@@ -2190,7 +2190,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 if ((wParam & CC_CONTEXT) | (wParam & CC_TABSIZE))
                 {
-                    // postavime znova skripty
+                    // rebuild the scripts
                     if (FileView[fviLeft]->Is(fvtText))
                     {
                         SetWait(TRUE);
@@ -2230,11 +2230,11 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_ACTIVATEWINDOW:
     {
-        // pokud je okno disabled, pravdepodobne je nad nim zobrazen msgbox a vytazeni
-        // okna nahoru by zpusobilo jeho aktivaci (to byl problem v jedne starsi verzi SS,
-        // kdyz uzivatel nechal porovnat dva shodne soubory -- zobrazilo se toto okno,
-        // nasledne vyskocil msgbox s informaci o shode a nasledne se dorucila tato
-        // zprava, ktera msgboxu ukradla focus a ktivovala okno pod nim)
+        // if the window is disabled, a message box is probably shown above it; bringing the
+        // window to the top would activate it (this was a problem in an older version of SS
+        // when the user compared two identical files -- this window appeared, then a
+        // message box popped up with the match information, and afterwards this message
+        // arrived and stole the focus from the message box and activated the window below)
         if (IsWindowEnabled(HWindow))
         {
             ShowWindow(HWindow, ShowCmd /*SW_SHOW*/);
@@ -2252,15 +2252,15 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         DragAcceptFiles(HWindow, FALSE);
 
-        // zrusime pole drive nez okno, kdyz je pole velike, okno se zavre, ale thread zije dal
-        // (probiha v nem destrukce prvku pole), to vede k tomu, ze je thread zakillovan pri
-        // releasu pluginu drive nez sam zkonci
+        // release the arrays before the window; if the array is large, the window closes but the
+        // thread continues running (destroying the array elements). That leads to the thread being
+        // killed when the plugin is released before it finishes on its own.
         if (FileView[fviLeft])
             FileView[fviLeft]->DestroyData();
         if (FileView[fviRight])
             FileView[fviRight]->DestroyData();
 
-        // uvolnime velike struktury nyni, viz poznamka vyse
+        // release the large structures now, see note above
         LinesToChanges.clear();
         ChangesToLines[0].clear();
         ChangesToLines[1].clear();
@@ -2269,7 +2269,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         SaveRebarLayout();
 
-        // v pripade, ze jeste bezi worker, ukoncime ho
+        // if a worker is still running, stop it
         CancelWorker = CW_SILENT;
         TRACE_I("Waiting 'til worker finished");
         while (1)

--- a/src/plugins/filecomp/mainwnd.h
+++ b/src/plugins/filecomp/mainwnd.h
@@ -8,8 +8,8 @@
 // CMainWindow
 //
 
-#define BI_TOOLBAR 0  // band s toollbarou
-#define BI_DIFFLIST 1 // band s combacem
+#define BI_TOOLBAR 0  // band with the toolbar
+#define BI_DIFFLIST 1 // band with the combo box
 
 #define IDC_REBAR 100
 #define IDC_TOOLBAR 101
@@ -17,7 +17,7 @@
 #define IDC_LEFTFILEVIEW 103
 #define IDC_RIGHTFILEVIEW 104
 
-// indexy bitmap pro toolbaru
+// bitmap indices for the toolbar
 #define BI_COPY 0
 #define BI_SELECTALL 1
 #define BI_FIRSTDIFF 2
@@ -25,19 +25,19 @@
 #define BI_NEXTDIFF 4
 #define BI_LASTDIFF 5
 
-#define REBAR_BORDER 2 // vyska mezery pod rebarou
+#define REBAR_BORDER 2 // height of the gap beneath the rebar
 
-// flagy pro CMainWindow::UpdateToolbarButtons()
+// flags for CMainWindow::UpdateToolbarButtons()
 #define UTB_DIFFSSELECTION 0x01
 #define UTB_TEXTSELECTION 0x02
 #define UTB_MENU 0x04
 #define UTB_FORCEDISABLE 0x08
 #define UTB_ALL (UTB_DIFFSSELECTION | UTB_TEXTSELECTION | UTB_MENU)
 
-#define CW_CONTINUE 0 // jedeme dal
-#define CW_CANCEL 1   // storno operace
-#define CW_EXIT 2     // storno a exit file comparatoru
-#define CW_SILENT 3   // ukonceni threadu bez message boxu pro usera
+#define CW_CONTINUE 0 // keep going
+#define CW_CANCEL 1   // cancel the operation
+#define CW_EXIT 2     // cancel and exit the file comparator
+#define CW_SILENT 3   // terminate the thread without a message box for the user
 
 extern HCURSOR HWaitCursor;
 
@@ -62,7 +62,7 @@ protected:
     int Active;
     CSplitBarWindow* SplitBar;
     CRebar* Rebar;
-    LONG RebarHeight; // vyska rebary + vyska mezery pod rebarou
+    LONG RebarHeight; // height of the rebar plus the gap below it
     CComboBox* ComboBox;
     HWND HToolbar;
     CIntIndexes LinesToChanges;
@@ -77,7 +77,7 @@ protected:
     int SelectedDifference;
     BOOL DataValid;
     BOOL InputEnabled;
-    int CancelWorker; // viz. konstanty CW_xxx
+    int CancelWorker; // see the CW_xxx constants
     BOOL FirstCompare;
     CCompareOptions Options;
     //int DifferencesCount;
@@ -92,7 +92,7 @@ protected:
     BOOL Recompare;
     BOOL bOptionsChangedBeingHandled; // Simple semaphore
 
-    // pro binarni compare
+    // for binary compare
     CBinaryChanges Changes;
     BOOL OutOfRange;
     UINT ShowCmd;

--- a/src/plugins/filecomp/mtxtout.cpp
+++ b/src/plugins/filecomp/mtxtout.cpp
@@ -20,7 +20,7 @@ public:
 
     LOGFONT lf;
     int FontWidth, FontHeight;
-    bool SubstCharIsSpace; // TRUE = jako substitucni znak se pouziva mezera a ne 0xB7 /* middle dot */
+    bool SubstCharIsSpace; // TRUE = use a space as the substitution character instead of 0xB7 /* middle dot */
 };
 
 // Returns true if some mapping ever can take place
@@ -38,8 +38,8 @@ bool FontHasChangedX(CChar* ViewerFontMapping, HDC memDC, int fontWidth, int fon
     for (x = start; x < end; x++)
     {
         CChar result = x;
-        // DrawTextEx by patrne selhal na jednom surrogate (bez dvojky do paru)
-        // nebo neplatnem UTF-16 znaku
+        // DrawTextEx probably failed on a single surrogate (missing the paired second code unit)
+        // or on an invalid UTF-16 character
         if (TCharSpecific<CChar>::IsValidChar(x))
         {
             ch[0] = x;
@@ -53,7 +53,7 @@ bool FontHasChangedX(CChar* ViewerFontMapping, HDC memDC, int fontWidth, int fon
             {
                 if (rect.right - rect.left != fontWidth)
                 {
-                    if (x == 0xB7 /* middle dot */) // pokud je 'middle-dot' take spatne siroky, substituujeme za mezeru, ktera snad musi byt OK
+                    if (x == 0xB7 /* middle dot */) // if the middle dot is also the wrong width, substitute a space that should be safe
                     {
                         substChar = (CChar)' ';
                         int z;
@@ -68,7 +68,7 @@ bool FontHasChangedX(CChar* ViewerFontMapping, HDC memDC, int fontWidth, int fon
             else
                 TRACE_I("CFileViewWindow::ReloadConfiguration(): DrawTextEx: error for: " << x);
         }
-        ViewerFontMapping[x] = result; // zapisujeme az vysledek, protoze hrozi soubeh vice threadu (neni synchronizovano sekci)
+        ViewerFontMapping[x] = result; // write the result only after the check because multiple threads might race (not synchronized by a critical section)
     }
     *substCharIsSpace = substChar == (CChar)' ';
     return ret;
@@ -78,10 +78,10 @@ template <class CChar>
 void TMappedTextOut<CChar>::FontHasChanged(LOGFONT* plf, HFONT font, int fontWidth, int fontHeight)
 {
     //  if (!ViewerFontMapping) return;
-    // XP64/Vista: font fixedsys obsahuje znaky, ktere nemaji ocekavanou sirku (i kdyz je to fixed-width font), proto
-    // omerujeme jednotlive znaky a ty ktere nemaji spravnou sirku mapujeme na nahradni znak o spravne sirce
+    // XP64/Vista: the Fixedsys font contains characters that do not have the expected width (even though it is a fixed-width font), so
+    // we measure individual characters and map those with the wrong width to a replacement character with the correct width
     ViewerFontNeedsMapping = false;
-    if (WindowsXP64AndLater) // krome XP64 a Visty jsme na tuhle prasecinku nenarazili, takze to nebudeme ani testovat
+    if (WindowsXP64AndLater) // apart from XP64 and Vista we have not encountered this ugly quirk, so we will not even test it
     {
         LPVOID pNewFont;
 
@@ -228,7 +228,7 @@ LPVOID CMappedFontFactory::FindFont(LOGFONT* plf, HFONT font, LPVOID* ViewerFont
                 {
                     memset(pMap, 0xFE, sizeof(wchar_t) * TCharSpecific<wchar_t>::CharCount());
                     FontHasChangedX((wchar_t*)pMap, memDC, fontWidth, fontHeight, 0, 256, &substCharIsSpace);
-                    bNeedMapping = true; // neoverujeme vsechny znaky, tedy nelze tvrdit, ze mapovani nebude potreba
+                    bNeedMapping = true; // we do not verify every character, so we cannot claim mapping will not be needed
                 }
             }
             if (bNeedMapping)

--- a/src/plugins/filecomp/mtxtout.h
+++ b/src/plugins/filecomp/mtxtout.h
@@ -54,7 +54,7 @@ public:
 
     void FontHasChanged(LOGFONT* plf, HFONT font, int fontWidth, int fontHeight);
 
-    // nahrazuje ExtTextOut: pod Vistou provadi premapovani na "spravne siroke" znaky (viz ViewerFontNeedsMapping)
+    // replaces ExtTextOut: on Vista remaps to "properly wide" characters (see ViewerFontNeedsMapping)
     BOOL DoTextOut(HDC hdc, int X, int Y, UINT fuOptions, CONST RECT* lprc,
                    const CChar* lpString, UINT cbCount, CONST INT* lpDx)
     {
@@ -86,18 +86,18 @@ public:
             return ExtTextOutX(hdc, X, Y, fuOptions, lprc, lpString, cbCount, lpDx);
     }
 
-    // true = (jen XP64/Vista) je potreba mapovat znaky pred vykreslenim (nektera pismena jsou "spatne" siroka)
+    // true = (only XP64/Vista) it is necessary to map characters before drawing (some letters are "wrongly" wide)
     bool NeedMapping() { return ViewerFontNeedsMapping; }
 
-    // premapuje, mozne volat jen pokud NeedMapping vraci true!!!
+    // remaps, may be called only if NeedMapping returns true!!!
     CChar MapChar(CChar c) { return ViewerFontMapping[TCharSpecific<CChar>::Unsigned(c)]; }
 
-    // mozne volat jen pokud NeedMapping vraci true!!!
+    // may be called only if NeedMapping returns true!!!
     void CalcMappingIfNeeded(HDC hDC, const CChar* buf, int len);
 
 private:
-    bool ViewerFontNeedsMapping; // TRUE = (jen XP64/Vista) je potreba mapovat znaky pred vykreslenim (nektera pismena jsou "spatne" siroka)
-    CChar* ViewerFontMapping;    // mapovani pro pripad, kdy je ViewerFontNeedsMapping==true
+    bool ViewerFontNeedsMapping; // TRUE = (only XP64/Vista) characters must be mapped before drawing (some letters are "wrongly" wide)
+    CChar* ViewerFontMapping;    // mapping used when ViewerFontNeedsMapping == true
     CChar* Buffer;
     size_t BufferSize;
     LPVOID pMappedFont;

--- a/src/plugins/filecomp/precomp.h
+++ b/src/plugins/filecomp/precomp.h
@@ -25,8 +25,8 @@
 #define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
 #endif
 
-// opatreni proti runtime check failure v debug verzi: puvodni verze makra pretypovava rgb na WORD,
-// takze hlasi ztratu dat (RED slozky)
+// workaround for runtime check failure in debug builds: the original macro cast rgb to WORD,
+// so it reports a data loss (RED component)
 #undef GetGValue
 #define GetGValue(rgb) ((BYTE)(((rgb) >> 8) & 0xFF))
 

--- a/src/plugins/filecomp/remote.cpp
+++ b/src/plugins/filecomp/remote.cpp
@@ -40,7 +40,7 @@ void CRemoteComparator::CreateRemoteComparator()
         TerminateEvent = NULL;
         return;
     }
-    // TODO nastavit mensi zasobnik
+    // TODO set a smaller stack
     RemoteComparatorThread = rc->Create(ThreadQueue);
     if (!RemoteComparatorThread)
     {
@@ -134,7 +134,7 @@ void CRemoteComparator::RecieveMessage(const CMessage* message)
 
     if (!ok && *msg->ReleaseEvent)
     {
-        // pustime dal filecomp.exe
+        // let filecomp.exe continue running
         HANDLE event = OpenEvent(EVENT_MODIFY_STATE, FALSE, msg->ReleaseEvent);
         SetEvent(event);
         CloseHandle(event);

--- a/src/plugins/filecomp/remote.h
+++ b/src/plugins/filecomp/remote.h
@@ -19,7 +19,7 @@ public:
 protected:
     CMessageCenter MessageCenter;
     static BOOL Created;
-    static HANDLE RemoteComparatorThread; // POZOR: handle threadu jen pro pouziti v ThreadQueue
+    static HANDLE RemoteComparatorThread; // NOTE: thread handle to be used only in ThreadQueue
     static HANDLE TerminateEvent;
     virtual unsigned Body();
     virtual void RecieveMessage(const CMessage* message);

--- a/src/plugins/filecomp/textio.cpp
+++ b/src/plugins/filecomp/textio.cpp
@@ -567,10 +567,10 @@ void CTextFileReader::Get(char*& buffer, size_t& size, const int& cancel)
 
     size = ConvertEols(Buffer, size_t(Size));
     // add virtual line at the end of the file
-    Buffer[size++] = '\n'; // text vzdy konci na '\n'
+    Buffer[size++] = '\n'; // text always ends with '\n'
 
     buffer = Buffer;
-    Buffer = NULL; // uze je prirazeny volajicimu
+    Buffer = NULL; // already handed over to the caller
     BufferedCharacters = 0;
 }
 
@@ -587,7 +587,7 @@ void CTextFileReader::Get(wchar_t*& buffer, size_t& size, const int& cancel)
     buffer = NULL;
     try
     {
-        // TODO nezapominat skipnout BOM mark
+        // TODO remember to skip the BOM mark
         switch (Encoding)
         {
         case encASCII8:
@@ -610,7 +610,7 @@ void CTextFileReader::Get(wchar_t*& buffer, size_t& size, const int& cancel)
 
         size = ConvertEols(buffer, size);
         // add virtual line at the end of the file
-        buffer[size++] = '\n'; // text vzdy konci na '\n'
+        buffer[size++] = '\n'; // text always ends with '\n'
         if (NormalizationForm)
         {
             int len = PNormalizeString(NormalizationC, buffer, (int)size, NULL, 0);
@@ -773,7 +773,7 @@ void CTextFileReader::ReadUTF8(wchar_t*& buffer, size_t& size, const int& cancel
 {
     CByteReader input(Name, File, Size, Buffer, BufferSize, BufferedCharacters, cancel, MD5);
 
-    Buffer = NULL; // o uvolneni se stara input
+    Buffer = NULL; // input takes care of freeing it
     BufferedCharacters = 0;
 
     size_t allocated = Size; // worst case estimate (each UTF-8 byte codes one UCS-4 char)
@@ -945,7 +945,7 @@ void CTextFileReader::ReadUTF16(wchar_t*& buffer, size_t& size, const int& cance
     buffer = (wchar_t*)Buffer;
     size = Size / 2; // TODO warn if byte is missing
 
-    Buffer = NULL; // buffer byl predan volajicimu
+    Buffer = NULL; // buffer was passed to the caller
     BufferedCharacters = 0;
 
     // convert to little endian
@@ -960,7 +960,7 @@ void CTextFileReader::ReadUTF32(wchar_t*& buffer, size_t& size, const int& cance
 {
     CByteReader input(Name, File, Size, Buffer, BufferSize, BufferedCharacters, cancel, MD5);
 
-    Buffer = NULL; // o uvolneni se stara input
+    Buffer = NULL; // input takes care of freeing it
     BufferedCharacters = 0;
 
     // optimistic estimate (each UTF-32 byte codes one UTF-16 char, no surrogate

--- a/src/plugins/filecomp/textio.h
+++ b/src/plugins/filecomp/textio.h
@@ -19,7 +19,7 @@ public:
         ftText
     };
     // text encoding
-    // TODO pridat ruzne verze unicode formatu
+    // TODO add other Unicode format variants
     enum eEncoding
     {
         encUnknown,
@@ -46,7 +46,7 @@ public:
     CTextFileReader();
     ~CTextFileReader();
 
-    // 'size' nesmi byt vetsi nez numeric_limits<size_t>::max - 1
+    // 'size' must not be greater than numeric_limits<size_t>::max - 1
     void Set(const char* name, HANDLE file, size_t size, int eolConversions,
              eEncoding encoding, eEndian endians, int performASCII8InputEnc,
              const char* parASCII8InputEncTableName, BOOL normalizationForm, bool needMD5);
@@ -64,7 +64,7 @@ public:
     void ForceEncoding(eEncoding encoding, eEndian endian) { Encoding = encoding; }
     bool HasSurrogates()
     {
-        // TODO nekdy to treba budem podporovat, zatim umime jen BMP
+        // TODO maybe support this someday; for now we handle only BMP
         return false;
     }
 

--- a/src/plugins/filecomp/viewtext.cpp
+++ b/src/plugins/filecomp/viewtext.cpp
@@ -185,7 +185,7 @@ void TTextFileViewWindow<CChar>::SetData(CChar* text, CLineBuffer& lines, CLineS
     DestroyData();
     Text = text;
     Lines.swap(lines);
-    Script[0].swap(script); // TODO nemelo by se tohle presunout do parenta?
+    Script[0].swap(script); // TODO shouldn't this be moved to the parent?
     // resize POLYTEXT buffers
     int maxc = 0;
     for (CLineScript::iterator ls = Script[0].begin(); ls < Script[0].end(); ++ls)
@@ -288,7 +288,7 @@ BOOL TTextFileViewWindow<CChar>::CopySelection()
     int len = int((Lines[l2] + charEnd) - (Lines[l1] + charBegin));
     if (len)
     {
-        // nahradime LF za CRLF
+        // replace LF with CRLF
         const CChar* sour = Lines[l1] + charBegin;
         int s = 0, d = 0, i;
         int size = (int)(1.1 * len);
@@ -313,7 +313,7 @@ BOOL TTextFileViewWindow<CChar>::CopySelection()
             }
             memcpy(buffer + d, sour + s, i * sizeof(CChar));
             d += i;
-            s += i + 1; // preskocime LF
+                s += i + 1; // skip the LF
             if (s <= len)
             {
                 buffer[d++] = '\r';
@@ -458,7 +458,7 @@ template <class CChar>
 void TTextFileViewWindow<CChar>::NextCharBlock(int line, int& xpos)
 {
     int len = int(Lines[line + 1] - Lines[line]) - 1;
-    // presuneme se na konec slova/mezery/bloku jinych znaku
+    // move to the end of the word/space/block of other characters
     int cat = GetCharCat(Lines[line][xpos]);
 
     while (xpos < len && GetCharCat(Lines[line][xpos]) == cat)
@@ -514,7 +514,7 @@ void TTextFileViewWindow<CChar>::PolytextLengthFixup(typename std::vector<POLYTE
             begin->lpstr += offset;
             begin->n -= offset;
         }
-        // TODO na 4K displayich už 1024 nemusí stačit!!
+        // TODO on 4K displays 1024 might no longer be enough!!
         begin->n = min(begin->n, UINT(1024));
     }
 }
@@ -530,7 +530,7 @@ void TTextFileViewWindow<CChar>::Paint()
         oldPalette = SelectPalette(dc, Palette, FALSE);
     HFONT oldFont = (HFONT)SelectObject(dc, HFont);
 
-    // urcim interval radku, ktery je treba prekreslit
+    // determine the range of lines that needs to be repainted
     RECT clipRect;
     int clipRet = GetClipBox(dc, &clipRect);
     int clipFirstRow = 0;
@@ -543,15 +543,15 @@ void TTextFileViewWindow<CChar>::Paint()
 
     if (size_t(FirstVisibleLine + clipLastRow) >= Script[ViewMode].size())
     {
-        // skoncime posledni platnou radkou ve skriptu
+        // stop at the last valid line in the script
         clipLastRow = int(Script[ViewMode].size() - FirstVisibleLine);
     }
 
-    RECT r1; // cislo radky
+    RECT r1; // line-number area
     r1.left = 0;
     r1.right = LineNumWidth;
-    r1.bottom = 0; // abychom meli pozdeji platana data, kdyby kreslici smycka vubec neprobehla
-    RECT r2;       // vlastni radek textu
+    r1.bottom = 0; // ensure we have valid data later if the drawing loop never runs
+    RECT r2;       // actual text row
     r2.left = r1.right;
     r2.right = Width;
     //int text_x = r2.left;
@@ -574,19 +574,19 @@ void TTextFileViewWindow<CChar>::Paint()
         {
             colorScheme = LC_NORMAL;
 
-            // vykreslime lajnu oddelujici difference uprostred radky
-            // hrana ve sloupci s cisly radek
+            // draw the line that separates differences across the middle of the row
+            // edge in the line-number column
             SetBkColor(dc, LineColors[colorScheme].LineNumBkColor);
             hOldPen = (HPEN)SelectObject(dc, LineColors[colorScheme].LineNumBorderPen);
             MoveToEx(dc, r1.left, (r1.top + r1.bottom) / 2, NULL);
             LineTo(dc, r1.right, (r1.top + r1.bottom) / 2);
             ExcludeClipRect(dc, r1.left, (r1.top + r1.bottom) / 2, r1.right, (r1.top + r1.bottom) / 2 + 1);
 
-            // hrana v casti s textem souboru
+            // edge in the file-text area
             SetBkColor(dc, LineColors[colorScheme].BkColor);
             (HPEN) SelectObject(dc, LineColors[colorScheme].BorderPen);
-            // posouvame offset zacatku souradnice aby na carky spravne navazovali
-            // pri scrollu
+            // shift the starting coordinate offset so the tick marks align correctly
+            // during scrolling
             MoveToEx(dc, r1.left - FirstVisibleChar * FontWidth, (r1.top + r1.bottom) / 2, NULL);
             LineTo(dc, r2.right, (r1.top + r1.bottom) / 2);
             SelectObject(dc, hOldPen);
@@ -601,7 +601,7 @@ void TTextFileViewWindow<CChar>::Paint()
                 colorScheme = LC_FOCUS;
             else
             {
-                // aby se nam barevne nezvyraznily rozdili v prazdnych radcich pri 'ignore blank lines'
+                // avoid highlighting differences in empty rows when 'ignore blank lines' is enabled
                 if (((TTextFileViewWindow<CChar>*)Siblink)->Script[ViewMode][line].GetClass() == CLineSpec::lcCommon)
                     colorScheme = LC_NORMAL;
                 else
@@ -612,12 +612,12 @@ void TTextFileViewWindow<CChar>::Paint()
 
             if (line == SelectDiffBegin || line > 0 && line - 1 == SelectDiffEnd)
             {
-                // vykreslime cast ohraniceni aktivni difference na hornim okraji radku
-                // hrana ve sloupci s cisly radek
+                // draw part of the active difference border along the top edge of the row
+                // edge in the line-number column
                 hOldPen = (HPEN)SelectObject(dc, LineColors[LC_FOCUS].LineNumBorderPen);
                 MoveToEx(dc, r1.left, r1.top, NULL);
                 LineTo(dc, r1.right, r1.top);
-                // hrana v casti s textem souboru
+                // edge in the file-text area
                 (HPEN) SelectObject(dc, LineColors[LC_FOCUS].BorderPen);
                 LineTo(dc, r2.right, r1.top);
                 SelectObject(dc, hOldPen);
@@ -625,11 +625,11 @@ void TTextFileViewWindow<CChar>::Paint()
                 r2.top++;
             }
 
-            // vykreslime jen pozadi u cisla radky
+            // draw only the background behind the line number
             SetBkColor(dc, LineColors[colorScheme].LineNumBkColor);
             ExtTextOut(dc, 0, 0, ETO_OPAQUE /*| ETO_CLIPPED*/, &r1, NULL, 0, NULL);
 
-            // vykreslime prazdnou radku
+            // draw an empty row
             if (line >= SelectionLineBegin && line < SelectionLineEnd)
                 SetBkColor(dc, GetPALETTERGB(Colors[TEXT_BK_SELECTION]));
             else
@@ -664,12 +664,12 @@ void TTextFileViewWindow<CChar>::Paint()
 
             if (line == SelectDiffBegin || line > 0 && line - 1 == SelectDiffEnd)
             {
-                // vykreslime cast ohraniceni aktivni difference na hornim okraji radku
-                // hrana ve sloupci s cisly radek
+                // draw part of the active difference border along the top edge of the row
+                // edge in the line-number column
                 hOldPen = (HPEN)SelectObject(dc, LineColors[LC_FOCUS].LineNumBorderPen);
                 MoveToEx(dc, r1.left, r1.top, NULL);
                 LineTo(dc, r1.right, r1.top);
-                // hrana ve casti s textem souboru
+                // edge in the file-text area
                 (HPEN) SelectObject(dc, LineColors[LC_FOCUS].BorderPen);
                 LineTo(dc, r2.right, r1.top);
                 SelectObject(dc, hOldPen);
@@ -677,7 +677,7 @@ void TTextFileViewWindow<CChar>::Paint()
                 r2.top++;
             }
 
-            // vykreslime cislo radky najednou s pozadim
+            // draw the line number together with its background
             int l = Script[ViewMode][line].GetLine();
             char num[numeric_limits<size_t>::digits10 + 1];
             sprintf(num, "%*d", LineNumDigits, l + 1);
@@ -685,11 +685,11 @@ void TTextFileViewWindow<CChar>::Paint()
             SetBkColor(dc, LineColors[colorScheme].LineNumBkColor);
             MappedASCII8TextOut.DoTextOut(dc, BORDER_WIDTH, text_y, ETO_OPAQUE | ETO_CLIPPED, &r1, num, LineNumDigits, NULL);
 
-            // vykreslime radku texu najednou s pozadim
+            // draw the text row together with its background
             int len = FormatLine(dc, LineBuffer, Lines[l], Lines[l + 1] - 1);
             if (line > SelectionLineBegin && line < SelectionLineEnd)
             {
-                // cely radek je vybrany
+                // the entire row is selected
                 SetTextColor(dc, GetPALETTERGB(Colors[TEXT_FG_SELECTION]));
                 SetBkColor(dc, GetPALETTERGB(Colors[TEXT_BK_SELECTION]));
                 goto LNORMAL_PAINT;
@@ -698,9 +698,9 @@ void TTextFileViewWindow<CChar>::Paint()
             {
                 if (line == SelectionLineBegin || line == SelectionLineEnd)
                 {
-                    // je vybrana jen cast radku
-                    // vykreslime jen vybranou cast a vyjmeme ji z clipping regionu,
-                    // potom pres ni vykreslime radku normalnima barvama
+                    // only part of the row is selected
+                    // draw just the selected portion and remove it from the clipping region,
+                    // then paint the row over it with normal colors
 
                     int offset1 = 0,
                         offset2 = len - FirstVisibleChar;
@@ -786,7 +786,6 @@ void TTextFileViewWindow<CChar>::Paint()
               OutputDebugString(ss);*/
 
                         // Windows XP seems to fail on len ~ 200 000. 1024 should be enough for everybody
-                        // TODO na 4K displayich už 1024 nemusí stačit!!
                         ExtTextOutX(dc, r3.left, text_y, ETO_OPAQUE | ETO_CLIPPED, &r3,
                                     LineBuffer + FirstVisibleChar + offset1, min(1024, offset2 - offset1), NULL);
 
@@ -794,7 +793,7 @@ void TTextFileViewWindow<CChar>::Paint()
                     }
                 }
 
-                // nastavime normalni barvy
+                // set the normal colors
                 SetTextColor(dc, LineColors[colorScheme].FgColor);
                 SetBkColor(dc, LineColors[colorScheme].BkColor);
             }
@@ -808,7 +807,7 @@ void TTextFileViewWindow<CChar>::Paint()
                 size_t count;
 
                 if (((TTextFileViewWindow<CChar>*)Siblink)->Script[ViewMode][MainWindow->GetChangeFirstLine(line)].GetClass() == CLineSpec::lcBlank)
-                    goto LNORMAL_PAINT; // pouze add, nebo delete
+                    goto LNORMAL_PAINT; // only add or delete
 
                 if (Script[ViewMode][line].GetChanges())
                 {
@@ -819,11 +818,11 @@ void TTextFileViewWindow<CChar>::Paint()
                     //copy(script + 1, script + 1 + *script, LineChanges.begin());
                 }
                 else
-                    goto LCOMMON; // jde o celoradkovy blok bez differenci
+                    goto LCOMMON; // this is a whole-line block without differences
 
                 while (j < count)
                 {
-                    // spolecne znaky
+                    // common characters
                     if (LineChanges[j] != offs && LineChanges[j] > FirstVisibleChar)
                     {
                         PTCommon[c].x = r2.left + FontWidth * (offs - FirstVisibleChar);
@@ -835,29 +834,29 @@ void TTextFileViewWindow<CChar>::Paint()
                         PTCommon[c].rcl.bottom = r2.bottom;
                         if (offs < FirstVisibleChar)
                         {
-                            // zacatek bloku neni videt
+                            // the start of the block is not visible
                             PTCommon[c].rcl.left = LineNumWidth;
-                            adjusted = FALSE; // vynulujem flag
+                            adjusted = FALSE; // reset the flag
                         }
-                        else
-                        {
-                            PTCommon[c].rcl.left = r2.left + FontWidth * (offs - FirstVisibleChar);
-                            if (adjusted)
+                            else
                             {
-                                PTCommon[c].rcl.left += CaretWidth;
-                                adjusted = FALSE; // vynulujem flag
+                                PTCommon[c].rcl.left = r2.left + FontWidth * (offs - FirstVisibleChar);
+                                if (adjusted)
+                                {
+                                    PTCommon[c].rcl.left += CaretWidth;
+                                    adjusted = FALSE; // reset the flag
+                                }
                             }
-                        }
                         PTCommon[c].rcl.right = r2.left + FontWidth * (LineChanges[j] - FirstVisibleChar);
                         PTCommon[c].pdx = 0;
                         c++;
                     }
-                    // zmenene znaky
+                    // changed characters
                     offs = int(LineChanges[j]);
                     j++;
                     if (offs < LineChanges[j])
                     {
-                        // normalni blok
+                        // normal block
                         if (LineChanges[j] > FirstVisibleChar)
                         {
                             PTChange[d].x = r2.left + FontWidth * (offs - FirstVisibleChar);
@@ -878,7 +877,7 @@ void TTextFileViewWindow<CChar>::Paint()
                     }
                     else
                     {
-                        // svisly prouzek pro oznaceni mista insertion/deletion v druhem panelu
+                        // vertical stripe marking the insertion/deletion position in the other panel
                         if (offs >= FirstVisibleChar)
                         {
                             PTZeroChange[z].x = r2.left + FontWidth * (offs - FirstVisibleChar);
@@ -888,7 +887,7 @@ void TTextFileViewWindow<CChar>::Paint()
                             PTZeroChange[z].rcl.top = r2.top;
                             PTZeroChange[z].rcl.bottom = r2.bottom;
                             PTZeroChange[z].rcl.left = r2.left + FontWidth * (offs - FirstVisibleChar);
-                            PTZeroChange[z].n = offs < len ? 1 : 0; // osetrime pripad na konci radky
+                            PTZeroChange[z].n = offs < len ? 1 : 0; // handle the case at the end of the row
                             PTZeroChange[z].rcl.right = PTZeroChange[z].rcl.left + CaretWidth;
                             adjusted = TRUE;
                             PTZeroChange[z].pdx = 0;
@@ -898,7 +897,7 @@ void TTextFileViewWindow<CChar>::Paint()
                     offs = int(LineChanges[j]);
                     j++;
                 }
-            // spolecne znaky - od poslendi zmeny do konce radku
+            // common characters - from the last change to the end of the row
 
             /*if (len - offs || c > 0)
           {*/
@@ -912,7 +911,7 @@ void TTextFileViewWindow<CChar>::Paint()
                 PTCommon[c].rcl.bottom = r2.bottom;
                 if (offs < FirstVisibleChar)
                 {
-                    // zacatek bloku neni videt
+                    // the start of the block is not visible
                     PTCommon[c].rcl.left = LineNumWidth;
                 }
                 else
@@ -992,11 +991,11 @@ void TTextFileViewWindow<CChar>::Paint()
             {
             LNORMAL_PAINT:
                 if (FirstVisibleChar > len)
-                    len = FirstVisibleChar; // jen vymazeme pozadi
+                    len = FirstVisibleChar; // just clear the background
                 // Windows XP seems to fail on len ~ 200 000. 1024 should be enough for everybody
                 len -= FirstVisibleChar;
 
-                // TODO na 4K displayich už 1024 nemusí stačit!!
+                // TODO on 4K displays 1024 might no longer be enough!!
                 ExtTextOutX(dc, r2.left, text_y, ETO_OPAQUE | ETO_CLIPPED, &r2,
                             LineBuffer + FirstVisibleChar, min(1024, len), NULL);
             }
@@ -1007,19 +1006,18 @@ void TTextFileViewWindow<CChar>::Paint()
 
     if (r1.bottom < clipRect.bottom)
     {
-        // jeste vykreslime prazdny prostor od posledniho platneho
-        // radku  ve skriptu do spodniho okraje okna
+        // also draw the empty area from the last valid line in the script to the bottom edge of the window
 
         r1.top = r2.top = r1.bottom;
         r1.bottom = r2.bottom = clipRect.bottom;
 
         if (FirstVisibleLine + i - 1 == SelectDiffEnd)
         {
-            // vykreslime cast ohraniceni aktivni difference na hornim okraji radku
+            // draw part of the active difference border along the top edge of the row
             hOldPen = (HPEN)SelectObject(dc, LineColors[LC_FOCUS].LineNumBorderPen);
             MoveToEx(dc, r1.left, r1.top, NULL);
             LineTo(dc, r1.right, r1.top);
-            // hrana v casti s textem souboru
+            // edge in the file-text area
             (HPEN) SelectObject(dc, LineColors[LC_FOCUS].BorderPen);
             LineTo(dc, r2.right, r1.top);
             SelectObject(dc, hOldPen);
@@ -1027,11 +1025,11 @@ void TTextFileViewWindow<CChar>::Paint()
             r2.top++;
         }
 
-        // vykreslime jen pozadi u cisla radky
+        // draw only the background behind the line number
         SetBkColor(dc, LineColors[LC_NORMAL].LineNumBkColor);
         ExtTextOut(dc, 0, 0, ETO_OPAQUE /*| ETO_CLIPPED*/, &r1, NULL, 0, NULL);
 
-        // vykreslime prazdnou radku
+        // draw an empty row
         SetBkColor(dc, LineColors[LC_NORMAL].BkColor);
         ExtTextOut(dc, 0, 0, ETO_OPAQUE /*| ETO_CLIPPED*/, &r2, NULL, 0, NULL);
     }

--- a/src/plugins/filecomp/viewwnd.cpp
+++ b/src/plugins/filecomp/viewwnd.cpp
@@ -50,7 +50,7 @@ CFileViewWindow::CFileViewWindow(CFileViewID id, CFileViewType type)
     LineNumDigits = 0;
     LineNumWidth = (LineNumDigits + 1) * FontWidth + BORDER_WIDTH;
 
-    // nastavime barevna schemata
+    // set up the color schemes
     memset(LineColors, 0, sizeof(LineColors));
 
     Siblink = NULL;
@@ -91,7 +91,7 @@ void CFileViewWindow::ReloadConfiguration(DWORD flags, BOOL updateWindow)
                         updateWindow);
     if (flags & CC_COLORS)
     {
-        // nastavime barevna schemata
+        // update the color schemes
         int j;
         for (j = 0; j < 3; j++)
         {
@@ -163,7 +163,7 @@ void CFileViewWindow::ResetMouseWheelAccumulatorHandler(UINT uMsg, WPARAM wParam
     case WM_SYSKEYDOWN:
     case WM_KEYDOWN:
     {
-        // pokud je SHIFT stisteny, chodi autorepeat, ale nas zajima jen ten prvni stisk
+        // if SHIFT is held down we get auto-repeat, but we care only about the first press
         BOOL firstPress = (lParam & 0x40000000) == 0;
         if (!firstPress)
             break;
@@ -248,7 +248,7 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         switch (wParam)
         {
-        // vertikalni scrollovani
+        // vertical scrolling
         case 'K':
         case VK_UP:
             if (!shiftPressed && !altPressed)
@@ -298,7 +298,7 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 wScrollNotify = SB_BOTTOM;
             break;
 
-        // horizontalni scrollovani
+        // horizontal scrolling
         case 'L':
         case VK_RIGHT:
             if (!ctrlPressed && !shiftPressed && !altPressed)
@@ -350,13 +350,13 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         short zDelta = (short)HIWORD(wParam);
         if ((zDelta < 0 && MouseWheelAccumulator > 0) || (zDelta > 0 && MouseWheelAccumulator < 0))
-            ResetMouseWheelAccumulator(); // pri zmene smeru otaceni kolecka je potreba nulovat akumulator
+            ResetMouseWheelAccumulator(); // when the wheel reverses direction we must reset the accumulator
 
         BOOL controlPressed = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
         BOOL altPressed = (GetKeyState(VK_MENU) & 0x8000) != 0;
         BOOL shiftPressed = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
 
-        // ctrl+wheel -- skakani po diferencich
+        // ctrl+wheel — jump between differences
         if (controlPressed && !altPressed && !shiftPressed)
         {
             MouseWheelAccumulator += 1000 * zDelta;
@@ -369,12 +369,12 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             }
         }
 
-        // wheel bez modifikatoru: standardni scroll
+        // wheel without modifiers: standard scrolling
         if (!controlPressed && !altPressed && !shiftPressed)
         {
-            DWORD wheelScroll = SG->GetMouseWheelScrollLines(); // muze byt az WHEEL_PAGESCROLL(0xffffffff)
+            DWORD wheelScroll = SG->GetMouseWheelScrollLines(); // can be as high as WHEEL_PAGESCROLL(0xffffffff)
             DWORD pageHeight = (DWORD)(Height / FontHeight);
-            wheelScroll = max(1, (int)min(wheelScroll, pageHeight - 1)); // omezime maximalne na delku stranky
+            wheelScroll = max(1, (int)min(wheelScroll, pageHeight - 1)); // cap it by the page height
 
             MouseWheelAccumulator += 1000 * zDelta;
             int stepsPerLine = max(1, (int)((1000 * WHEEL_DELTA) / wheelScroll));
@@ -396,12 +396,12 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             }
         }
 
-        // shift+wheel: horizontalni scroll
+        // shift+wheel: horizontal scrolling
         if (!controlPressed && !altPressed && shiftPressed)
         {
-            DWORD wheelScroll = SG->GetMouseWheelScrollLines(); // muze byt az WHEEL_PAGESCROLL(0xffffffff)
+            DWORD wheelScroll = SG->GetMouseWheelScrollLines(); // can be as high as WHEEL_PAGESCROLL(0xffffffff)
             DWORD pageWidth = max(1, int(Width / FontWidth));
-            wheelScroll = max(1, (int)min((int)wheelScroll, (int)(pageWidth - 1))); // omezime maximalne na delku stranky
+            wheelScroll = max(1, (int)min((int)wheelScroll, (int)(pageWidth - 1))); // cap it by the page width
 
             MouseWheelAccumulator += 1000 * zDelta;
             int stepsPerChar = max(1, (int)((1000 * WHEEL_DELTA) / wheelScroll));
@@ -430,11 +430,11 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         short zDelta = (short)HIWORD(wParam);
 
         if ((zDelta < 0 && MouseHWheelAccumulator > 0) || (zDelta > 0 && MouseHWheelAccumulator < 0))
-            ResetMouseWheelAccumulator(); // pri zmene smeru naklapeni kolecka je potreba nulovat akumulator
+            ResetMouseWheelAccumulator(); // when the wheel tilting changes direction we must reset the accumulator
 
-        DWORD wheelScroll = SG->GetMouseWheelScrollChars(); // muze byt az WHEEL_PAGESCROLL(0xffffffff)
+        DWORD wheelScroll = SG->GetMouseWheelScrollChars(); // can be as high as WHEEL_PAGESCROLL(0xffffffff)
         DWORD pageWidth = max(1, int(Width / FontWidth));
-        wheelScroll = max(1, (int)min((int)wheelScroll, (int)(pageWidth - 1))); // omezime maximalne na delku stranky
+        wheelScroll = max(1, (int)min((int)wheelScroll, (int)(pageWidth - 1))); // cap it by the page width
 
         MouseHWheelAccumulator += 1000 * zDelta;
         int stepsPerChar = max(1, (int)((1000 * WHEEL_DELTA) / wheelScroll));
@@ -454,7 +454,7 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     SendMessage(HWindow, WM_HSCROLL, charsToScroll < 0 ? SB_LINEUP : SB_LINEDOWN, 0);
             }
         }
-        return TRUE; // udalost jsme zpracovali a nemame zajem o emulaci pomoci klikani na scrollbar (stane se v pripade vraceni FALSE)
+        return TRUE; // event handled; skip scrollbar-click emulation (that happens if we returned FALSE)
     }
 
     case WM_RBUTTONUP:
@@ -693,7 +693,7 @@ BOOL CTextFileViewWindowBase::RebuildScript(
 
             if ((GetAsyncKeyState(VK_ESCAPE) & 0x8001) && GetForegroundWindow() == GetParent(HWindow))
             {
-                MSG msg; // vyhodime nabufferovany ESC
+                MSG msg; // drop the buffered ESC key
                 while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                     ;
                 cancel = TRUE;
@@ -703,8 +703,8 @@ BOOL CTextFileViewWindowBase::RebuildScript(
         }
     }
 
-    // urcime maxWidth
-    int counter = 1000; // testujeme na cancel kazdy tisicy pruchod
+    // determine maxWidth
+    int counter = 1000; // check for cancellation every thousand iterations
     for (CLineScript::iterator i = Script[ViewMode].begin(); i < Script[ViewMode].end();
          ++i)
     {
@@ -718,7 +718,7 @@ BOOL CTextFileViewWindowBase::RebuildScript(
         {
             if ((GetAsyncKeyState(VK_ESCAPE) & 0x8001) && GetForegroundWindow() == GetParent(HWindow))
             {
-                MSG msg; // vyhodime nabufferovany ESC
+                MSG msg; // drop the buffered ESC key
                 while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                     ;
                 cancel = TRUE;
@@ -729,14 +729,14 @@ BOOL CTextFileViewWindowBase::RebuildScript(
         }
     }
 
-    // zjistime velikost mista pro cisla radku
+    // determine the width reserved for line numbers
     LineNumDigits = 1;
     int j = max(GetLines(), ((CTextFileViewWindowBase*)Siblink)->GetLines());
     while (j /= 10)
         LineNumDigits++;
     LineNumWidth = (LineNumDigits + 1) * FontWidth + BORDER_WIDTH;
 
-    // nastavime scrollbaru
+    // configure the scrollbar
     SCROLLINFO si;
     si.cbSize = sizeof(SCROLLINFO);
     si.fMask = SIF_DISABLENOSCROLL | SIF_POS | SIF_PAGE | SIF_RANGE;
@@ -775,7 +775,7 @@ BOOL CTextFileViewWindowBase::SetMaxWidth(int maxWidth)
     if (!ReallocLineBuffer())
         return FALSE;
 
-    // nastavime scrollbaru
+    // update the scrollbar
     SCROLLINFO si;
     si.cbSize = sizeof(SCROLLINFO);
     si.fMask = SIF_DISABLENOSCROLL | SIF_PAGE | SIF_POS | SIF_RANGE;
@@ -932,13 +932,13 @@ void CTextFileViewWindowBase::SelectDifference(int line, int count, BOOL center)
         (count >= page && (line + count - 1 < FirstVisibleLine || line >= FirstVisibleLine + page) ||
          count < page && (line < FirstVisibleLine || line + count - 1 >= FirstVisibleLine + page)))
     {
-        // difference neni viditelna na obrazovce
+        // difference is not visible on the screen
         int pos = FirstVisibleLine;
         if (count > page)
-            pos = line; // zobrazime differenci u hornoho okraje okna
+            pos = line; // show the difference at the top edge of the window
         else
         {
-            pos = line - (page - count) / 2; // vycentrujeme differenci k oknu
+            pos = line - (page - count) / 2; // center the difference in the window
             if (pos < 0)
                 pos = 0;
         }
@@ -960,7 +960,7 @@ void CTextFileViewWindowBase::SelectDifference(int line, int count, BOOL center)
         {
             if (SelectDiffEnd >= FirstVisibleLine && SelectDiffBegin <= FirstVisibleLine + page)
             {
-                // zajistime prekresleni drive vybrane difference
+                // ensure the previously selected difference is repainted
                 r.top = (SelectDiffBegin - FirstVisibleLine) * FontHeight;
                 if (r.top < 0)
                     r.top = 0;
@@ -969,7 +969,7 @@ void CTextFileViewWindowBase::SelectDifference(int line, int count, BOOL center)
                     r.bottom = Height;
                 InvalidateRect(HWindow, &r, FALSE);
             }
-            // zajistime vykresleni nyni vybrane difference
+            // ensure the newly selected difference is drawn
             r.top = (line - FirstVisibleLine) * FontHeight;
             if (r.top < 0)
                 r.top = 0;
@@ -999,7 +999,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
 {
     CALL_STACK_MESSAGE3("CTextFileViewWindowBase::UpdateSelection(%d, %d)", x, y);
     if (!DataValid || !Tracking)
-        return; // jen tak pro jistotu
+        return; // just to be safe
     if (x < LineNumWidth)
         x = LineNumWidth;
     if (y < 0)
@@ -1030,7 +1030,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
 
     if (TrackingLineBegin != line || TrackingCharBegin != end)
     {
-        // aby se nam na WM_LBUTTONUP nevyfokusovala difference
+        // prevent the difference from grabbing focus on WM_LBUTTONUP
         SelectDifferenceOnButtonUp = FALSE;
     }
 
@@ -1039,7 +1039,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
     int oldCharBegin = SelectionCharBegin;
     int oldCharEnd = SelectionCharEnd;
 
-    // nastavime aktualni vyber
+    // set the current selection
     BOOL reverse;
     if (TrackingLineBegin < line ||
         TrackingLineBegin == line && TrackingCharBegin < end)
@@ -1062,7 +1062,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
     if ((SelectionLineBegin != SelectionLineEnd || SelectionCharBegin != SelectionCharEnd) &&
         (GetKeyState(VK_CONTROL) & 0x8000) != 0) //ctrlPressed
     {
-        // vybirame cele radky
+        // select whole lines
         SelectionCharBegin = 0;
         if (ViewMode != fvmOnlyDifferences || Script[ViewMode][SelectionLineEnd].GetClass() != CLineSpec::lcSeparator)
         {
@@ -1078,7 +1078,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
 
     if (ViewMode == fvmOnlyDifferences)
     {
-        // ohlidame aby slo vybirat jen v ramci jedne difference
+        // ensure selection stays within a single difference
         if (TrackingLineBegin < line)
         {
             if (Script[ViewMode][SelectionLineBegin].GetClass() == CLineSpec::lcSeparator)
@@ -1112,16 +1112,16 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
         }
     }
 
-    // posuneme kurzor na konec vyberu
+    // move the caret to the end of the selection
     if (reverse)
         SetCaretPos(SelectionCharBegin, SelectionLineBegin);
     else
         SetCaretPos(SelectionCharEnd, SelectionLineEnd);
 
-    // zajistime prekresleni postizenych casti
+    // ensure the affected areas are repainted
     RepaintSelection(oldLineBegin, oldLineEnd, oldCharBegin, oldCharEnd);
 
-    // enablujem/disablujem tlacitko pro COPY v toolbare
+    // enable or disable the COPY toolbar button
     //  CMainWindow * parent = (CMainWindow *) WindowsManager.GetWindowPtr(GetParent(HWindow));
     if (MainWindow /*parent*/)
         MainWindow /*parent*/->UpdateToolbarButtons(UTB_TEXTSELECTION);
@@ -1132,7 +1132,7 @@ void CTextFileViewWindowBase::RepaintSelection(int oldLineBegin, int oldLineEnd,
 {
     CALL_STACK_MESSAGE5("CTextFileViewWindowBase::RepaintSelection(%d, %d, %d, %d)",
                         oldLineBegin, oldLineEnd, oldCharBegin, oldCharEnd);
-    // zajistime prekresleni jen postizenych casti
+    // ensure only the affected areas are repainted
     RECT r;
     r.left = LineNumWidth;
     r.right = Width;
@@ -1285,7 +1285,7 @@ void CTextFileViewWindowBase::SetCaretPos(int xPos, int yPos)
             x = LineNumWidth + (MeasureLine(l, CaretXPos) - FirstVisibleChar) * FontWidth;
         }
         if (x < LineNumWidth)
-            x = -1; // mensi finta, aby caret zmizel za roh
+            x = -1; // small trick to hide the caret past the corner
         ::SetCaretPos(x, y);
     }
 }

--- a/src/plugins/filecomp/viewwnd.h
+++ b/src/plugins/filecomp/viewwnd.h
@@ -16,30 +16,30 @@ class CMainWindow;
 #define BORDER_WIDTH 2
 
 // line color index
-#define LC_NORMAL 0 // shodne text
-#define LC_CHANGE 1 // zmeneny text
-#define LC_FOCUS 2  // zmeneny a fokusovany text
+#define LC_NORMAL 0 // matching text
+#define LC_CHANGE 1 // changed text
+#define LC_FOCUS 2  // changed text with focus
 
 struct CLineColors
 {
     COLORREF LineNumFgColor;
     COLORREF LineNumBkColor;
-    HPEN LineNumBorderPen; // platne jen pro LC_FOCUS (ramecek kolem fokusu) a LC_NORMAL (separator differenci)
+    HPEN LineNumBorderPen; // valid only for LC_FOCUS (focus border) and LC_NORMAL (difference separator)
     COLORREF FgColor;
     COLORREF BkColor;
-    HPEN BorderPen;    // platne jen pro LC_FOCUS (ramecek kolem fokusu) a LC_NORMAL (separator differenci)
-    COLORREF FgCommon; // barva spolecneho textu pro zobrazeni rozdilu v radce
+    HPEN BorderPen;    // valid only for LC_FOCUS (focus border) and LC_NORMAL (difference separator)
+    COLORREF FgCommon; // color of common text when differences are shown on the row
     COLORREF BkCommon;
 };
 
-// identifikace okna
+// window identification
 enum CFileViewID
 {
     fviLeft,
     fviRight
 };
 
-// identifikace okna
+// window identification
 enum CFileViewType
 {
     fvtText,
@@ -51,7 +51,7 @@ extern HCURSOR HArrowCursor;
 
 extern const char* FILEVIEWWINDOW_CLASSNAME;
 
-// proporcionalne k sirce okna, na okraje kasleme, jde o "odhad"
+// proportional to the window width; we ignore margins, this is only an "estimate"
 #define FAST_LEFTRIGHT __max(1, width / FontWidth / 6)
 
 BOOL TestHScrollWParam(WPARAM wParam);
@@ -76,7 +76,7 @@ protected:
     TMappedTextOut<char> MappedASCII8TextOut;
     BOOL Tracking;
 
-    // slouzi pro akumulaci mikrokroku pri otaceni koleckem mysi, viz
+    // accumulates micro steps while the mouse wheel turns; see
     // http://msdn.microsoft.com/en-us/library/ms997498.aspx (Best Practices for Supporting Microsoft Mouse and Keyboard Devices)
     int MouseWheelAccumulator;  // vertical
     int MouseHWheelAccumulator; // horizontal
@@ -133,10 +133,10 @@ protected:
 //   return (line & LF_BLANK) == LF_BLANK || (line & LF_BLANK) == LF_SEPARATOR;
 // }
 
-// id timeru pro automaticky scroll pri vyberu textu pomoci mysi
+// timer ID for automatic scrolling when selecting text with the mouse
 #define IDT_SCROLLTEXT 1
 
-// znak, ktery se obevi misto prazdnych znaku
+// character that appears instead of empty slots
 //#define WHITE_SPACE_CHAR ((char)0xB7)
 
 // update selection flag
@@ -165,13 +165,12 @@ protected:
     int CaretXPos;
     int CaretYPos;
     BOOL ShowWhiteSpace;
-    // prvni prvek LineChanges[cislo_zmeny][cislo_radky_ve_zmene] udava pocet
-    // nasledujicich paru, kazdy par urcuje offset pocatku a konce zmeny v
-    // radce
+    // the first element of LineChanges[change_index][line_index_in_change] gives the count
+    // of following pairs, each pair specifies the start and end offset of the change on the row
     // unsigned int ***LineChanges;
     // int * ChangesToLinesMap;
     // int * LinesToChangesMap;
-    // CEditScript * EdScript; // potrebne poze pro in-line changes
+    // CEditScript * EdScript; // needed only for in-line changes
     BOOL DetailedDifferences;
     int TabSize;
     CMainWindow* MainWindow;

--- a/src/plugins/filecomp/viewwnd2.cpp
+++ b/src/plugins/filecomp/viewwnd2.cpp
@@ -14,7 +14,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     SLOW_CALL_STACK_MESSAGE4("CTextFileViewWindowBase::WindowProc(0x%X, 0x%IX, 0x%IX)", uMsg,
                              wParam, lParam);
 
-    // dame prilezitost k resetu akumulatoru pro mouse wheel
+    // give the mouse wheel accumulator a chance to reset
     ResetMouseWheelAccumulatorHandler(uMsg, wParam, lParam);
 
     switch (uMsg)
@@ -23,13 +23,13 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (Siblink)
         {
-            // zrusime vyber textu v druhem okne
+            // clear the text selection in the other window
             if (DisplayCaret)
                 Siblink->RemoveSelection(TRUE);
         }
         ShowCaret();
 
-        // informujeme parenta, ze jsme prevzali fokus
+        // inform the parent that we took focus
         //      CMainWindow * parent = (CMainWindow *) WindowsManager.GetWindowPtr(GetParent(HWindow));
         if (MainWindow /*parent*/)
             MainWindow /*parent*/->SetActiveFileView(ID);
@@ -48,7 +48,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (GetFocus() != HWindow)
             SetFocus(HWindow);
-        // zrusime vyber textu v druhem okne
+        // clear the text selection in the other window
         if (!DisplayCaret)
             Siblink->RemoveSelection(TRUE);
         if (DataValid)
@@ -56,14 +56,14 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             int line = FirstVisibleLine + HIWORD(lParam) / FontHeight;
             if (line < int(Script[ViewMode].size()))
             {
-                // pri nasledujicim WM_LBUTTONUP fokusujeme differenci
-                // tento flag se shodi v UpdateSelection, kdyz user vybere nejaky text
+                // focus the difference on the next WM_LBUTTONUP
+                // this flag is cleared in UpdateSelection when the user selects any text
                 SelectDifferenceOnButtonUp = TRUE;
 
                 TrackingLineBegin = line;
                 if (LOWORD(lParam) >= LineNumWidth)
                 {
-                    // nastavime novy vyber textu
+                    // set the new text selection
                     if (Script[ViewMode][line].IsBlank())
                         TrackingCharBegin = 0;
                     else
@@ -96,28 +96,28 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 //          CMainWindow * parent = (CMainWindow *) WindowsManager.GetWindowPtr(GetParent(HWindow));
                 if (LOWORD(lParam) < LineNumWidth)
                 {
-                    // zkusime vybrat celou differenci do bloku
+                    // try to select the entire difference as a block
                     if (!MainWindow /*parent*/ || !MainWindow /*parent*/->GetDifferenceRange(line, &start, &end))
                         return 0;
                 }
                 else
                 {
                     if ((GetKeyState(VK_CONTROL) & 0x8000) == 0)
-                        wholeLines = FALSE; // vyber celeho slova
+                        wholeLines = FALSE; // select the whole word
                     else
-                        start = end = line; //vyber celeho radku
+                        start = end = line; // select the entire line
                 }
 
-                // ulozime stary vyber textu
+                // store the old text selection
                 int oldLineBegin = SelectionLineBegin;
                 int oldLineEnd = SelectionLineEnd;
                 int oldCharBegin = SelectionCharBegin;
                 int oldCharEnd = SelectionCharEnd;
 
-                // nastavime novy vyber textu
+                // set the new text selection
                 if (wholeLines)
                 {
-                    //vybirame cele radky
+                    // select whole lines
                     SelectionLineBegin = start;
                     SelectionCharBegin = 0;
                     if (end + 1 < int(Script[ViewMode].size()))
@@ -139,16 +139,16 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
                 else
                 {
-                    //vyber slova
+                    // select the word
                     if (Script[ViewMode][line].IsBlank())
-                        return 0; // neni co vybirat
+                        return 0; // nothing to select
 
                     int l = Script[ViewMode][line].GetLine();
                     start = end = TransformXOrg(LOWORD(lParam), line);
                     SelectWord(l, start, end);
 
                     if (start == end)
-                        return 0; // neni co vybirat
+                        return 0; // nothing to select
 
                     SelectionLineBegin = SelectionLineEnd = line;
                     SelectionCharBegin = start;
@@ -184,7 +184,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         if (DataValid && TrackingLineBegin < int(Script[ViewMode].size()) && SelectDifferenceOnButtonUp)
         {
-            // zkusime vybrat differenci
+            // try to select the difference
             //        CMainWindow * parent = (CMainWindow *) WindowsManager.GetWindowPtr(GetParent(HWindow));
             if (MainWindow /*parent*/)
                 MainWindow /*parent*/->SelectDifferenceByLine(TrackingLineBegin, FALSE);
@@ -228,16 +228,16 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
             switch (wParam)
             {
-            // vertikalni scrollovani
+            // vertical scrolling
             case 'K':
             case VK_UP:
                 if (!ctrlPressed && !altPressed)
                 {
                     if (!shiftPressed && IsSelected())
                     {
-                        SetCaretPos(SelectionCharBegin, SelectionLineBegin); // presuneme se na zacatek vyberu
+                        SetCaretPos(SelectionCharBegin, SelectionLineBegin); // move to the start of the selection
                     }
-                    // ohlidame aby slo vybirat jen v ramci jedne difference
+                    // ensure selection stays within a single difference
                     // NOTE: Script[fvmOnlyDifferences] is empty when showing identical files
                     if (!Script[ViewMode].empty() && (ViewMode != fvmOnlyDifferences || !shiftPressed ||
                                                       CaretYPos == 0 || Script[ViewMode][CaretYPos - 1].GetClass() != CLineSpec::lcSeparator))
@@ -258,7 +258,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 {
                     if (ViewMode == fvmOnlyDifferences && shiftPressed)
                     {
-                        // ohlidame, aby slo vybirat jen v ramci jedne difference
+                        // ensure selection stays within a single difference
                         int i;
                         for (i = CaretYPos; i > CaretYPos - Height / FontHeight + 1 && i > 0; i--)
                         {
@@ -285,7 +285,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 {
                     if (ViewMode == fvmOnlyDifferences && shiftPressed)
                     {
-                        // ohlidame, aby slo vybirat jen v ramci jedne difference
+                        // ensure selection stays within a single difference
                         int i;
                         for (i = CaretYPos; i < CaretYPos + Height / FontHeight + 1 && i < int(Script[ViewMode].size()) - 1; i++)
                         {
@@ -312,9 +312,9 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 {
                     if (!shiftPressed && IsSelected())
                     {
-                        SetCaretPos(SelectionCharEnd, SelectionLineEnd); // presuneme se na konec vyberu
+                        SetCaretPos(SelectionCharEnd, SelectionLineEnd); // move to the end of the selection
                     }
-                    // ohlidame aby slo vybirat jen v ramci jedne difference
+                    // ensure selection stays within a single difference
                     // NOTE: Script[fvmOnlyDifferences] is empty when showing identical files
                     if (!Script[ViewMode].empty() && (ViewMode != fvmOnlyDifferences || !shiftPressed ||
                                                       Script[ViewMode][CaretYPos].GetClass() != CLineSpec::lcSeparator))
@@ -349,7 +349,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 {
                 LHOME:
 
-                    // ohlidame aby slo vybirat jen v ramci jedne difference
+                    // ensure selection stays within a single difference
                     int i = 0;
                     if (ViewMode == fvmOnlyDifferences && shiftPressed)
                     {
@@ -371,7 +371,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 {
                 LEND:
 
-                    // ohlidame aby slo vybirat jen v ramci jedne difference
+                    // ensure selection stays within a single difference
                     int i = int(Script[ViewMode].size()) - 1;
                     if (ViewMode == fvmOnlyDifferences && shiftPressed)
                     {
@@ -386,7 +386,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
                 break;
 
-            // horizontalni scrollovani
+        // horizontal scrolling
             case 'L':
             case VK_RIGHT:
             {
@@ -395,7 +395,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 if (!ctrlPressed && !shiftPressed && IsSelected())
                 {
-                    SetCaretPos(SelectionCharEnd, SelectionLineEnd); // presuneme se na konec vyberu
+                    SetCaretPos(SelectionCharEnd, SelectionLineEnd); // move to the end of the selection
                     break;
                 }
 
@@ -412,8 +412,8 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 if (CaretXPos == len)
                 {
-                    // presuneme se na nasledujici radek
-                    // ohlidame aby slo vybirat jen v ramci jedne difference
+                    // move to the next line
+                    // ensure selection stays within a single difference
                     if (ViewMode != fvmOnlyDifferences || !shiftPressed ||
                         Script[ViewMode][CaretYPos].GetClass() != CLineSpec::lcSeparator)
                     {
@@ -424,10 +424,10 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
 
                 if (!ctrlPressed)
-                    SetCaretPos(CaretXPos + 1, CaretYPos); // presuneme se na nasledujici znak
+                    SetCaretPos(CaretXPos + 1, CaretYPos); // move to the next character
                 else
                 {
-                    // presuneme se na konec slova/mezery/bloku jinych znaku
+                    // move to the end of the word/space/block of other characters
                     int xpos = CaretXPos;
                     NextCharBlock(l, xpos);
 
@@ -444,14 +444,14 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 if (!ctrlPressed && !shiftPressed && IsSelected())
                 {
-                    SetCaretPos(SelectionCharBegin, SelectionLineBegin); // presuneme se na zacatek vyberu
+                    SetCaretPos(SelectionCharBegin, SelectionLineBegin); // move to the start of the selection
                     break;
                 }
 
                 if (CaretXPos == 0)
                 {
-                    // posuneme se na predchozi radek
-                    // ohlidame aby slo vybirat jen v ramci jedne difference
+                    // move to the previous line
+                    // ensure selection stays within a single difference
                     if (ViewMode != fvmOnlyDifferences || !shiftPressed ||
                         CaretYPos == 0 || Script[ViewMode][CaretYPos - 1].GetClass() != CLineSpec::lcSeparator)
                     {
@@ -462,10 +462,10 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
 
                 if (!ctrlPressed)
-                    SetCaretPos(CaretXPos - 1, CaretYPos); // posuneme se na predchozi znak
+                    SetCaretPos(CaretXPos - 1, CaretYPos); // move to the previous character
                 else
                 {
-                    // presuneme se na konec slova/mezery/bloku jinych znaku
+                    // move to the end of the word/space/block of other characters
                     int l = Script[ViewMode][CaretYPos].GetLine();
                     int xpos = CaretXPos;
                     PrevCharBlock(l, xpos);
@@ -482,17 +482,17 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     MainWindow /*parent*/->SelectDifferenceByLine(CaretYPos, TRUE);
                 if (shiftPressed)
                 {
-                    // zkusime vybrat celou differenci do bloku
+                    // try to select the entire difference as a block
                     int start, end;
                     if (MainWindow /*parent*/ && MainWindow /*parent*/->GetDifferenceRange(CaretYPos, &start, &end))
                     {
-                        // ulozime stary vyber textu
+                        // store the old text selection
                         int oldLineBegin = SelectionLineBegin;
                         int oldLineEnd = SelectionLineEnd;
                         int oldCharBegin = SelectionCharBegin;
                         int oldCharEnd = SelectionCharEnd;
 
-                        // nastavime novy vyber textu, vybirame cele radky
+                        // set the new text selection and select whole lines
                         SelectionLineBegin = start;
                         SelectionCharBegin = 0;
                         if (end + 1 < int(Script[ViewMode].size()))
@@ -578,13 +578,13 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     SelectionLineEnd = y1;
                     SelectionCharEnd = x1;
                 }
-                // zajistime prekresleni postizenych casti
+                // ensure the affected areas are repainted
                 RepaintSelection(oldLineBegin, oldLineEnd, oldCharBegin, oldCharEnd);
                 //            CMainWindow * parent = (CMainWindow *) WindowsManager.GetWindowPtr(GetParent(HWindow));
                 if (MainWindow /*parent*/)
                     MainWindow /*parent*/->UpdateToolbarButtons(UTB_TEXTSELECTION);
             }
-            case USF_NOCHANGE:; // nic nedelame
+            case USF_NOCHANGE:; // do nothing
             }
 
             if (wScrollNotify != -1)
@@ -673,7 +673,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 if (Siblink)
                 {
-                    // zrusime stary vyber textu
+                    // clear the previous text selection
                     Siblink->RemoveSelection(TRUE);
                 }
 
@@ -765,7 +765,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SendMessage(Siblink->HWindow, WM_USER_VSCROLL, SB_THUMBTRACK, pos);
         lParam = pos;
     }
-        // pokracujem dal ...
+        // keep going ...
 
     case WM_USER_VSCROLL:
     {
@@ -788,8 +788,8 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
 
     case WM_HSCROLL:
-        // aby nedochazelo ke konfliktu SB_FASTLEFT a SB_FASTRIGHT
-        // se standardnimi parametry
+        // prevent conflicts between SB_FASTLEFT and SB_FASTRIGHT
+        // using the standard parameters
         if (!TestHScrollWParam(wParam))
             return 0;
         if (LOWORD(wParam) == SB_THUMBTRACK)
@@ -802,7 +802,7 @@ CTextFileViewWindowBase::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         wParam &= 0xFFFF;
         SendMessage(Siblink->HWindow, WM_USER_HSCROLL, wParam, lParam);
-        // pokracujem dal ...
+        // keep going ...
 
     case WM_USER_HSCROLL:
     {

--- a/src/plugins/filecomp/viewwnd3.cpp
+++ b/src/plugins/filecomp/viewwnd3.cpp
@@ -172,7 +172,7 @@ BOOL CHexFileViewWindow::SetData(QWORD firstDiff, const char* path, QWORD siblin
         FirstDiff = 0; // Files are actually equal
     SiblinkSize = siblinkSize;
 
-    // zjistime velikost mista pro offset
+    // determine the width reserved for the offset
     LineNumDigits = ComputeAddressCharWidth(Mapping.GetFileSize(), SiblinkSize);
     LineNumWidth = (LineNumDigits + 1) * FontWidth + BORDER_WIDTH;
 
@@ -199,7 +199,7 @@ void CHexFileViewWindow::Paint()
         oldPalette = SelectPalette(dc, Palette, FALSE);
     HFONT oldFont = (HFONT)SelectObject(dc, HFont);
 
-    // urcim interval radku, ktery je treba prekreslit
+    // determine the range of rows that needs to be repainted
     RECT clipRect;
     int clipRet = GetClipBox(dc, &clipRect);
     int clipFirstRow = 0;
@@ -210,12 +210,12 @@ void CHexFileViewWindow::Paint()
         clipLastRow = clipRect.bottom / FontHeight + 1;
     }
 
-    RECT r1; // cislo radky
+    RECT r1; // line-number area
     r1.left = 0;
     r1.right = LineNumDigits * FontWidth + 2 * BORDER_WIDTH;
-    r1.bottom = 0; // abychom meli pozdeji platana data, kdyby kreslici smycka vubec neprobehla
-    RECT r2;       // tri znaky + mezera v hexa oblasti (napr "1F ")
-    RECT r3;       // ascii oblast
+    r1.bottom = 0; // ensure we have valid data later if the drawing loop never runs
+    RECT r2;       // three characters plus a space in the hex area (for example "1F ")
+    RECT r3;       // ASCII area
     //r2.left = r1.right;
     //r2.right = Width;
     //int text_x = r2.left;
@@ -267,14 +267,14 @@ void CHexFileViewWindow::Paint()
     __try
     {
         int i;
-        // vykreslime mezeru offsetem a textem
+        // draw the gap between the offset and the text
         r.top = clipRect.top;
         r.bottom = clipRect.bottom;
         r.left = r1.right;
         r.right = LineNumWidth;
         SetBkColor(dc, LineColors[LC_NORMAL].BkColor);
         ExtTextOut(dc, 0, 0, ETO_OPAQUE, &r, NULL, 0, NULL);
-        // vykreslime mezeru mezi sloupci s DWORDy mezery
+        // draw the gap between columns of DWORDs
         for (i = HScrollOffs / 13; i < BytesPerLine / 4; i++)
         {
             r.left = LineNumWidth + FontWidth * (11 + i * 13) - HScrollOffs * FontWidth;
@@ -283,7 +283,7 @@ void CHexFileViewWindow::Paint()
                 r.left = LineNumWidth;
             ExtTextOut(dc, 0, 0, ETO_OPAQUE, &r, NULL, 0, NULL);
         }
-        // vykreslime zbytek
+        // draw the rest
         for (i = clipFirstRow; i < clipLastRow; i++)
         {
             text_y = r1.top = r2.top = r3.top = i * FontHeight;
@@ -291,7 +291,7 @@ void CHexFileViewWindow::Paint()
 
             colorScheme = LC_NORMAL;
 
-            // vykreslime cislo radky najednou s pozadim
+            // draw the line number together with its background
             char num[32];
             QWord2Ascii(ViewOffset + i * BytesPerLine, num, LineNumDigits);
             SetTextColor(dc, LineColors[colorScheme].LineNumFgColor);
@@ -335,13 +335,13 @@ void CHexFileViewWindow::Paint()
                     SetBkColor(dc, GetPALETTERGB(Colors[TEXT_BK_SELECTION]));
                 }
 
-                // kreslime ASCII cast
+                // render the ASCII part
                 if (r3.left >= LineNumWidth)
                 {
                     MappedASCII8TextOut.DoTextOut(dc, r3.left, text_y, ETO_OPAQUE | ETO_CLIPPED, &r3, data + j, 1, NULL);
                 }
 
-                // kreslime hex cast
+                // render the hex part
                 if (r2.right > LineNumWidth)
                 {
                     char buf[2];
@@ -352,7 +352,7 @@ void CHexFileViewWindow::Paint()
                     if (colorScheme == LC_NORMAL ||
                         k < maxj && (k >= siblinkSize || siblinkData[k] != data[k]))
                     {
-                        // vykreslime celou trojici ('XX ') v jedne barve
+                        // draw the entire trio ('XX ') in one color
                         r = r2;
                         if (r.left < LineNumWidth)
                             r.left = LineNumWidth;
@@ -360,7 +360,7 @@ void CHexFileViewWindow::Paint()
                     }
                     else
                     {
-                        // vykreslime prvni dva znaky
+                        // draw the first two characters
                         r = r2;
                         r.right = r2.left + 2 * FontWidth;
                         if (r2.right > LineNumWidth)
@@ -369,7 +369,7 @@ void CHexFileViewWindow::Paint()
                                 r.left = LineNumWidth;
                             MappedASCII8TextOut.DoTextOut(dc, r2.left, text_y, ETO_OPAQUE | ETO_CLIPPED, &r, buf, 2, NULL);
                         }
-                        // vykreslime oddelujici mezeru
+                        // draw the separating space
                         if (r.right < r2.right)
                         {
                             SetTextColor(dc, LineColors[LC_NORMAL].FgColor);
@@ -399,7 +399,7 @@ void CHexFileViewWindow::Paint()
     }
     __except (HandleFileException(GetExceptionInformation()))
     {
-        // chyba v souboru
+        // file error
         goto LERASE_WINDOW;
     }
 
@@ -418,19 +418,18 @@ void CHexFileViewWindow::Paint()
 
     if (r1.bottom < clipRect.bottom)
     {
-        // jeste vykreslime prazdny prostor od posledniho platneho
-        // radku do spodniho okraje okna
+        // also draw the empty area from the last valid row down to the bottom edge of the window
 
         r1.top = r2.top = r1.bottom;
         r1.bottom = r2.bottom = clipRect.bottom;
         r2.left = LineNumWidth;
         r2.right = Width;
 
-        // vykreslime jen pozadi u cisla radky
+        // draw only the background behind the line number
         SetBkColor(dc, LineColors[LC_NORMAL].LineNumBkColor);
         ExtTextOut(dc, 0, 0, ETO_OPAQUE, &r1, NULL, 0, NULL);
 
-        // vykreslime prazdnou radku
+        // draw an empty row
         SetBkColor(dc, LineColors[LC_NORMAL].BkColor);
         ExtTextOut(dc, 0, 0, ETO_OPAQUE, &r2, NULL, 0, NULL);
     }
@@ -445,11 +444,11 @@ void CHexFileViewWindow::Paint()
         r2.left = r1.right;
         r2.right = Width;
 
-        // vykreslime jen pozadi u cisla radky
+        // draw only the background behind the line number
         SetBkColor(dc, LineColors[LC_NORMAL].LineNumBkColor);
         ExtTextOut(dc, 0, 0, ETO_OPAQUE, &r1, NULL, 0, NULL);
 
-        // vykreslime prazdnou radku
+        // draw an empty row
         SetBkColor(dc, LineColors[LC_NORMAL].BkColor);
         ExtTextOut(dc, 0, 0, ETO_OPAQUE, &r2, NULL, 0, NULL);
     }
@@ -466,14 +465,14 @@ int CHexFileViewWindow::HandleFileException(EXCEPTION_POINTERS* e)
     if (Mapping.IsFileIOException(e))
     {
         HandleFileError(Path, ERROR_SUCCESS);
-        return EXCEPTION_EXECUTE_HANDLER; // spustime __except blok
+        return EXCEPTION_EXECUTE_HANDLER; // enter the __except block
     }
     if (((CHexFileViewWindow*)Siblink)->Mapping.IsFileIOException(e))
     {
         HandleFileError(((CHexFileViewWindow*)Siblink)->GetPath(), ERROR_SUCCESS);
-        return EXCEPTION_EXECUTE_HANDLER; // spustime __except blok
+        return EXCEPTION_EXECUTE_HANDLER; // enter the __except block
     }
-    return EXCEPTION_CONTINUE_SEARCH; // hodime vyjimku dale ... call-stacku
+    return EXCEPTION_CONTINUE_SEARCH; // propagate the exception further up the call stack
 }
 
 void CHexFileViewWindow::HandleFileError(const char* path, int error)
@@ -554,7 +553,7 @@ CHexFileViewWindow::FindDifference(int cmd, QWORD* pOffset)
 
                     if ((GetAsyncKeyState(VK_ESCAPE) & 0x8001) && GetForegroundWindow() == GetParent(HWindow))
                     {
-                        MSG msg; // vyhodime nabufferovany ESC
+                        MSG msg; // drop the buffered ESC key
                         while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                             ;
                         return 0;
@@ -610,7 +609,7 @@ CHexFileViewWindow::FindDifference(int cmd, QWORD* pOffset)
 
                 if ((GetAsyncKeyState(VK_ESCAPE) & 0x8001) && GetForegroundWindow() == GetParent(HWindow))
                 {
-                    MSG msg; // vyhodime nabufferovany ESC
+                    MSG msg; // drop the buffered ESC key
                     while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                         ;
                     return 0;
@@ -635,7 +634,7 @@ CHexFileViewWindow::FindDifference(int cmd, QWORD* pOffset)
         }
         else
         {
-            // hledame pozpatku
+            // search backwards
             QWORD diffEnd;
 
             if (cmd == CM_PREVDIFF || cmd == CM_LASTDIFF && Mapping.GetFileSize() == SiblinkSize)
@@ -688,7 +687,7 @@ CHexFileViewWindow::FindDifference(int cmd, QWORD* pOffset)
 
                     if ((GetAsyncKeyState(VK_ESCAPE) & 0x8001) && GetForegroundWindow() == GetParent(HWindow))
                     {
-                        MSG msg; // vyhodime nabufferovany ESC
+                        MSG msg; // drop the buffered ESC key
                         while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                             ;
                         return 0;
@@ -696,7 +695,7 @@ CHexFileViewWindow::FindDifference(int cmd, QWORD* pOffset)
                 }
 
                 if (!remain)
-                    return 0; // jsou shodny
+                    return 0; // they match
 
                 offset = offset - (start - ptr0);
                 diffEnd = remain = offset + 1;
@@ -742,7 +741,7 @@ CHexFileViewWindow::FindDifference(int cmd, QWORD* pOffset)
 
                 if ((GetAsyncKeyState(VK_ESCAPE) & 0x8001) && GetForegroundWindow() == GetParent(HWindow))
                 {
-                    MSG msg; // vyhodime nabufferovany ESC
+                    MSG msg; // drop the buffered ESC key
                     while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                         ;
                     return 0;
@@ -787,7 +786,7 @@ void CHexFileViewWindow::SelectDifference(QWORD offset, QWORD length, BOOL cente
     }
     else
     {
-      ViewOffset = __max(((__int64)pos - (page - (__int64)lines)/2), 0) *BytesPerLine; // vycentrujeme differenci k oknu
+      ViewOffset = __max(((__int64)pos - (page - (__int64)lines)/2), 0) *BytesPerLine; // center the difference in the window
     }
     */
         if (lines <= page)
@@ -810,7 +809,7 @@ CHexFileViewWindow::CalculateOffset(int x, int y)
     if (y < 0)
     {
         y = 0;
-        x = LineNumWidth - HScrollOffs * FontWidth; // aby vyslo hOffs nula
+        x = LineNumWidth - HScrollOffs * FontWidth; // so that hOffs becomes zero
     }
     QWORD offset = ViewOffset + y / FontHeight * BytesPerLine;
     int hOffs = (x - LineNumWidth) + HScrollOffs * FontWidth;
@@ -902,7 +901,7 @@ void CHexFileViewWindow::UpdateSelection(int x, int y)
         }
         InvalidateRect(HWindow, NULL, TRUE);
         UpdateWindow(HWindow);
-        // enablujem/disablujem tlacitko pro COPY v toolbare
+        // enable or disable the COPY toolbar button
         CMainWindow* parent = (CMainWindow*)WindowsManager.GetWindowPtr(GetParent(HWindow));
         if (parent)
             parent->UpdateToolbarButtons(UTB_TEXTSELECTION);
@@ -915,14 +914,14 @@ CHexFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE4("CHexFileViewWindow::WindowProc(0x%X, 0x%IX, 0x%IX)", uMsg,
                         wParam, lParam);
 
-    // dame prilezitost k resetu akumulatoru pro mouse wheel
+    // give the mouse wheel accumulator a chance to reset
     ResetMouseWheelAccumulatorHandler(uMsg, wParam, lParam);
 
     switch (uMsg)
     {
     case WM_SETFOCUS:
     {
-        // informujeme parenta, ze jsme prevzali fokus
+        // inform the parent that we took focus
         CMainWindow* parent = (CMainWindow*)WindowsManager.GetWindowPtr(GetParent(HWindow));
         if (parent)
             parent->SetActiveFileView(ID);
@@ -941,7 +940,7 @@ CHexFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (LOWORD(lParam) >= LineNumWidth)
             {
                 QWORD offset = CalculateOffset(LOWORD(lParam), HIWORD(lParam));
-                // zkusime vybrat differenci
+                // try to select the difference
                 SelectDifferenceOnButtonUp = TRUE;
                 TrackingOffsetBegin = offset;
                 Tracking = TRUE;
@@ -1047,7 +1046,7 @@ CHexFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         lParam = (LPARAM)pos;
         wParam = (WPARAM)(pos >> 32);
     }
-        // pokracujem dal ...
+        // keep going ...
 
     case WM_USER_VSCROLL:
     {
@@ -1070,8 +1069,8 @@ CHexFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
 
     case WM_HSCROLL:
-        // aby nedochazelo ke konfliktu SB_FASTLEFT a SB_FASTRIGHT
-        // se standardnimi parametry
+        // prevent conflicts between SB_FASTLEFT and SB_FASTRIGHT
+        // using the standard parameters
         if (!TestHScrollWParam(wParam))
             return 0;
         if (LOWORD(wParam) == SB_THUMBTRACK)
@@ -1084,7 +1083,7 @@ CHexFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         wParam &= 0xFFFF;
         SendMessage(Siblink->HWindow, WM_USER_HSCROLL, wParam, lParam);
-        // pokracujem dal ...
+        // keep going ...
 
     case WM_USER_HSCROLL:
     {

--- a/src/plugins/filecomp/worker.cpp
+++ b/src/plugins/filecomp/worker.cpp
@@ -212,7 +212,7 @@ CFilecompWorker::Body()
 
 void CFilecompWorker::GuardedBody()
 {
-    // otevreme soubory
+    // open the files
     int i;
     for (i = 0; i <= 1; i++)
     {
@@ -241,7 +241,7 @@ void CFilecompWorker::GuardedBody()
 
     if (Options.ForceBinary)
     {
-        // srovname jako binarni soubory
+        // compare as binary files
         CompareBinaryFiles();
     }
     else
@@ -263,7 +263,7 @@ void CFilecompWorker::GuardedBody()
         if (files[0].GetType() == CTextFileReader::ftText &&
             files[1].GetType() == CTextFileReader::ftText)
         {
-            // srovnam jako text
+            // compare as text
 
             if (Options.IgnoreLineBreakChanges)
             {
@@ -275,7 +275,7 @@ void CFilecompWorker::GuardedBody()
             if (files[0].GetEncoding() == CTextFileReader::encASCII8 &&
                 files[1].GetEncoding() == CTextFileReader::encASCII8)
             {
-                // srovname jako ASCII8 text
+                // compare as ASCII8 text
                 CompareTextFiles<char>(files);
                 //TRACE_I("Total time spent by comparing files " << TotalRuntime.Read());
                 //TRACE_I("Total time spent by shifting boundaries " << ShiftBoundaries.Read());
@@ -287,29 +287,29 @@ void CFilecompWorker::GuardedBody()
             }
             else
             {
-                // srovname jako UNICODE text
+                // compare as UNICODE text
                 if (files[0].HasSurrogates() || files[1].HasSurrogates())
                 {
-                    // srovname jako UCS-4/UTF-32 text
-                    // TODO nekdy to treba budem podporovat, zatim umime jen BMP
-                    // tento kod se nikdy nespusti, HasSurrogates vraci vzdy false
+                    // compare as UCS-4/UTF-32 text
+                    // TODO maybe we will support it one day; for now we handle only BMP
+                    // this code never runs; HasSurrogates always returns false
                     throw CFilecompWorker::CException("Only BMP character set is supported.");
                     //CompareTextFiles<DWORD>(files);
                 }
                 else
                 {
-                    // srovname jako UCS-2 text (UTF-16 without surrogates)
-                    // TODO pritomne surrogates ingorujeme, uzivatel dostane warning
+                    // compare as UCS-2 text (UTF-16 without surrogates)
+                    // TODO present surrogates are ignored; the user receives a warning
                     CompareTextFiles<wchar_t>(files);
                 }
             }
         }
         else
         {
-            // uvolnime pamet
+            // free the memory
             files[0].Reset();
             files[1].Reset();
-            // srovname jako binarni soubory
+            // compare as binary files
             CompareBinaryFiles();
         }
     }

--- a/src/plugins/filecomp/worker.h
+++ b/src/plugins/filecomp/worker.h
@@ -22,7 +22,7 @@ struct CCompareOptions
     // Ignore all horizontal white space.
     int IgnoreAllSpace;
 
-    // zahrnuto do ingnore space change
+    // included in IgnoreSpaceChange
     // Ignore changes that affect only blank lines.
     //int IgnoreBlankLines;
 
@@ -275,26 +275,26 @@ struct CWorkerFileData
 class CFilecompWorker : public CThread
 {
 public:
-    // obecna chyba
+    // general error
     class CException : public std::exception
     {
     public:
         CException(const char* s = "Unspecified Error.") : exception(s) {}
         static void Raise(int error, int lastError, ...);
     };
-    // ukonceno uzivatelem
+    // canceled by the user
     class CAbortByUserException : public std::exception
     {
     public:
         CAbortByUserException() : exception("") {}
     };
-    // soubory jsou stejny
+    // files are identical
     class CFilesDontDifferException : public std::exception
     {
     public:
         CFilesDontDifferException() : exception("") {}
     };
-    // soubory jsou stejny
+    // files are identical
     class CAllDiffsIgnoredException : public std::exception
     {
     public:
@@ -308,7 +308,7 @@ protected:
     HWND Parent;
     HWND MainWindow; // The window receiving WM_USER_WORKERNOTIFIES
     CCompareOptions Options;
-    const int& CancelFlag; // 0 ... jedeme dal, jinak konec
+    const int& CancelFlag; // 0 ... keep going, otherwise stop
     HANDLE Event;
 
     CWorkerFileData Files[2];

--- a/src/plugins/filecomp/worker2.cpp
+++ b/src/plugins/filecomp/worker2.cpp
@@ -217,8 +217,8 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
 
     for (;;)
     {
-        // zjistime delku difference
-        // offset ukazuje na zacatek difference
+        // determine the length of the difference
+        // offset points to the start of the difference
 
         offsetSave = offset;
         remain = totalSize - offset;
@@ -283,7 +283,7 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
         {
             changes.push_back(CBinaryChange(offsetSave, lenghtSave));
             if (changes.size() == MaxBinChanges)
-                break; // dale uz nehledame, je jich az az
+                break; // no need to search further; there are plenty of them
             HWND hComboWnd = (HWND)SendMessage(MainWindow, WM_USER_WORKERNOTIFIES, WN_GET_CHANGESCOMBO, NULL);
             if (hComboWnd)
             {
@@ -310,10 +310,10 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
         else
             break;
 
-        // hledame zacatek dalsi difference
-        offset = changes.back().Offset + changes.back().Length; // zacne za posledni differenci
+        // look for the start of the next difference
+        offset = changes.back().Offset + changes.back().Length; // starts after the last difference
         if (offset >= totalSize)
-            break; // uz jsme na konci souboru
+            break; // we are already at the end of the file
         remain = totalSize - offset;
 
         while (remain)
@@ -331,7 +331,7 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
                 }
             }
 
-            // porovnavame po blokach o velikosti size
+            // compare in blocks of the given size
             DWORD size = (DWORD)__min(blokSize, remain);
 
             ptr0 = cf[0].ReadBuffer(offset, size, CancelFlag);
@@ -367,7 +367,7 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
 
         if (remain)
         {
-            offset = ptr0 - start + offset; // offset nyni ukazuje na zacatek nasledujici difference
+            offset = ptr0 - start + offset; // the offset now points to the start of the next difference
         }
     }
 


### PR DESCRIPTION
## Summary
- translate font mapping comments to explain substitution behavior and XP64-specific quirks
- clarify buffer ownership and Unicode handling annotations in the text reader and remote comparator
- convert viewer repainting and selection guidance across text and hex windows to English

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e129281ff0832285ddb82d68a5fe2b