### PR TITLE
demoplug: translate plugin and fs comments

### DIFF
--- a/src/plugins/demoplug/archiver.cpp
+++ b/src/plugins/demoplug/archiver.cpp
@@ -59,7 +59,7 @@ CArcPluginDataInterface::SetupView(BOOL leftPanel, CSalamanderViewAbstract* view
 
         CColumn column;
         lstrcpy(column.Name, "Size2");
-        lstrcpy(column.Description, "Size in an alternate format");
+        lstrcpy(column.Description, "Size v jinem provedeni");
         column.GetText = GetSzText;
         column.SupportSorting = 1;
         column.LeftAlignment = 0;

--- a/src/plugins/demoplug/archiver.cpp
+++ b/src/plugins/demoplug/archiver.cpp
@@ -11,11 +11,11 @@
 
 #include "precomp.h"
 
-// spolecny interface pro pluginova data archivatoru
+// shared interface for archiver plugin data
 CArcPluginDataInterface ArcPluginDataInterface;
 
 // ****************************************************************************
-// SEKCE ARCHIVERU
+// ARCHIVER SECTION
 // ****************************************************************************
 
 //
@@ -23,8 +23,8 @@ CArcPluginDataInterface ArcPluginDataInterface;
 // CArcPluginDataInterface
 //
 
-// callback volany ze Salamandera pro ziskani textu
-// popis viz. spl_com.h / FColumnGetText
+// callback invoked by Salamander to obtain text
+// see spl_com.h / FColumnGetText for details
 void WINAPI GetSzText()
 {
     if (*TransferIsDir && !(*TransferFileData)->SizeValid)
@@ -43,11 +43,11 @@ CArcPluginDataInterface::SetupView(BOOL leftPanel, CSalamanderViewAbstract* view
     view->GetTransferVariables(TransferFileData, TransferIsDir, TransferBuffer, TransferLen, TransferRowData,
                                TransferPluginDataIface, TransferActCustomData);
 
-    // sloupce upravujeme jen v detailed rezimu
+    // adjust columns only in detailed mode
     if (view->GetViewMode() == VIEW_MODE_DETAILED)
     {
-        // zkusime najit std. Size a zaradit se za nej; pokud ho nenajdeme,
-        // zaradime se na konec
+        // try to find the standard Size column and insert after it; if it is not found,
+        // append the column at the end
         int sizeIndex = view->GetColumnsCount();
         int i;
         for (i = 0; i < sizeIndex; i++)
@@ -59,7 +59,7 @@ CArcPluginDataInterface::SetupView(BOOL leftPanel, CSalamanderViewAbstract* view
 
         CColumn column;
         lstrcpy(column.Name, "Size2");
-        lstrcpy(column.Description, "Size v jinem provedeni");
+        lstrcpy(column.Description, "Size in an alternate format");
         column.GetText = GetSzText;
         column.SupportSorting = 1;
         column.LeftAlignment = 0;
@@ -100,7 +100,7 @@ CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salam
     SalamanderGeneral->ShowMessageBox("CPluginInterfaceForArchiver::ListArchive", LoadStr(IDS_PLUGINNAME), MSGBOX_INFO);
 #endif // DEMOPLUG_QUIET
 
-    // nastavime jaka data ve 'file' jsou platna
+    // define which data fields in 'file' are valid
     dir->SetValidData(VALID_DATA_EXTENSION |
                       VALID_DATA_DOSNAME |
                       VALID_DATA_SIZE |
@@ -126,13 +126,13 @@ CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salam
     file.NameLen = strlen(file.Name);
     char* s = strrchr(file.Name, '.');
     if (s != NULL)
-        file.Ext = s + 1; // ".cvspass" ve Windows je pripona ...
+        file.Ext = s + 1; // ".cvspass" is a Windows extension...
     else
         file.Ext = file.Name + file.NameLen;
     file.Size = CQuadWord(666, 0);
     file.Attr = FILE_ATTRIBUTE_ARCHIVE;
     file.Hidden = 0;
-    file.PluginData = 666; // zbytecne, jen tak pro formu
+    file.PluginData = 666; // redundant, just for show
 
     SYSTEMTIME st;
     GetSystemTime(&st);
@@ -161,8 +161,8 @@ CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salam
     file.IsOffline = 0;
     file.IconOverlayIndex = 1; // icon-overlay: slow file
 
-    // prida automaticky dva adresare "test" a "path" (protoze jeste neexistuji),
-    // aby mohl pridat 'file'
+    // automatically adds two directories "test" and "path" (because they do not yet exist)
+    // so that it can add 'file'
     if (!dir->AddFile("test\\path", file, pluginData))
     {
         SalamanderGeneral->Free(file.Name);
@@ -170,7 +170,7 @@ CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salam
         return FALSE;
     }
 
-    // pridame jeste dva soubory
+    // add two more files
     file.Name = SalamanderGeneral->DupStr("test2.txt");
     if (file.Name == NULL)
     {
@@ -180,7 +180,7 @@ CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salam
     file.NameLen = strlen(file.Name);
     s = strrchr(file.Name, '.');
     if (s != NULL)
-        file.Ext = s + 1; // ".cvspass" ve Windows je pripona ...
+        file.Ext = s + 1; // ".cvspass" is a Windows extension...
     else
         file.Ext = file.Name + file.NameLen;
     file.Size = CQuadWord(555, 0);
@@ -201,13 +201,13 @@ CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salam
     file.NameLen = strlen(file.Name);
     s = strrchr(file.Name, '.');
     if (s != NULL)
-        file.Ext = s + 1; // ".cvspass" ve Windows je pripona ...
+        file.Ext = s + 1; // ".cvspass" is a Windows extension...
     else
         file.Ext = file.Name + file.NameLen;
     file.Size = CQuadWord(444, 0);
     file.Attr |= FILE_ATTRIBUTE_ENCRYPTED;
     file.IsLink = SalamanderGeneral->IsFileLink(file.Ext);
-    file.IconOverlayIndex = ICONOVERLAYINDEX_NOTUSED; // none icon-overlay
+    file.IconOverlayIndex = ICONOVERLAYINDEX_NOTUSED; // no icon overlay
     if (!dir->AddFile("test\\path", file, pluginData))
     {
         SalamanderGeneral->Free(file.Name);
@@ -226,23 +226,23 @@ CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salam
     }
     file.NameLen = strlen(file.Name);
     if (!sortByExtDirsAsFiles)
-        file.Ext = file.Name + file.NameLen; // adresare nemaji pripony
+        file.Ext = file.Name + file.NameLen; // directories have no extension
     else
     {
         s = strrchr(file.Name, '.');
         if (s != NULL)
-            file.Ext = s + 1; // ".cvspass" ve Windows je pripona ...
+            file.Ext = s + 1; // ".cvspass" is a Windows extension...
         else
             file.Ext = file.Name + file.NameLen;
     }
     file.Size = CQuadWord(0, 0);
     file.Attr = FILE_ATTRIBUTE_DIRECTORY;
     file.Hidden = 0;
-    file.PluginData = 666; // zbytecne, jen tak pro formu
+    file.PluginData = 666; // redundant, just for show
     file.IsLink = 0;
-    file.IconOverlayIndex = ICONOVERLAYINDEX_NOTUSED; // none icon-overlay
+    file.IconOverlayIndex = ICONOVERLAYINDEX_NOTUSED; // no icon overlay
 
-    // zmeni data adresare "test" (vytvoren automaticky, viz predchozi AddFile) na 'file'
+    // change the data of the "test" directory (created automatically, see the previous AddFile) to 'file'
     if (!dir->AddDir("", file, pluginData))
     {
         SalamanderGeneral->Free(file.Name);
@@ -265,10 +265,10 @@ CPluginInterfaceForArchiver::UnpackArchive(CSalamanderForOperationsAbstract* sal
     SalamanderGeneral->ShowMessageBox("CPluginInterfaceForArchiver::UnpackArchive", LoadStr(IDS_PLUGINNAME), MSGBOX_INFO);
 #endif // DEMOPLUG_QUIET
 
-    // interni pakovace nejspis pouziji metodu salCalls->SafeCreateFile pro prime
-    //   vypakovavani
-    // pro ostatni je zde zpusob s vypakovanim do docasneho adresare a nasledny
-    //   presun na spravnou pozici na disku (resi prepisy souboru, atd.):
+    // internal packers will probably use salCalls->SafeCreateFile for direct
+    //   extraction
+    // for the rest there is an approach that unpacks to a temporary directory and then
+    //   moves the files to the correct location on disk (handles overwriting files, etc.):
 
     BOOL ret = FALSE;
     char tmpExtractDir[MAX_PATH];
@@ -290,17 +290,17 @@ CPluginInterfaceForArchiver::UnpackArchive(CSalamanderForOperationsAbstract* sal
         {
             totalSize += size;
 
-            // vytvareni listu souboru, ktery se maji vypakovat
+            // building the list of files that should be extracted
         }
 
-        /*  // zopakujeme enumeraci (jen tak, ukazka "resetu" enumerace)
+        /*  // repeat the enumeration (just as a demonstration of "resetting" the enumeration)
     totalSize = 0;
     next(NULL, -1, NULL, NULL, NULL, nextParam, NULL);
     while ((name = next(NULL, 0, &isDir, &size, &fileData, nextParam, NULL)) != NULL)
     {
       totalSize += size;
 
-      // vytvareni listu souboru, ktery se maji vypakovat
+      // building the list of files that should be extracted
     }
 */
 
@@ -309,64 +309,64 @@ CPluginInterfaceForArchiver::UnpackArchive(CSalamanderForOperationsAbstract* sal
                                              tmpExtractDir, totalSize, "Unpacking DemoPlug Archive"))
         {
             /*
-      // ukazka progress dialogu s jednim progress metrem
+      // demonstration of a progress dialog with a single progress bar
       salamander->OpenProgressDialog("Unpacking DemoPlug Archive", FALSE, NULL, FALSE);
       salamander->ProgressSetTotalSize(CQuadWord(30, 0), CQuadWord(-1, -1));
-      // provedeni rozpakovani - prubezne se volaji nasl. metody:
-      salamander->ProgressDialogAddText("preparing data...", FALSE); // delayedPaint==FALSE, protoze nechceme cekat na timer a navic nebudeme volat ProgressAddSize
-      Sleep(1000);  // simulace cinosti
+      // performing the extraction - the following methods are called sequentially:
+      salamander->ProgressDialogAddText("preparing data...", FALSE); // delayedPaint==FALSE because we do not want to wait for the timer and we are not going to call ProgressAddSize
+      Sleep(1000);  // activity simulation
       ret = TRUE;
       int c = 30;
       while (c--)
       {
-        salamander->ProgressDialogAddText("test text", TRUE);  // delayedPaint==TRUE, abychom nebrzdili
-        Sleep(50);  // simulace cinnosti
-        if (!salamander->ProgressAddSize(1, TRUE))  // delayedPaint==TRUE, abychom nebrzdili
+        salamander->ProgressDialogAddText("test text", TRUE);  // delayedPaint==TRUE so that we do not slow the UI down
+        Sleep(50);  // activity simulation
+        if (!salamander->ProgressAddSize(1, TRUE))  // delayedPaint==TRUE so that we do not slow the UI down
         {
           salamander->ProgressDialogAddText("canceling operation, please wait...", FALSE);
           salamander->ProgressEnableCancel(FALSE);
-          Sleep(1000);  // simulace uklizeci cinosti
+          Sleep(1000);  // cleanup simulation
           ret = FALSE;
-          break;   // preruseni akce
+          break;   // cancel the action
         }
       }
-      Sleep(500);  // simulace cinosti
+      Sleep(500);  // activity simulation
       salamander->CloseProgressDialog();
 */
 
-            // ukazka progress dialogu s dvema progress metry
+            // demonstration of a progress dialog with two progress bars
             salamander->OpenProgressDialog("Unpacking DemoPlug Archive", TRUE, NULL, FALSE);
             salamander->ProgressSetTotalSize(CQuadWord(30, 0), CQuadWord(90, 0));
-            // provedeni rozpakovani - prubezne se volaji nasl. metody:
-            salamander->ProgressDialogAddText("preparing data...", FALSE); // delayedPaint==FALSE, protoze nechceme cekat na timer a navic nebudeme volat ProgressAddSize
-            Sleep(1000);                                                   // simulace cinosti
+            // performing the extraction - the following methods are called repeatedly:
+            salamander->ProgressDialogAddText("preparing data...", FALSE); // delayedPaint==FALSE because we do not want to wait for the timer and we are not going to call ProgressAddSize
+            Sleep(1000);                                                   // activity simulation
             ret = TRUE;
             int c = 90;
             while (c--)
             {
-                salamander->ProgressDialogAddText("test text", TRUE); // delayedPaint==TRUE, abychom nebrzdili
-                Sleep(50);                                            // simulace cinnosti
-                if ((c + 1) % 30 == 0)                                // simulace "dalsi soubor"
+                salamander->ProgressDialogAddText("test text", TRUE); // delayedPaint==TRUE so that we do not slow the UI down
+                Sleep(50);                                            // activity simulation
+                if ((c + 1) % 30 == 0)                                // simulating "another file"
                 {
-                    // salamander->ProgressSetTotalSize(CQuadWord(30, 0), CQuadWord(-1, -1)); // nastaveni "velikosti" dalsiho souboru (zakomentovano, protoze tady je zbytecne, at se nenastavuje porad dokola 30)
-                    salamander->ProgressSetSize(CQuadWord(0, 0), CQuadWord(-1, -1), TRUE); // delayedPaint==TRUE, abychom nebrzdili
+                    // salamander->ProgressSetTotalSize(CQuadWord(30, 0), CQuadWord(-1, -1)); // configuring the "size" of the next file (commented out here so it is not repeatedly set to 30)
+                    salamander->ProgressSetSize(CQuadWord(0, 0), CQuadWord(-1, -1), TRUE); // delayedPaint==TRUE so that we do not slow the UI down
                 }
-                if (!salamander->ProgressAddSize(1, TRUE)) // delayedPaint==TRUE, abychom nebrzdili
+                if (!salamander->ProgressAddSize(1, TRUE)) // delayedPaint==TRUE so that we do not slow the UI down
                 {
                     salamander->ProgressDialogAddText("canceling operation, please wait...", FALSE);
                     salamander->ProgressEnableCancel(FALSE);
-                    Sleep(1000); // simulace uklizeci cinosti
+                    Sleep(1000); // cleanup simulation
                     ret = FALSE;
-                    break; // preruseni akce
+                    break; // cancel the action
                 }
             }
-            Sleep(500); // simulace cinosti
+            Sleep(500); // activity simulation
             salamander->CloseProgressDialog();
 
-            // ret je pri uspechu TRUE, jinak zustava FALSE
+            // ret is TRUE on success; otherwise it remains FALSE
             if (ret)
             {
-                // soubory jsou vybalene v tmp-adresari, je treba je umistit
+                // the files are unpacked in the temporary directory and must be placed
                 if (!salamander->MoveFiles(tmpExtractDir, targetDir, tmpExtractDir, fileName))
                     delTempDir = FALSE;
             }
@@ -398,9 +398,9 @@ CPluginInterfaceForArchiver::UnpackOneFile(CSalamanderForOperationsAbstract* sal
         return FALSE;
     }
 
-    // rozpakovani bez progress dialogu
+    // unpacking without a progress dialog
 
-    // misto rozpakovani jen vytvorime pokusny soubor
+    // instead of unpacking we only create a test file
     char name[MAX_PATH];
     strcpy(name, targetDir);
     const char* lastComp = strrchr(nameInArchive, '\\');
@@ -420,7 +420,7 @@ CPluginInterfaceForArchiver::UnpackOneFile(CSalamanderForOperationsAbstract* sal
             ULONG written;
             WriteFile(file, "New File\r\n", 10, &written, NULL);
             HANDLES(CloseHandle(file));
-            return TRUE; // "rozpakovani" se povedlo
+            return TRUE; // the "unpacking" succeeded
         }
     }
 
@@ -456,17 +456,17 @@ CPluginInterfaceForArchiver::PackToArchive(CSalamanderForOperationsAbstract* sal
     while ((name = next(SalamanderGeneral->GetMsgBoxParent(), 3, &dosName, &isDir, &size,
                         &attr, &lastWrite, nextParam, &errorOccured)) != NULL)
     {
-        if (errorOccured == SALENUM_ERROR) // sem SALENUM_CANCEL prijit nemuze
+        if (errorOccured == SALENUM_ERROR) // SALENUM_CANCEL cannot appear here
             TRACE_I("Not all files and directories from disk will be packed.");
 
         totalSize += size;
 
-        // vytvareni listu souboru, ktery se maji zapakovat
+        // building the list of files that should be packed
     }
     if (errorOccured != SALENUM_SUCCESS)
     {
         TRACE_I("Not all files and directories from disk will be packed.");
-        // test, jestli nenastala chyba a uzivatel si nepral prerusit operaci (tlacitko Cancel)
+        // check whether an error occurred and the user requested to cancel the operation (Cancel button)
         if (errorOccured == SALENUM_CANCEL)
         {
             salamander->CloseProgressDialog();
@@ -491,25 +491,25 @@ CPluginInterfaceForArchiver::PackToArchive(CSalamanderForOperationsAbstract* sal
     {
         salamander->ProgressSetTotalSize(CQuadWord(100, 0) /*totalSize*/, CQuadWord(-1, -1));
 
-        // provedeni pakovani
+        // perform the packing
         salamander->ProgressDialogAddText("test text 1", FALSE);
-        Sleep(500); // simulace cinosti
+        Sleep(500); // activity simulation
         if (!salamander->ProgressAddSize(50, FALSE))
-            ret = FALSE; // break;   // preruseni akce
+            ret = FALSE; // cancel the action
         else
         {
             salamander->ProgressDialogAddText("test text 2", FALSE);
-            Sleep(500); // simulace cinosti
+            Sleep(500); // activity simulation
             if (!salamander->ProgressAddSize(50, FALSE))
-                ret = FALSE; // break;   // preruseni akce
+                ret = FALSE; // cancel the action
             else
                 ret = TRUE;
         }
-        // ret je pri uspechu TRUE, jinak zustava FALSE
+        // ret is TRUE on success; otherwise it remains FALSE
     }
     salamander->CloseProgressDialog();
 
-    // POZOR: nezapomenout nastavit Archive atribut souboru (zmena souboru archivu -> je treba ho oznacit pro backup)
+    // NOTE: do not forget to set the Archive attribute on the file (the archive file changed -> it must be marked for backup)
 
     return ret;
 }
@@ -539,30 +539,30 @@ CPluginInterfaceForArchiver::DeleteFromArchive(CSalamanderForOperationsAbstract*
     {
         totalSize += size;
 
-        // vytvareni listu souboru, ktery se maji smazat
+        // building the list of files that should be deleted
     }
 
     salamander->ProgressSetTotalSize(CQuadWord(100, 0) /*totalSize*/, CQuadWord(-1, -1));
 
-    // provedeni mazani
+    // perform the deletion
     salamander->ProgressDialogAddText("test text 1", FALSE);
-    Sleep(500); // simulace cinosti
+    Sleep(500); // activity simulation
     if (!salamander->ProgressAddSize(50, FALSE))
-        ret = FALSE; // break;   // preruseni akce
+        ret = FALSE; // cancel the action
     else
     {
         salamander->ProgressDialogAddText("test text 2", FALSE);
-        Sleep(500); // simulace cinosti
+        Sleep(500); // activity simulation
         if (!salamander->ProgressAddSize(50, FALSE))
-            ret = FALSE; // break;   // preruseni akce
+            ret = FALSE; // cancel the action
         else
             ret = TRUE;
     }
-    // ret je pri uspechu TRUE, jinak zustava FALSE
+    // ret is TRUE on success; otherwise it remains FALSE
 
     salamander->CloseProgressDialog();
 
-    // POZOR: nezapomenout nastavit Archive atribut souboru (zmena souboru archivu -> je treba ho oznacit pro backup)
+    // NOTE: do not forget to set the Archive attribute on the file (the archive file changed -> it must be marked for backup)
 
     return ret;
 }
@@ -623,25 +623,25 @@ CPluginInterfaceForArchiver::UnpackWholeArchive(CSalamanderForOperationsAbstract
 
     BOOL ret = FALSE;
     if (delArchiveWhenDone)
-        archiveVolumes->Add(fileName, -2); // FIXME: az plugin doucime multi-volume archivy, musime sem napridavat vsechny svazky archivu (aby se smazal kompletni archiv)
+        archiveVolumes->Add(fileName, -2); // FIXME: once the plugin learns multi-volume archives we must add all archive volumes here (to delete the entire archive)
     salamander->OpenProgressDialog("Unpacking DemoPlug Archive", FALSE, NULL, FALSE);
     salamander->ProgressSetTotalSize(CQuadWord(100, 0), CQuadWord(-1, -1));
 
-    // provedeni rozpakovani
+    // perform the unpacking
     salamander->ProgressDialogAddText("test text 1", FALSE);
-    Sleep(500); // simulace cinosti
+    Sleep(500); // activity simulation
     if (!salamander->ProgressAddSize(50, FALSE))
-        ret = FALSE; // break;   // preruseni akce
+        ret = FALSE; // cancel the action
     else
     {
         salamander->ProgressDialogAddText("test text 2", FALSE);
-        Sleep(500); // simulace cinosti
+        Sleep(500); // activity simulation
         if (!salamander->ProgressAddSize(50, FALSE))
-            ret = FALSE; // break;   // preruseni akce
+            ret = FALSE; // cancel the action
         else
             ret = TRUE;
     }
-    // ret je pri uspechu TRUE, jinak zustava FALSE
+    // ret is TRUE on success; otherwise it remains FALSE
 
     salamander->CloseProgressDialog();
 
@@ -659,7 +659,7 @@ CPluginInterfaceForArchiver::CanCloseArchive(CSalamanderForOperationsAbstract* s
 #else  // DEMOPLUG_QUIET
 
     if (SalamanderGeneral->IsCriticalShutdown())
-        return TRUE; // pri critical shutdown se na nic neptame
+        return TRUE; // during a critical shutdown we do not ask any questions
 
     return force && SalamanderGeneral->ShowMessageBox("CPluginInterfaceForArchiver::CanCloseArchive (can close).\n"
                                                       "Return is forced to TRUE.",
@@ -697,7 +697,7 @@ CPluginInterfaceForArchiver::GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL*
     if (tempPath[0] == 0 ||
         !SalamanderGeneral->SalPathAppend(tempPath, "DemoPlug Temporary Copies", MAX_PATH))
     {
-        tempPath[0] = 0; // chyba -> jdeme do systemoveho TEMPu
+        tempPath[0] = 0; // error -> fall back to the system TEMP
     }
     *ownDelete = TRUE;
     *cacheCopies = FALSE;
@@ -713,7 +713,7 @@ void ClearTEMPIfNeeded(HWND parent)
     {
         SalamanderGeneral->SalPathAddBackslash(tmpDir, 2 * MAX_PATH);
         char* tmpDirEnd = tmpDir + strlen(tmpDir);
-        // pridame masku (nevejde se = nema smysl nic hledat)
+        // add the mask (if it does not fit, there is no point in searching)
         if (SalamanderGeneral->SalPathAppend(tmpDir, "SAL*.tmp", 2 * MAX_PATH))
         {
             TIndirectArray<char> tmpDirs(10, 50);
@@ -723,14 +723,14 @@ void ClearTEMPIfNeeded(HWND parent)
             if (find != INVALID_HANDLE_VALUE)
             {
                 do
-                { // zpracujeme vsechny nalezene adresare (chyby hledani ignorujeme)
+                { // process all found directories (ignore search errors)
                     if ((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && strlen(data.cFileName) > 3)
                     {
                         char* s = data.cFileName + 3;
                         while (*s != 0 && *s != '.' &&
                                (*s >= '0' && *s <= '9' || *s >= 'a' && *s <= 'f' || *s >= 'A' && *s <= 'F'))
                             s++;
-                        if (SalamanderGeneral->StrICmp(s, ".tmp") == 0) // odpovida "SAL" + hex-cislo + ".tmp" = je temer jiste nas adresar
+                        if (SalamanderGeneral->StrICmp(s, ".tmp") == 0) // matches "SAL" + hex number + ".tmp" = almost certainly our directory
                         {
                             char* tmp = SalamanderGeneral->DupStr(data.cFileName);
                             if (tmp != NULL)
@@ -797,10 +797,9 @@ CPluginInterfaceForArchiver::DeleteTmpCopy(const char* fileName, BOOL firstFile)
     CALL_STACK_MESSAGE3("CPluginInterfaceForArchiver::DeleteTmpCopy(%s, %d)", fileName, firstFile);
 
     /*
-  // test messageboxu (messageboxy pouzivat jen v krajnim pripade) - dela bordel
-  // v pripade, ze ma nektery plugin otevreny nejaky vlastni modalni dialog (kosmeticke
-  // vady: messagebox k tomuto dialogu neni modalni a po svem zavreni aktivuje
-  // parenta dialogu)
+  // message box test (message boxes should be used only in an extreme situation) - it makes a mess
+  // if another plugin has its own modal dialog open (cosmetic issue: the message box for this dialog is not modal
+  // and after closing it activates the dialog's parent)
   char buf[500];
   sprintf(buf, "File \"%s\" will be deleted.", fileName);
   SalamanderGeneral->SalMessageBox(SalamanderGeneral->GetMsgBoxParent(),
@@ -808,32 +807,32 @@ CPluginInterfaceForArchiver::DeleteTmpCopy(const char* fileName, BOOL firstFile)
                                    MB_OK | MB_ICONINFORMATION);
 */
 
-    // je-li critical shutdown, neni vhodna doba na pomale mazani souboru (brzo nas proces zabiji),
-    // pri prvnim dalsim startu pluginu v prvnim spustenem Salamanderovi se to smaze "v klidu",
-    // nic lepsiho asi nevymyslime
+    // if this is a critical shutdown it is not a good time for slow file deletion (our process will be killed soon),
+    // at the first subsequent plugin start in the first Salamander instance this will be deleted "calmly",
+    // we probably cannot come up with anything better
     if (SalamanderGeneral->IsCriticalShutdown())
         return;
 
-    // ukazka pouziti wait-okenka
-    static DWORD ti = 0; // cas zacatku mazani prvniho souboru z rady (pri vice najednou mazanych souborech)
+    // demonstration of using the wait window
+    static DWORD ti = 0; // time when deletion of the first file in the batch started (when deleting multiple files at once)
     DWORD showTime = 1000;
     if (firstFile)
-        ti = GetTickCount(); // zajistime, aby se wait-okno ukazovalo po jedne sekunde v ramci vsech mazani
+        ti = GetTickCount(); // ensure that the wait window shows up after one second across the entire deletion batch
     else
     {
-        DWORD work = GetTickCount() - ti; // jak dlouho uz se maze (od mazani prvniho souboru z rady)
+        DWORD work = GetTickCount() - ti; // how long the deletion has been running (since the first file in the batch)
         if (work < 1000)
             showTime -= work;
         else
             showTime = 0;
     }
     SalamanderGeneral->CreateSafeWaitWindow("Deleting temporary file unpacked from archive, please wait...",
-                                            LoadStr(IDS_PLUGINNAME), showTime, FALSE /* TRUE pokud umime cinnost prerusit */,
+                                            LoadStr(IDS_PLUGINNAME), showTime, FALSE /* TRUE if we can cancel the operation */,
                                             SalamanderGeneral->GetMsgBoxParent());
-    // simulace cinnosti (okenko je videt az po 1 sekunde)
+    // activity simulation (the window becomes visible after one second)
     Sleep(2000);
 
-    // obycejne mazani souboru
+    // regular file deletion
     SalamanderGeneral->ClearReadOnlyAttr(fileName);
 
     if (DeleteFile(fileName))
@@ -841,7 +840,7 @@ CPluginInterfaceForArchiver::DeleteTmpCopy(const char* fileName, BOOL firstFile)
     else
         TRACE_I("Unable to delete temporary copy from disk-cache (" << fileName << ").");
 
-    // zavreme wait-okenko, akce skoncila
+    // close the wait window; the action finished
     SalamanderGeneral->DestroySafeWaitWindow();
 }
 
@@ -850,11 +849,11 @@ CPluginInterfaceForArchiver::PrematureDeleteTmpCopy(HWND parent, int copiesCount
 {
     CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::PrematureDeleteTmpCopy(, %d)", copiesCount);
 
-    // je-li critical shutdown, neni vhodna doba na pomale mazani souboru (brzo nas proces zabiji),
-    // pri prvnim dalsim startu pluginu v prvnim spustenem Salamanderovi se to smaze "v klidu",
-    // nic lepsiho asi nevymyslime
+    // if this is a critical shutdown it is not a good time for slow file deletion (our process will be killed soon),
+    // at the first subsequent plugin start in the first Salamander instance this will be deleted "calmly",
+    // we probably cannot come up with anything better
     if (SalamanderGeneral->IsCriticalShutdown())
-        return FALSE; // pri critical shutdown se na nic neptame
+        return FALSE; // during a critical shutdown we do not ask any questions
 
     char buf[500];
     sprintf(buf, "%d temporary file(s) extracted from archive are still in use.\n"

--- a/src/plugins/demoplug/demoplug.h
+++ b/src/plugins/demoplug/demoplug.h
@@ -11,24 +11,24 @@
 
 #pragma once
 
-// je-li DEMOPLUG_QUIET definovano, setri se dotazy v message-boxech
+// if DEMOPLUG_QUIET is defined, keep message-box prompts to a minimum
 #define DEMOPLUG_QUIET
 
-// je-li ENABLE_DYNAMICMENUEXT definovano, nepridavaji se polozky do menu
-// v CPluginInterface::Connect (vola se jen jednou pri loadu pluginu),
-// ale opakovane pred kazdym otevrenim menu, viz FUNCTION_DYNAMICMENUEXT
-// (umoznuje pluginu menit dynamicky menu podle aktualnich potreb)
+// if ENABLE_DYNAMICMENUEXT is defined, menu items are not added
+// in CPluginInterface::Connect (called only once when the plugin loads),
+// but repeatedly before each menu is opened, see FUNCTION_DYNAMICMENUEXT
+// (lets the plugin change the menu dynamically based on current needs)
 //#define ENABLE_DYNAMICMENUEXT
 
-// globalni data
-extern const char* PluginNameEN; // neprekladane jmeno pluginu, pouziti pred loadem jazykoveho modulu + pro debug veci
-extern HINSTANCE DLLInstance;    // handle k SPL-ku - jazykove nezavisle resourcy
-extern HINSTANCE HLanguage;      // handle k SLG-cku - jazykove zavisle resourcy
+// global data
+extern const char* PluginNameEN; // untranslated plugin name, used before the language module loads and for debug purposes
+extern HINSTANCE DLLInstance;    // handle to the SPL - language-independent resources
+extern HINSTANCE HLanguage;      // handle to the SLG - language-dependent resources
 
-// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+// general Salamander interface - valid from startup until the plugin terminates
 extern CSalamanderGeneralAbstract* SalamanderGeneral;
 
-// rozhrani poskytujici upravene Windows controly pouzivane v Salamanderovi
+// interface providing customized Windows controls used in Salamander
 extern CSalamanderGUIAbstract* SalamanderGUI;
 
 BOOL InitViewer();
@@ -37,20 +37,20 @@ void ReleaseViewer();
 BOOL InitFS();
 void ReleaseFS();
 
-// FS-name pridelene Salamanderem po loadu pluginu
+// FS name assigned by Salamander after the plugin loads
 extern char AssignedFSName[MAX_PATH];
 extern int AssignedFSNameLen;
 
-// vyvolava se pro prvni instanci DEMOPLUGu: pripadny vymaz vlastniho tmp-diru
-// s kopiemi souboru vybalenymi z archivu predchozimi instancemi DEMOPLUGu
+// invoked for the first instance of DEMOPLUG: optional cleanup of its own temp directory
+// with file copies extracted from archives by previous DEMOPLUG instances
 void ClearTEMPIfNeeded(HWND parent);
 
-// ukazatele na tabulky mapovani na mala/velka pismena
+// pointers to tables for lower/upper case mapping
 extern unsigned char* LowerCase;
 extern unsigned char* UpperCase;
 
-// globalni promenne, do ktery si ulozim ukazatele na globalni promenne v Salamanderovi
-// pro archiv i pro FS - promenne se sdileji
+// global variables used to store pointers to Salamander's global variables
+// shared between the archiver and the FS
 extern const CFileData** TransferFileData;
 extern int* TransferIsDir;
 extern char* TransferBuffer;
@@ -59,40 +59,40 @@ extern DWORD* TransferRowData;
 extern CPluginDataInterfaceAbstract** TransferPluginDataIface;
 extern DWORD* TransferActCustomData;
 
-// globalni data
+// global data
 extern char Str[MAX_PATH];
 extern int Number;
-extern int Selection; // "second" in configuration dialog
+extern int Selection; // "second" option in the configuration dialog
 extern BOOL CheckBox;
 extern int RadioBox;                       // radio 2 in configuration dialog
-extern BOOL CfgSavePosition;               // ukladat pozici okna/umistit dle hlavniho okna
-extern WINDOWPLACEMENT CfgWindowPlacement; // neplatne, pokud CfgSavePosition != TRUE
-extern int Size2FixedWidth;                // sloupec Size2 (archiver): LO/HI-WORD: levy/pravy panel: FixedWidth
-extern int Size2Width;                     // sloupec Size2 (archiver): LO/HI-WORD: levy/pravy panel: Width
-extern int CreatedFixedWidth;              // sloupec Created (FS): LO/HI-WORD: levy/pravy panel: FixedWidth
-extern int CreatedWidth;                   // sloupec Created (FS): LO/HI-WORD: levy/pravy panel: Width
-extern int ModifiedFixedWidth;             // sloupec Modified (FS): LO/HI-WORD: levy/pravy panel: FixedWidth
-extern int ModifiedWidth;                  // sloupec Modified (FS): LO/HI-WORD: levy/pravy panel: Width
-extern int AccessedFixedWidth;             // sloupec Accessed (FS): LO/HI-WORD: levy/pravy panel: FixedWidth
-extern int AccessedWidth;                  // sloupec Accessed (FS): LO/HI-WORD: levy/pravy panel: Width
-extern int DFSTypeFixedWidth;              // sloupec DFS Type (FS): LO/HI-WORD: levy/pravy panel: FixedWidth
-extern int DFSTypeWidth;                   // sloupec DFS Type (FS): LO/HI-WORD: levy/pravy panel: Width
+extern BOOL CfgSavePosition;               // save the window position/place it according to the main window
+extern WINDOWPLACEMENT CfgWindowPlacement; // invalid when CfgSavePosition != TRUE
+extern int Size2FixedWidth;                // Size2 column (archiver): LOW/HIGH WORD: left/right panel: FixedWidth
+extern int Size2Width;                     // Size2 column (archiver): LOW/HIGH WORD: left/right panel: Width
+extern int CreatedFixedWidth;              // Created column (FS): LOW/HIGH WORD: left/right panel: FixedWidth
+extern int CreatedWidth;                   // Created column (FS): LOW/HIGH WORD: left/right panel: Width
+extern int ModifiedFixedWidth;             // Modified column (FS): LOW/HIGH WORD: left/right panel: FixedWidth
+extern int ModifiedWidth;                  // Modified column (FS): LOW/HIGH WORD: left/right panel: Width
+extern int AccessedFixedWidth;             // Accessed column (FS): LOW/HIGH WORD: left/right panel: FixedWidth
+extern int AccessedWidth;                  // Accessed column (FS): LOW/HIGH WORD: left/right panel: Width
+extern int DFSTypeFixedWidth;              // DFS Type column (FS): LOW/HIGH WORD: left/right panel: FixedWidth
+extern int DFSTypeWidth;                   // DFS Type column (FS): LOW/HIGH WORD: left/right panel: Width
 
-extern DWORD LastCfgPage; // start page (sheet) in configuration dialog
+extern DWORD LastCfgPage; // start page (sheet) in the configuration dialog
 
-// image-list pro jednoduche ikony FS
+// image list for simple FS icons
 extern HIMAGELIST DFSImageList;
 
-// [0, 0] - pro otevrena okna viewru: konfigurace pluginu se zmenila
+// [0, 0] - for open viewer windows: plugin configuration has changed
 #define WM_USER_VIEWERCFGCHNG WM_APP + 3246
-// [0, 0] - pro otevrena okna viewru: je treba podriznou historie
+// [0, 0] - for open viewer windows: history needs to be trimmed
 #define WM_USER_CLEARHISTORY WM_APP + 3247
-// [0, 0] - pro otevrena okna vieweru: Salamander pregeneroval fonty, mame zavolat SetFont() listam
+// [0, 0] - for open viewer windows: Salamander regenerated fonts, call SetFont() for the lists
 #define WM_USER_SETTINGCHANGE WM_APP + 3248
 
 char* LoadStr(int resID);
 
-// prikazy pluginoveho menu
+// plugin menu commands
 #define MENUCMD_ALWAYS 1
 #define MENUCMD_DIR 2
 #define MENUCMD_ARCFILE 3
@@ -107,7 +107,7 @@ char* LoadStr(int resID);
 #define MENUCMD_SHOWCONTROLS 12
 #define MENUCMD_SEP 13
 #define MENUCMD_HIDDENITEM 14
-#define MENUCMD_CHECKDEMOPLUGTMPDIR 15 // prvni instance DEMOPLUGu: pripadny vymaz vlastniho tmp-diru s kopiemi souboru vybalenymi z archivu predchozimi instancemi DEMOPLUGu
+#define MENUCMD_CHECKDEMOPLUGTMPDIR 15 // first DEMOPLUG instance: optionally clean its temp dir with files unpacked by previous instances
 #define MENUCMD_DISCONNECT_LEFT 16
 #define MENUCMD_DISCONNECT_RIGHT 17
 #define MENUCMD_DISCONNECT_ACTIVE 18
@@ -126,12 +126,12 @@ public:
 
     virtual void WINAPI GetFileDataForUpDir(const char* archivePath, CFileData& upDir)
     {
-        // zadna vlastni data plugin v CFileData nema, takze neni potreba nic menit/alokovat
+        // the plugin stores no custom data in CFileData, so nothing needs to change or be allocated
     }
     virtual BOOL WINAPI GetFileDataForNewDir(const char* dirName, CFileData& dir)
     {
-        // zadna vlastni data plugin v CFileData nema, takze neni potreba nic menit/alokovat
-        return TRUE; // vracime uspech
+        // the plugin stores no custom data in CFileData, so nothing needs to change or be allocated
+        return TRUE; // report success
     }
 
     virtual HIMAGELIST WINAPI GetSimplePluginIcons(int iconSize) { return NULL; }
@@ -221,7 +221,7 @@ public:
 class CPluginInterfaceForFS : public CPluginInterfaceForFSAbstract
 {
 protected:
-    int ActiveFSCount; // pocet aktivnich FS interfacu (jen pro kontrolu dealokace)
+    int ActiveFSCount; // number of active FS interfaces (only to verify deallocation)
 
 public:
     CPluginInterfaceForFS() { ActiveFSCount = 0; }
@@ -322,29 +322,29 @@ protected:
 class CViewerWindow : public CWindow
 {
 public:
-    HANDLE Lock;                      // 'lock' objekt nebo NULL (do signaled stavu az zavreme soubor)
-    char Name[MAX_PATH];              // jmeno souboru nebo ""
-    CRendererWindow Renderer;         // vnitrni okno vieweru
-    HIMAGELIST HGrayToolBarImageList; // toolbar a menu v sedivem provedeni (pocitano z barevneho)
-    HIMAGELIST HHotToolBarImageList;  // toolbar a menu v barevnem provedeni
+    HANDLE Lock;                      // 'lock' object or NULL (set to the signaled state after the file is closed)
+    char Name[MAX_PATH];              // file name or ""
+    CRendererWindow Renderer;         // inner viewer window
+    HIMAGELIST HGrayToolBarImageList; // toolbar and menu in the gray variant (computed from the colored one)
+    HIMAGELIST HHotToolBarImageList;  // toolbar and menu in the colored variant
 
     DWORD Enablers[vweCount];
 
-    HWND HRebar; // drzi MenuBar a ToolBar
+    HWND HRebar; // holds the menu bar and toolbar
     CGUIMenuPopupAbstract* MainMenu;
     CGUIMenuBarAbstract* MenuBar;
     CGUIToolBarAbstract* ToolBar;
 
-    int EnumFilesSourceUID;    // UID zdroje pro enumeraci souboru ve vieweru
-    int EnumFilesCurrentIndex; // index aktualniho souboru ve vieweru ve zdroji
+    int EnumFilesSourceUID;    // source UID for enumerating files in the viewer
+    int EnumFilesCurrentIndex; // index of the current viewer file within the source
 
 public:
     CViewerWindow(int enumFilesSourceUID, int enumFilesCurrentIndex);
 
     HANDLE GetLock();
 
-    // je-li 'setLock' TRUE, dojde k nastaveni 'Lock' do signaled stavu (je
-    // potreba po zavreni souboru)
+    // if 'setLock' is TRUE, set 'Lock' to the signaled state (it is
+    // needed after closing the file)
     void OpenFile(const char* name, BOOL setLock = TRUE);
 
     BOOL IsMenuBarMessage(CONST MSG* lpMsg);
@@ -365,8 +365,8 @@ protected:
     void UpdateEnablers();
 };
 
-extern CWindowQueue ViewerWindowQueue; // seznam vsech oken viewru
-extern CThreadQueue ThreadQueue;       // seznam vsech threadu oken
+extern CWindowQueue ViewerWindowQueue; // list of all viewer windows
+extern CThreadQueue ThreadQueue;       // list of all window threads
 
 //
 // ****************************************************************************
@@ -377,7 +377,7 @@ extern CThreadQueue ThreadQueue;       // seznam vsech threadu oken
 // ****************************************************************************
 // CConnectData
 //
-// struktura pro predani dat z "Connect" dialogu do nove vytvoreneho FS
+// structure for passing data from the "Connect" dialog to a newly created FS
 
 struct CConnectData
 {
@@ -391,24 +391,24 @@ struct CConnectData
     }
 };
 
-// struktura pro predani dat z "Connect" dialogu do nove vytvoreneho FS
+// structure for passing data from the "Connect" dialog to a newly created FS
 extern CConnectData ConnectData;
 
 //
 // ****************************************************************************
 // CDeleteProgressDlg
 //
-// ukazka vlastniho progress dialogu pro operaci Delete na FS
+// example of a custom progress dialog for the Delete operation on the FS
 
 class CDeleteProgressDlg : public CCommonDialog
 {
 protected:
     CGUIProgressBarAbstract* ProgressBar;
-    BOOL WantCancel; // TRUE pokud uzivatel chce Cancel
+    BOOL WantCancel; // TRUE if the user wants to cancel
 
-    // protoze dialog nebezi ve vlastnim threadu, je zbytecne pouzivat WM_TIMER
-    // metodu; stejna nas musi zavolat pro vypumpovani message queue
-    DWORD LastTickCount; // pro detekci ze uz je treba prekreslit zmenena data
+    // because the dialog does not run in its own thread, using a WM_TIMER method is pointless
+    // the caller must invoke us anyway to pump the message queue
+    DWORD LastTickCount; // to detect when changed data needs to be repainted
 
     char TextCache[MAX_PATH];
     BOOL TextCacheIsDirty;
@@ -420,8 +420,8 @@ public:
 
     void Set(const char* fileName, DWORD progress, BOOL dalayedPaint);
 
-    // vyprazdni message queue (volat dostatecne casto) a umozni prekreslit, stisknout Cancel...
-    // vraci TRUE, pokud uzivatel chce prerusit operaci
+    // empties the message queue (call often enough) and allows repainting, handling Cancel, ...
+    // returns TRUE if the user wants to interrupt the operation
     BOOL GetWantCancel();
 
 protected:
@@ -455,8 +455,8 @@ struct CFSData
 class CPluginFSDataInterface : public CPluginDataInterfaceAbstract
 {
 protected:
-    char Path[MAX_PATH]; // buffer pro plne jmeno souboru/adresare pouzivane pri nacitani ikon
-    char* Name;          // ukazatel do Path za posledni backslash cesty (na jmeno)
+    char Path[MAX_PATH]; // buffer for the full file/directory name used when loading icons
+    char* Name;          // pointer within Path after the last backslash (to the name)
 
 public:
     CPluginFSDataInterface(const char* path);
@@ -501,18 +501,18 @@ public:
 //
 // CTopIndexMem
 //
-// pamet top-indexu listboxu v panelu - pouziva CPluginFSInterface pro korektni
-// chovani ExecuteOnFS (zachovani top-indexu po vstupu a vystupu z podadresare)
+// memory for the listbox top index in the panel - used by CPluginFSInterface for proper
+// ExecuteOnFS behavior (preserves the top index when entering and leaving subdirectories)
 
-#define TOP_INDEX_MEM_SIZE 50 // pocet pamatovanych top-indexu (urovni), minimalne 1
+#define TOP_INDEX_MEM_SIZE 50 // number of remembered top indexes (levels), at least 1
 
 class CTopIndexMem
 {
 protected:
-    // cesta pro posledni zapamatovany top-index
+    // path for the last remembered top index
     char Path[MAX_PATH];
-    int TopIndexes[TOP_INDEX_MEM_SIZE]; // zapamatovane top-indexy
-    int TopIndexesCount;                // pocet zapamatovanych top-indexu
+    int TopIndexes[TOP_INDEX_MEM_SIZE]; // stored top indexes
+    int TopIndexesCount;                // number of stored top indexes
 
 public:
     CTopIndexMem() { Clear(); }
@@ -520,25 +520,25 @@ public:
     {
         Path[0] = 0;
         TopIndexesCount = 0;
-    } // vycisti pamet
-    void Push(const char* path, int topIndex);        // uklada top-index pro danou cestu
-    BOOL FindAndPop(const char* path, int& topIndex); // hleda top-index pro danou cestu, FALSE->nenalezeno
+    } // clears the memory
+    void Push(const char* path, int topIndex);        // stores the top index for the given path
+    BOOL FindAndPop(const char* path, int& topIndex); // finds the top index for the given path, FALSE -> not found
 };
 
 //
 // ****************************************************************************
 // CPluginFSInterface
 //
-// sada metod pluginu, ktere potrebuje Salamander pro praci s file systemem
+// set of plugin methods required by Salamander to work with the file system
 
 class CPluginFSInterface : public CPluginFSInterfaceAbstract
 {
 public:
-    char Path[MAX_PATH];             // aktualni cesta
-    BOOL PathError;                  // TRUE pokud se nepovedla ListCurrentPath (path error), bude se volat ChangePath
-    BOOL FatalError;                 // TRUE pokud se nepovedla ListCurrentPath (fatal error), bude se volat ChangePath
-    CTopIndexMem TopIndexMem;        // pamet top-indexu pro ExecuteOnFS()
-    BOOL CalledFromDisconnectDialog; // TRUE = user chce disconnectnout toto FS z Disconnect dialogu (klavesa F12)
+    char Path[MAX_PATH];             // current path
+    BOOL PathError;                  // TRUE if ListCurrentPath failed (path error); ChangePath will be called
+    BOOL FatalError;                 // TRUE if ListCurrentPath failed (fatal error); ChangePath will be called
+    CTopIndexMem TopIndexMem;        // top-index cache used by ExecuteOnFS()
+    BOOL CalledFromDisconnectDialog; // TRUE = the user wants to disconnect this FS from the Disconnect dialog (F12)
 
 public:
     CPluginFSInterface();
@@ -608,17 +608,17 @@ public:
     virtual void WINAPI ShowSecurityInfo(HWND parent) {}
 };
 
-// spolecny interface pro pluginova data archivatoru
+// common interface for archiver plugin data
 extern CArcPluginDataInterface ArcPluginDataInterface;
 
-// pomocna promenna pro testy
+// helper variable for tests
 extern CPluginFSInterfaceAbstract* LastDetachedFS;
 
-// rozhrani pluginu poskytnute Salamanderovi
+// plugin interface provided to Salamander
 extern CPluginInterface PluginInterface;
 
-// otevre konfiguracni dialog; pokud jiz existuje, zobrazi hlasku a vrati se
+// opens the configuration dialog; if it already exists, shows a message and returns
 void OnConfiguration(HWND hParent);
 
-// otevre About okno
+// opens the About window
 void OnAbout(HWND hParent);

--- a/src/plugins/demoplug/dialogs.h
+++ b/src/plugins/demoplug/dialogs.h
@@ -15,7 +15,7 @@
 //
 // CCommonDialog
 //
-// Dialog centrovany k parentu
+// Dialog centered relative to the parent
 //
 
 class CCommonDialog : public CDialog
@@ -61,7 +61,7 @@ class CConfigPageFirst : public CCommonPropSheetPage
 public:
     CConfigPageFirst();
 
-    virtual void Validate(CTransferInfo& ti); // aby v pripade chyby neprobehla ani cast transferu dat
+    virtual void Validate(CTransferInfo& ti); // prevent any portion of the data transfer when an error occurs
     virtual void Transfer(CTransferInfo& ti);
 };
 
@@ -115,8 +115,8 @@ public:
 class CPathDialog : public CCommonDialog
 {
 public:
-    char* Path;     // odkaz na vnejsi buffer s cestou (in/out), min. MAX_PATH znaku
-    BOOL* FilePath; // odkaz na vnejsi BOOL hodnotu (in/out) - TRUE/FALSE - cesta k souboru/adresari
+    char* Path;     // pointer to an external path buffer (in/out), at least MAX_PATH characters
+    BOOL* FilePath; // pointer to an external BOOL value (in/out) - TRUE/FALSE - path to a file/directory
 
 public:
     CPathDialog(HWND parent, char* path, BOOL* filePath);

--- a/src/plugins/demoplug/precomp.cpp
+++ b/src/plugins/demoplug/precomp.cpp
@@ -11,9 +11,9 @@
 
 #include "precomp.h"
 
-// projekt DemoPlug obsahuje tri skupiny modulu
+// the DemoPlug project contains three groups of modules
 //
-// 1) modul precomp.cpp, ktery postavi demoplug.pch (/Yc"precomp.h")
-// 2) moduly vyuzivajici demoplug.pch (/Yu"precomp.h")
-// 3) commony maji vlastni, automaticky generovany WINDOWS.PCH
+// 1) module precomp.cpp, which builds demoplug.pch (/Yc"precomp.h")
+// 2) modules that use demoplug.pch (/Yu"precomp.h")
+// 3) the common sources have their own automatically generated WINDOWS.PCH
 //    (/YX"windows.h" /Fp"$(OutDir)\WINDOWS.PCH")


### PR DESCRIPTION
## Summary
- translate the DemoPlug core comments to English, covering plugin globals, initialization, and icon overlay notes
- clarify the FS connect dialog comments to English and document the sample icon handling
- update the archiver Size2 column description to an English phrase

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2350ffc2483228e54ba9364a3228c