### PR TITLE
splitcbn: polish translated interface comments

### DIFF
--- a/src/plugins/splitcbn/combine.cpp
+++ b/src/plugins/splitcbn/combine.cpp
@@ -32,7 +32,7 @@ BOOL CombineFiles(TIndirectArray<char>& files, LPTSTR targetName,
 
     int idTitle = bOnlyCrc ? IDS_CRCTITLE : IDS_COMBINE;
 
-    // nascitani velikosti vsech partial files (soucasne kontrola jejich pristupnosti)
+    // sum sizes of all partial files (while simultaneously checking their accessibility)
     CQuadWord totalSize = CQuadWord(0, 0);
     char text[MAX_PATH + 50];
     int i;
@@ -50,7 +50,7 @@ BOOL CombineFiles(TIndirectArray<char>& files, LPTSTR targetName,
         SalamanderSafeFile->SafeFileClose(&file);
     }
 
-    // test volneho mista
+    // check available free space
     if (!bOnlyCrc)
     {
         char dir[MAX_PATH];
@@ -60,7 +60,7 @@ BOOL CombineFiles(TIndirectArray<char>& files, LPTSTR targetName,
             return FALSE;
     }
 
-    // vytvoreni vystupniho souboru
+    // create the output file
     SAFE_FILE outfile;
     if (!bOnlyCrc)
     {
@@ -71,7 +71,7 @@ BOOL CombineFiles(TIndirectArray<char>& files, LPTSTR targetName,
         }
     }
 
-    // spojeni
+    // merge the files
     char* pBuffer = new char[BUFSIZE];
     if (pBuffer == NULL)
     {
@@ -83,7 +83,7 @@ BOOL CombineFiles(TIndirectArray<char>& files, LPTSTR targetName,
 
     UINT32 CrcVal = 0;
 
-    // otevreni progress dialogu
+    // open the progress dialog
     salamander->OpenProgressDialog(LoadStr(idTitle), TRUE, parent, FALSE);
     salamander->ProgressSetTotalSize(CQuadWord(-1, -1), totalSize);
     salamander->ProgressSetSize(CQuadWord(-1, -1), CQuadWord(0, 0), FALSE);
@@ -360,19 +360,19 @@ static void AnalyzeFile(LPTSTR fileName, LPTSTR origName, UINT32& origCrc, FILET
 {
     CALL_STACK_MESSAGE2("AnalyzeFile(%s, , , , )", fileName);
     bNameAcquired = bCrcAcquired = FALSE;
-    // nacteni souboru do bufferu
+    // load the file into a buffer
     HANDLE hFile;
     if ((hFile = CreateFile(fileName, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
                             FILE_FLAG_SEQUENTIAL_SCAN, NULL)) == INVALID_HANDLE_VALUE)
         return;
     DWORD size = GetFileSize(hFile, NULL), numread;
-    // j.r. 21.1.2003: pri rozdeleni na 999 jsem dostal davku o velikosti 30KB
-    //  if (size > 10000) { CloseHandle(hFile); return; } // na tak velky soubory kaslem
+    // j.r. 21.1.2003: when splitting to 999 parts I received a batch of 30KB
+    //  if (size > 10000) { CloseHandle(hFile); return; } // skip such large files
     if (size > 200000)
     {
         CloseHandle(hFile);
         return;
-    } // na tak velky soubory kaslem
+    } // skip such large files
     char* text = new char[size + 1];
     char* text_locase = new char[size + 1];
     if (text == NULL || text_locase == NULL)
@@ -392,14 +392,14 @@ static void AnalyzeFile(LPTSTR fileName, LPTSTR origName, UINT32& origCrc, FILET
 
     strcpy(text_locase, text);
     CharLower(text_locase);
-    // zkusime najit "crc32" nebo "crc"
+    // try to find "crc32" or "crc"
     if (!bCrcAcquired)
     {
         bCrcAcquired = FindCrc(text_locase, "crc32", origCrc);
         if (!bCrcAcquired)
             bCrcAcquired = FindCrc(text_locase, "crc", origCrc);
     }
-    // "filename" nebo "name"
+    // "filename" or "name"
     if (!bNameAcquired)
     {
         bNameAcquired = FindName(text, text_locase, "filename", origName);
@@ -432,12 +432,12 @@ BOOL CombineCommand(DWORD eventMask, HWND parent, CSalamanderForOperationsAbstra
     BOOL isDir;
 
     if (eventMask & MENU_EVENT_FILES_SELECTED)
-    { // jsou vybrany soubory
+    { // files are selected
         int index = 0;
         BOOL bAllSameNames = TRUE;
         BOOL bFirst = TRUE;
 
-        // nacteme do pole vybrane polozky (krome adresaru)
+        // load selected items into the array (except directories)
         while ((pfd = SalamanderGeneral->GetPanelSelectedItem(PANEL_SOURCE, &index, &isDir)) != NULL)
         {
             if (!isDir)
@@ -460,47 +460,47 @@ BOOL CombineCommand(DWORD eventMask, HWND parent, CSalamanderForOperationsAbstra
             }
         }
 
-        // jestlize byla vsechna jmena stejna, je sance ze najdeme i doprovodny .BAT nebo .CRC
+        // if all names were identical, there is a chance we will find a companion .BAT or .CRC
         bTestCompanionFile = bAllSameNames;
         if (!bAllSameNames)
             strcpy(name1, "combinedfile");
         strcpy(companionFile, sourceDir);
         if (!SalamanderGeneral->SalPathAppend(companionFile, name1, MAX_PATH) ||
-            strlen(companionFile) + 1 >= MAX_PATH) // test pro strcat() nize
+            strlen(companionFile) + 1 >= MAX_PATH) // safety check for the strcat() below
         {
             SalamanderGeneral->ShowMessageBox(LoadStr(IDS_TOOLONGNAME2), LoadStr(IDS_COMBINE), MSGBOX_ERROR);
             return FALSE;
         }
         strcat(companionFile, ".");
     }
-    else // pouze fokus na souboru - snazime se rozsirit vyber o "vyssi" soubory
+    else // only the focus is on a file - try to extend the selection with "higher" files
     {
         pfd = SalamanderGeneral->GetPanelFocusedItem(PANEL_SOURCE, &isDir);
         if (pfd == NULL || isDir)
         {
-            TRACE_E("CombineCommand(): Neni fokus na souboru ?!?");
+            TRACE_E("CombineCommand(): No focus on a file?!?");
             return FALSE;
         }
         BOOL bJustOneFile = FALSE;
-        // nejprve analyza pripony
+        // first analyze the extension
         char* ext = _tcsrchr(pfd->Name, '.');
-        if (ext != NULL) // ".cvspass" ve Windows je pripona
+        if (ext != NULL) // ".cvspass" is an extension in Windows
         {
             BOOL bZeroPadded, bAddThisFile = TRUE;
             int nextIndex;
             if (!lstrcmpi(ext, ".tns"))
-            { // tns = Turbo Navigator Split - povazujeme za "000"
+            { // tns = Turbo Navigator Split - consider it as "000"
                 bZeroPadded = FALSE;
                 nextIndex = 2;
             }
             else if (!lstrcmpi(ext, ".bat") || !lstrcmpi(ext, ".crc"))
-            { // bat Salamandera nebo crc WinCommandera; s TN soubory to tady fungovat nebude
+            { // Salamander's BAT or WinCommander CRC; this will not work with TN files here
                 bZeroPadded = TRUE;
                 nextIndex = 1;
                 bAddThisFile = FALSE;
             }
             else
-            { // je pripona slozena z cislic?
+            { // is the extension composed of digits?
                 BOOL bNumbers = TRUE;
                 int numberCount = 0, i = 1;
                 while (ext[i])
@@ -515,7 +515,7 @@ BOOL CombineCommand(DWORD eventMask, HWND parent, CSalamanderForOperationsAbstra
                         i++;
                     }
                 if (!bNumbers || numberCount > 3)
-                    bJustOneFile = TRUE; // divna pripona - nic rozsirovat nebudem
+                    bJustOneFile = TRUE; // strange extension - we will not extend anything
                 else
                 {
                     bZeroPadded = (ext[1] == '0');
@@ -559,7 +559,7 @@ BOOL CombineCommand(DWORD eventMask, HWND parent, CSalamanderForOperationsAbstra
             }
         }
         else
-        { // chybi pripona - kaslem na to, nic rozsirovat nebudem
+        { // missing extension - skip it, we will not extend anything
             bJustOneFile = TRUE;
             strcpy(companionFile, sourceDir);
             if (!SalamanderGeneral->SalPathAppend(companionFile, "combinedfile", MAX_PATH))
@@ -579,9 +579,9 @@ BOOL CombineCommand(DWORD eventMask, HWND parent, CSalamanderForOperationsAbstra
     FILETIME origTime;
 
     if (bTestCompanionFile)
-    { // prohlidneme pripadny BAT nebo CRC
+    { // inspect a potential BAT or CRC
         size_t ext = strlen(companionFile);
-        if (ext + 3 >= MAX_PATH) // test pro strcat() nize
+        if (ext + 3 >= MAX_PATH) // safety check for the strcat() below
         {
             SalamanderGeneral->ShowMessageBox(LoadStr(IDS_TOOLONGNAME2), LoadStr(IDS_COMBINE), MSGBOX_ERROR);
             return FALSE;
@@ -607,13 +607,13 @@ BOOL CombineCommand(DWORD eventMask, HWND parent, CSalamanderForOperationsAbstra
     }
 
     if (!bName)
-    { // nastavime defaultni jmeno
+    { // set a default name
         strcpy(name1, companionFile);
         name1[strlen(name1) - 1] = 0;
         char* dot = _tcsrchr(name1, '.');
-        if (dot == NULL) // ".cvspass" ve Windows je pripona
+        if (dot == NULL) // ".cvspass" is an extension in Windows
         {
-            if (strlen(name1) + 4 >= MAX_PATH) // test pro strcat() nize
+            if (strlen(name1) + 4 >= MAX_PATH) // safety check for the strcat() below
             {
                 SalamanderGeneral->ShowMessageBox(LoadStr(IDS_TOOLONGNAME2), LoadStr(IDS_COMBINE), MSGBOX_ERROR);
                 return FALSE;
@@ -623,9 +623,9 @@ BOOL CombineCommand(DWORD eventMask, HWND parent, CSalamanderForOperationsAbstra
     }
 
     if (configCombineToOther)
-    { // JC - unor 2002 - uprava pro kombinovani do druhyho panelu, sorry, trochu prasarna
-        // ale predchozi kod s tim nepocital, takze bych ho musel cely prepsat...
-        // Tento kod nahradi cestu v "name1", ktera je do zdrojoveho panelu, cestou ciloveho panelu
+    { // JC - February 2002 - adjustment for combining to the other panel, sorry, a bit of a hack
+        // but the previous code did not anticipate it, so I would have had to rewrite it all...
+        // This code replaces the path in "name1", which points to the source panel, with the target panel path
         SalamanderGeneral->SalPathStripPath(name1);
         GetTargetDir(name2, NULL, FALSE);
         if (!SalamanderGeneral->SalPathAppend(name2, name1, MAX_PATH))

--- a/src/plugins/splitcbn/dialogs.cpp
+++ b/src/plugins/splitcbn/dialogs.cpp
@@ -15,7 +15,7 @@
 //  SPLIT DIALOG
 //
 
-#define STRICT_SYNTAX // nepovoli kraviny v COMBO_SIZE
+#define STRICT_SYNTAX // disallows nonsense values in COMBO_SIZE
 
 namespace split
 {
@@ -34,7 +34,7 @@ namespace split
         if (!partsize.Value)
         {
             TRACE_E("S/C.GetSizeOfLastPart: partsize == 0 ?!?");
-            return CQuadWord(0, 0); // ochrana pred delenim nulou, nemelo by nastat
+            return CQuadWord(0, 0); // guard against division by zero; should not happen
         }
         CQuadWord last;
         last.Value = filesize.Value % partsize.Value;
@@ -113,7 +113,7 @@ namespace split
         char text[100], number[100];
         GetDlgItemText(hDialog, IDC_COMBO_SIZE, text, 100);
 
-        // vypusteni mezer a tabulatoru a nahrezeni carky teckou
+        // remove spaces and tabs and replace commas with dots
         int i = 0, j = 0;
         while (text[i] && (strchr(" \t0123456789.,", text[i]) != NULL || (BYTE)text[i] == 0xA0))
         {
@@ -128,7 +128,7 @@ namespace split
             j++;
         text[j] = 0;
 
-        // ziskani multiplikatoru
+        // determine the multiplier
         DWORD multiplier = 1;
         BOOL ok = TRUE;
         if (!lstrcmpi(text + i, LoadStr(IDS_SIZE_KB)) || !lstrcmpi(text + i, LoadStr(IDS_SIZE_K)))
@@ -175,7 +175,7 @@ namespace split
         }
         if (parts > 0)
         {
-            CQuadWord size = (qwFileSize + CQuadWord(parts - 1, 0)) / CQuadWord(parts, 0); // zaokrouhlujeme nahoru
+            CQuadWord size = (qwFileSize + CQuadWord(parts - 1, 0)) / CQuadWord(parts, 0); // round up
             *pqwPartialSize = size;
             SalamanderGeneral->NumberToStr(text, size);
             //SalamanderGeneral->PrintDiskSize(text, size, 1);
@@ -243,7 +243,7 @@ namespace split
         {
             if ((GetKeyState(VK_CONTROL) & 0x8000) == 0 && (GetKeyState(VK_SHIFT) & 0x8000) == 0)
                 SalamanderGeneral->OpenHtmlHelp(hWnd, HHCDisplayContext, IDD_SPLIT, FALSE);
-            return TRUE; // F1 nenechame propadnout do parenta ani pokud nezobrazujeme help
+            return TRUE; // do not let F1 fall through to the parent even if help is not displayed
         }
 
         case WM_COMMAND:
@@ -647,7 +647,7 @@ namespace combine
         {
             if ((GetKeyState(VK_CONTROL) & 0x8000) == 0 && (GetKeyState(VK_SHIFT) & 0x8000) == 0)
                 SalamanderGeneral->OpenHtmlHelp(hWnd, HHCDisplayContext, IDD_COMBINE, FALSE);
-            return TRUE; // F1 nenechame propadnout do parenta ani pokud nezobrazujeme help
+            return TRUE; // do not let F1 fall through to the parent even if help is not displayed
         }
 
         case WM_COMMAND:
@@ -853,7 +853,7 @@ static INT_PTR CALLBACK ConfigDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
     {
         if ((GetKeyState(VK_CONTROL) & 0x8000) == 0 && (GetKeyState(VK_SHIFT) & 0x8000) == 0)
             SalamanderGeneral->OpenHtmlHelp(hWnd, HHCDisplayContext, IDD_CONFIG, FALSE);
-        return TRUE; // F1 nenechame propadnout do parenta ani pokud nezobrazujeme help
+        return TRUE; // do not let F1 fall through to the parent even if help is not displayed
     }
 
     case WM_COMMAND:
@@ -917,7 +917,7 @@ static INT_PTR CALLBACK CRCDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         sprintf(text, LoadStr(IDS_CRCDEC), calcCrc);
         SetDlgItemText(hWnd, IDC_EDIT_CRC2, text);
 
-        // !POZOR! ziskanou ikonu je treba ve WM_DESTROY destruovat
+        // WARNING! the obtained icon must be destroyed in WM_DESTROY
         HICON icon = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_WARN), IMAGE_ICON, 16, 16, LR_DEFAULTCOLOR);
         SendDlgItemMessage(hWnd, IDC_ICON_WARN, STM_SETIMAGE, IMAGE_ICON, (LPARAM)icon);
         icon = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_OK), IMAGE_ICON, 16, 16, LR_DEFAULTCOLOR);
@@ -946,7 +946,7 @@ static INT_PTR CALLBACK CRCDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
 
     case WM_DESTROY:
     {
-        // ikona ziskana bez flagu LR_SHARED se musi destruovat
+        // an icon obtained without the LR_SHARED flag must be destroyed
         HICON hIcon = (HICON)SendDlgItemMessage(hWnd, IDC_ICON_WARN, STM_SETIMAGE, IMAGE_ICON, NULL);
         if (hIcon != NULL)
             DestroyIcon(hIcon);

--- a/src/plugins/splitcbn/dialogs.h
+++ b/src/plugins/splitcbn/dialogs.h
@@ -3,16 +3,16 @@
 
 #pragma once
 
-BOOL SplitDialog(LPTSTR fileName,        // [in]     jmeno splitovaneho souboru
-                 CQuadWord& fileSize,    // [in]     jeho velikost
-                 LPTSTR targetDir,       // [in/out] cilovy adresar
-                 CQuadWord* partialSize, // [out]    velikost jedne casti
+BOOL SplitDialog(LPTSTR fileName,        // [in]     name of the file being split
+                 CQuadWord& fileSize,    // [in]     its size
+                 LPTSTR targetDir,       // [in/out] target directory
+                 CQuadWord* partialSize, // [out]    size of a single part
                  HWND hParent);
 
-BOOL CombineDialog(TIndirectArray<char>& files, // [in/out] pole jmen castecnych souboru
-                   LPTSTR targetName,           // [in/out] jmeno ciloveho souboru
-                   BOOL bOrigCrcFound,          // [in]     flag jestli byl nalezen puvodni CRC
-                   UINT32 origCrc,              // [in]     puvodni CRC
+BOOL CombineDialog(TIndirectArray<char>& files, // [in/out] array of partial file names
+                   LPTSTR targetName,           // [in/out] name of the target file
+                   BOOL bOrigCrcFound,          // [in]     flag indicating whether the original CRC was found
+                   UINT32 origCrc,              // [in]     original CRC
                    HWND hParent, CSalamanderForOperationsAbstract* salamander);
 
 void ConfigDialog(HWND hParent);

--- a/src/plugins/splitcbn/help/hh/salamander_help_shared.css
+++ b/src/plugins/splitcbn/help/hh/salamander_help_shared.css
@@ -206,14 +206,14 @@
 
 #help_page td.hdr
 {
-  /* tmavsi seda na leve strane */
+  /* darker gray on the left side */
   margin: .25em;
   background: #dddddd;
   vertical-align: top;
   padding: 2px 4px;
   font-weight: bold;
-  width: 10%;           /* zuzime levou stranu tabulky na minimum */
-  padding-right :10px;  /* ale nechame tam alespon 10 bodu, at to trochu vypada */
+  width: 10%;           /* shrink the left side of the table to a minimum */
+  padding-right :10px;  /* but leave at least 10 points so it still looks decent */
   white-space: nowrap;
 }
 

--- a/src/plugins/splitcbn/precomp.cpp
+++ b/src/plugins/splitcbn/precomp.cpp
@@ -3,8 +3,8 @@
 
 #include "precomp.h"
 
-// projekt SPLITCBN obsahuje tri skupiny modulu
+// the SPLITCBN project contains three groups of modules
 //
-// 1) modul precomp.cpp, ktery postavi splitcbn.pch (/Yc"precomp.h")
-// 2) moduly vyuzivajici splitcbn.pch (/Yu"precomp.h")
-// 3) commony nepouzivaji precompiled headers
+// 1) module precomp.cpp, which builds splitcbn.pch (/Yc"precomp.h")
+// 2) modules using splitcbn.pch (/Yu"precomp.h")
+// 3) commons that do not use precompiled headers

--- a/src/plugins/splitcbn/splitcbn.h
+++ b/src/plugins/splitcbn/splitcbn.h
@@ -51,8 +51,8 @@ extern BOOL configSplitToOther;
 extern BOOL configCombineToOther;
 extern BOOL configSplitToSubdir;
 
-extern HINSTANCE DLLInstance; // handle k SPL-ku - jazykove nezavisle resourcy
-extern HINSTANCE HLanguage;   // handle k SLG-cku - jazykove zavisle resourcy
+extern HINSTANCE DLLInstance; // handle to SPL - language-independent resources
+extern HINSTANCE HLanguage;   // handle to SLG - language-dependent resources
 char* LoadStr(int resID);
 void CenterWindow(HWND hWnd);
 void GetInfo(char* buffer, CQuadWord& size);

--- a/src/plugins/splitcbn/splitcbn.rh2
+++ b/src/plugins/splitcbn/splitcbn.rh2
@@ -7,18 +7,18 @@
 #endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
 
 #define IDC_STATIC_1 3000
-#include "statics.rh2"   // 3000 az 3039 jsou timto zabrane !!!
+#include "statics.rh2"   // 3000 to 3039 are reserved by this include !!!
 
-// IDcka pro propojeni s helpem
+// IDs for linking the help
 #define IDH_COMBINE                     2500
 #define IDH_SPLIT                       2501
-#define IDH_SPLIT2                      2502  // obchazime chybu Resource Workshopu (jinak nejde .rc otevrit, tragedie)
-#define IDH_SPLIT3                      2503  // obchazime chybu Resource Workshopu (jinak nejde .rc otevrit, tragedie)
-#define IDH_SPLIT4                      2504  // obchazime chybu Resource Workshopu (jinak nejde .rc otevrit, tragedie)
+#define IDH_SPLIT2                      2502  // work around a Resource Workshop bug (otherwise the .rc cannot be opened, disaster)
+#define IDH_SPLIT3                      2503  // work around a Resource Workshop bug (otherwise the .rc cannot be opened, disaster)
+#define IDH_SPLIT4                      2504  // work around a Resource Workshop bug (otherwise the .rc cannot be opened, disaster)
 
 // ********************************************************************************
 //
-//  TEXTY
+//  STRINGS
 //
 
 #define IDS_PLUGINNAME                  1
@@ -84,7 +84,7 @@
 
 // ********************************************************************************
 //
-//  IKONY
+//  ICONS
 //
 
 #define IDI_SPLIT                       2000

--- a/src/plugins/splitcbn/versinfo.rh2
+++ b/src/plugins/splitcbn/versinfo.rh2
@@ -13,7 +13,7 @@
 #define VERSINFO_MINORA      1
 #define VERSINFO_MINORB      1
 
-#include "spl_vers.h" // vytahneme cisla verzi + buildu
+#include "spl_vers.h" // pull in the version and build numbers
 
 #define VERSINFO_COPYRIGHT   "Copyright © 1997-2023 Open Salamander Authors"
 #define VERSINFO_COMPANY     "Open Salamander"


### PR DESCRIPTION
## Summary
- refine the splitcbn interface field comments so the English phrasing is natural while remaining true to the original Czech guidance
- update the combine command extension note to use consistent spelling and verified no Czech keywords remain in the plugin sources

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1927458548322ac14e2f556dfcf4f