### PR TITLE
regedt: translate remaining Czech comments

### DIFF
--- a/src/plugins/regedt/dialogs.cpp
+++ b/src/plugins/regedt/dialogs.cpp
@@ -10,10 +10,10 @@ BOOL MinBeepWhenDone;
 
 LPWSTR CopyOrMoveHistory[MAX_HISTORY_ENTRIES];
 
-HFONT EnvFont = NULL; // font prostredi (edit, toolbar, header, status)
-int EnvFontHeight;    // vyska fontu
+HFONT EnvFont = NULL; // environment font (edit, toolbar, header, status)
+int EnvFontHeight;    // font height
 
-//BOOL HaveForMicrosoftSanfSerif; // v systemu je nainstalovany font Microsoft Sans Serif
+//BOOL HaveForMicrosoftSanfSerif; // the system has the Microsoft Sans Serif font installed
 
 BOOL CreateEnvFont()
 {
@@ -28,11 +28,11 @@ BOOL CreateEnvFont()
     EnvFont = CreateFontIndirect(lf);
     if (EnvFont == NULL)
     {
-        TRACE_E("Font se nepovedl vytvorit.");
+        TRACE_E("Failed to create the font.");
         return FALSE;
     }
 
-    // zjistime si vysku
+    // determine the height
     HDC dc = GetDC(NULL);
     HFONT oldFont = (HFONT)SelectObject(dc, EnvFont);
     TEXTMETRIC tm;
@@ -181,7 +181,7 @@ void HistoryComboBox(CTransferInfoEx& ti, int id, LPWSTR text, int textMax,
 
         int toMove = historySize - 1;
 
-        // podivame jestli uz stejna polozka neni v historii
+        // check whether the same item is already in the history
         int i;
         for (i = 0; i < historySize; i++)
         {
@@ -195,17 +195,17 @@ void HistoryComboBox(CTransferInfoEx& ti, int id, LPWSTR text, int textMax,
                 break;
             }
         }
-        // alokujeme si pamet pro novou polozku
+        // allocate memory for the new entry
         LPWSTR ptr = new WCHAR[wcslen(text) + 1];
         if (ptr)
         {
-            // uvolnime pamet vymazavane polozky
+            // free the memory of the entry being deleted
             if (history[toMove])
                 delete[] history[toMove];
-            // vytvorime misto pro cestu kterou budeme ukladat
+            // make room for the path we are going to store
             for (i = toMove; i > 0; i--)
                 history[i] = history[i - 1];
-            // ulozime cestu
+            // store the path
             wcscpy(ptr, text);
             history[0] = ptr;
         }
@@ -280,8 +280,8 @@ BOOL CDialogEx::ValidateData()
             HWND wnd = GetFocus();
             while (wnd != NULL && wnd != ctrl)
                 wnd = GetParent(wnd);
-            if (wnd == NULL) // fokusime jen pokud neni ctrl predek GetFocusu
-            {                // jako napr. edit-line v combo-boxu
+            if (wnd == NULL) // focus only if the control is not an ancestor of GetFocus
+            {                // such as the edit line in a combo box
                 SendMessage(HWindow, WM_NEXTDLGCTL, (WPARAM)ctrl, TRUE);
             }
         }
@@ -304,8 +304,8 @@ BOOL CDialogEx::TransferData(CTransferType type)
             HWND wnd = GetFocus();
             while (wnd != NULL && wnd != ctrl)
                 wnd = GetParent(wnd);
-            if (wnd == NULL) // fokusime jen pokud neni ctrl predek GetFocusu
-            {                // jako napr. edit-line v combo-boxu
+            if (wnd == NULL) // focus only if the control is not an ancestor of GetFocus
+            {                // such as the edit line in a combo box
                 SendMessage(HWindow, WM_NEXTDLGCTL, (WPARAM)ctrl, TRUE);
             }
         }
@@ -327,8 +327,8 @@ CDialogEx::Execute()
                            (DLGPROC)CDialog::CDialogProc, (LPARAM)this);
     //  }
 
-    // nemame Microsoft Sans Serif musime ho v template vymenit
-    // za MS Shell Dlg
+    // if we don't have Microsoft Sans Serif we must replace it in the template
+    // with MS Shell Dlg
     /*
   DWORD size;
   LPDLGTEMPLATE templ = LoadDlgTemplate(ResID, size);
@@ -355,8 +355,8 @@ HWND CDialogEx::Create()
                               (DLGPROC)CDialog::CDialogProc, (LPARAM)this);
     //  }
 
-    // nemame Microsoft Sans Serif musime ho v template vymenit
-    // za MS Shell Dlg
+    // if we don't have Microsoft Sans Serif we must replace it in the template
+    // with MS Shell Dlg
     /*
   DWORD size;
   LPDLGTEMPLATE templ = LoadDlgTemplate(ResID, size);
@@ -478,7 +478,7 @@ void CNewValDialog::Transfer(CTransferInfoEx& ti)
             ti.ErrorOn(IDC_TYPE);
             return;
         }
-        *Type = (DWORD)SendMessage(combo, CB_GETITEMDATA, ret, 0); // x64 - Type je DWORD
+        *Type = (DWORD)SendMessage(combo, CB_GETITEMDATA, ret, 0); // x64 - Type is DWORD
     }
     CNewKeyDialog::Transfer(ti);
 }
@@ -503,7 +503,7 @@ void CEditValDialog::Validate(CTransferInfoEx& ti)
         ti.ErrorOn(IDC_TYPE);
         return;
     }
-    *Type = (DWORD)SendMessage(combo, CB_GETITEMDATA, ret, 0); // x64 - Type je DWORD
+    *Type = (DWORD)SendMessage(combo, CB_GETITEMDATA, ret, 0); // x64 - Type is DWORD
 
     if (*Type == REG_DWORD || *Type == REG_DWORD_BIG_ENDIAN || *Type == REG_QWORD)
     {
@@ -589,7 +589,7 @@ void CEditValDialog::Transfer(CTransferInfoEx& ti)
                 HexStringToNumber(buffer, d);
             else
                 DecStringToNumber(buffer, d);
-            if (*Type == REG_DWORD_BIG_ENDIAN) // otocime endiany
+            if (*Type == REG_DWORD_BIG_ENDIAN) // reverse the endianness
             {
                 d = d >> 24 | (d & 0x00FF0000) >> 8 | (d & 0x0000FF00) << 8 | (d & 0x000000FF) << 24;
             }
@@ -640,7 +640,7 @@ CEditValDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         wParam, lParam);
     switch (uMsg)
     {
-        /* j.r. pokud nastavime spravne tab-order, neni toto treba a navic bude edit selected
+        /* j.r. if we set the tab order correctly, this is not needed and the edit will be selected too
     case WM_INITDIALOG:
     {
       CNewValDialog::DialogProc(uMsg, wParam, lParam);
@@ -661,7 +661,7 @@ CEditValDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 int ret = (int)SendMessage(combo, CB_GETCURSEL, 0, 0);
                 if (ret == CB_ERR)
                     break;
-                *Type = (DWORD)SendMessage(combo, CB_GETITEMDATA, ret, 0); // x64 - Type je DWORD
+                *Type = (DWORD)SendMessage(combo, CB_GETITEMDATA, ret, 0); // x64 - Type is DWORD
 
                 DWORD show = *Type == REG_DWORD || *Type == REG_DWORD_BIG_ENDIAN || *Type == REG_QWORD ? SW_SHOW : SW_HIDE;
                 ShowWindow(GetDlgItem(HWindow, IDR_HEX), show);
@@ -698,7 +698,7 @@ CEditValDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 int ret = (int)SendMessage(combo, CB_GETCURSEL, 0, 0);
                 if (ret == CB_ERR)
                     break;
-                *Type = (DWORD)SendMessage(combo, CB_GETITEMDATA, ret, 0); // x64 - Type je DWORD
+                *Type = (DWORD)SendMessage(combo, CB_GETITEMDATA, ret, 0); // x64 - Type is DWORD
 
                 char buffer[21];
                 HWND dataHWnd = GetDlgItem(HWindow, IDE_DATA);
@@ -761,11 +761,11 @@ CEditValDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 BOOL CRawEditValDialog::ExportToTempFile()
 {
     CALL_STACK_MESSAGE1("CRawEditValDialog::ExportToTempFile()");
-    // uz je vyexportovany
+    // already exported
     if (*TempFile)
         return TRUE;
 
-    // vytvorime jmeno tmp soubor
+    // create a temp file name
     if (!SG->SalGetTempFileName(NULL, "SAL", TempDir, FALSE, NULL))
         return Error(IDS_CREATETEMP);
 
@@ -777,7 +777,7 @@ BOOL CRawEditValDialog::ExportToTempFile()
     TempFile[len + tlen] = 0;
     ReplaceUnsafeCharacters(TempFile + tlen);
 
-    // vytvorime/otevreme tmp soubor
+    // create/open the temp file
     HANDLE file = CreateFile(TempFile, GENERIC_WRITE, FILE_SHARE_READ, NULL,
                              CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (file == INVALID_HANDLE_VALUE)
@@ -805,7 +805,7 @@ BOOL CRawEditValDialog::ExportToTempFile()
 BOOL CRawEditValDialog::ImportFromTempFile()
 {
     CALL_STACK_MESSAGE1("CRawEditValDialog::ImportFromTempFile()");
-    // vytvorime/otevreme tmp soubor
+    // create/open the temp file
     HANDLE file = CreateFile(TempFile, GENERIC_READ, FILE_SHARE_READ, NULL,
                              OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (file == INVALID_HANDLE_VALUE)
@@ -857,7 +857,7 @@ void CRawEditValDialog::Transfer(CTransferInfoEx& ti)
     if (!ti.IsGood())
         return;
 
-    // nacteme nova data z tempu
+    // load the new data from the temp file
     if (Edit && !ImportFromTempFile())
     {
         ti.ErrorOn(IDB_EDIT);
@@ -872,7 +872,7 @@ CRawEditValDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         wParam, lParam);
     switch (uMsg)
     {
-        /* j.r. pokud nastavime spravne tab-order, neni toto treba a navic bude edit selected
+        /* j.r. if we set the tab order correctly, this is not needed and the edit will be selected too
     case WM_INITDIALOG:
     {
       CNewValDialog::DialogProc(uMsg, wParam, lParam);
@@ -1001,7 +1001,7 @@ CConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             RECT r;
             GetWindowRect((HWND)lParam, &r);
 
-            // vytvorime menu
+            // create the menu
             MENU_TEMPLATE_ITEM templ[] =
                 {
                     {MNTT_PB, 0, 0, 0, -1, 0, NULL},
@@ -1046,7 +1046,7 @@ CConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
                 else
                 {
-                    // jeste pro jistotu overime
+                    // double-check just to be sure
                     if (cmd < 30)
                     {
                         char var[100];
@@ -1065,7 +1065,7 @@ CConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             RECT r;
             GetWindowRect((HWND)lParam, &r);
 
-            // vytvorime menu
+            // create the menu
             MENU_TEMPLATE_ITEM templ[] =
                 {
                     {MNTT_PB, 0, 0, 0, -1, 0, NULL},
@@ -1123,7 +1123,7 @@ CConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
                 else
                 {
-                    // jeste pro jistotu overime
+                    // double-check just to be sure
                     if (cmd < 19)
                     {
                         char var[100];
@@ -1142,7 +1142,7 @@ CConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             RECT r;
             GetWindowRect((HWND)lParam, &r);
 
-            // vytvorime menu
+            // create the menu
             MENU_TEMPLATE_ITEM templ[] =
                 {
                     {MNTT_PB, 0, 0, 0, -1, 0, NULL},
@@ -1175,7 +1175,7 @@ CConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
                 else
                 {
-                    // jeste pro jistotu overime
+                    // double-check just to be sure
                     if (cmd < 6)
                     {
                         char var[100];

--- a/src/plugins/regedt/dialogs.h
+++ b/src/plugins/regedt/dialogs.h
@@ -7,11 +7,11 @@
 
 #define MAX_HISTORY_ENTRIES 20
 
-// pro okno FTP Searche
-// informuje o tom, ze jeden vyhledavaci thread zkoncil
+// for the FTP Search window
+// notifies that one search thread has finished
 #define WM_USER_SEARCH_FINISHED (WM_APP + 2)
 
-// informuje hlavni okno, ze ma refreshnout list view
+// notifies the main window that it should refresh the list view
 #define WM_USER_ADDFILE (WM_APP + 3)
 
 #define WM_USER_BUTTONS (WM_APP + 4)
@@ -26,15 +26,15 @@ extern LPWSTR CopyOrMoveHistory[MAX_HISTORY_ENTRIES];
 extern int DialogWidth;
 extern int DialogHeight;
 extern BOOL Maximized;
-extern int TypeDateColFW; // LO/HI-WORD: levy/pravy panel: sloupec Type/Date: FixedWidth
-extern int TypeDateColW;  // LO/HI-WORD: levy/pravy panel: sloupec Type/Date: Width
-extern int DataTimeColFW; // LO/HI-WORD: levy/pravy panel: sloupec Data/Time: FixedWidth
-extern int DataTimeColW;  // LO/HI-WORD: levy/pravy panel: sloupec Data/Time: Width
-extern int SizeColFW;     // LO/HI-WORD: levy/pravy panel: sloupec Size: FixedWidth
-extern int SizeColW;      // LO/HI-WORD: levy/pravy panel: sloupec Size: Width
+extern int TypeDateColFW; // LO/HI-WORD: left/right panel: Type/Date column: FixedWidth
+extern int TypeDateColW;  // LO/HI-WORD: left/right panel: Type/Date column: Width
+extern int DataTimeColFW; // LO/HI-WORD: left/right panel: Data/Time column: FixedWidth
+extern int DataTimeColW;  // LO/HI-WORD: left/right panel: Data/Time column: Width
+extern int SizeColFW;     // LO/HI-WORD: left/right panel: Size column: FixedWidth
+extern int SizeColW;      // LO/HI-WORD: left/right panel: Size column: Width
 
-extern HFONT EnvFont;     // font prostredi (edit, toolbar, header, status)
-extern int EnvFontHeight; // vyska fontu
+extern HFONT EnvFont;     // environment font (edit, toolbar, header, status)
+extern int EnvFontHeight; // font height
 
 BOOL InitDialogs();
 void ReleaseDialogs();
@@ -85,8 +85,8 @@ public:
     virtual BOOL TransferData(CTransferType type);
     virtual void Transfer(CTransferInfoEx& /*ti*/) {}
 
-    INT_PTR Execute(); // modalni dialog
-    HWND Create();     // nemodalni dialog
+    INT_PTR Execute(); // modal dialog
+    HWND Create();     // modeless dialog
 
 protected:
     virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);

--- a/src/plugins/regedt/editor.cpp
+++ b/src/plugins/regedt/editor.cpp
@@ -142,7 +142,7 @@ ExecuteExtPart(HWND msgParent, void* param)
     const char* name = SG->SalPathFindFileName(data->LongName);
     const char* ext = strrchr(name, '.');
     if (ext != NULL)
-        strcpy(data->Buffer, ++ext); // ".cvspass" ve Windows je pripona
+        strcpy(data->Buffer, ++ext); // ".cvspass" is treated as an extension in Windows
     else
         *data->Buffer = 0;
     return data->Buffer;
@@ -156,7 +156,7 @@ ExecuteDOSExtPart(HWND msgParent, void* param)
     const char* name = SG->SalPathFindFileName(data->DosName);
     const char* ext = strrchr(name, '.');
     if (ext != NULL)
-        strcpy(data->Buffer, ++ext); // ".cvspass" ve Windows je pripona
+        strcpy(data->Buffer, ++ext); // ".cvspass" is treated as an extension in Windows
     else
         *data->Buffer = 0;
     return data->Buffer;
@@ -301,7 +301,7 @@ ExecuteSalDir(HWND msgParent, void* param)
 {
     CALL_STACK_MESSAGE1("ExecuteSalDir(, )");
     CExpData* data = (CExpData*)param;
-    GetModuleFileName(NULL, data->Buffer, MAX_PATH); // hInstance==NULL: chceme cestu k EXE, ne k DLL
+    GetModuleFileName(NULL, data->Buffer, MAX_PATH); // hInstance==NULL: we want the path to the EXE, not to the DLL
     *(strrchr(data->Buffer, '\\') + 1) = 0;
     return data->Buffer;
 }
@@ -354,7 +354,7 @@ BOOL RemoveDoubleBackslahesFromPath(char* text)
     int len = (int)strlen(text);
     if (len < 3)
         return TRUE;
-    char* s = text + 2; // UNC cesty maji na zacatku "\\"
+    char* s = text + 2; // UNC paths start with "\\"
     char* d = s;
     while (*s != 0)
     {
@@ -377,9 +377,9 @@ BOOL ExpandCommand(const char* varText, char* buffer, int bufferLen, BOOL ignore
     if (SG->ExpandVarString(GetParent(), varText, buffer, bufferLen, ExpCommandVariables, &data,
                             ignoreEnvVarNotFoundOrTooLong))
     {
-        // promenne EXECUTE_WINDIR, EXECUTE_SYSDIR a EXECUTE_SALDIR jsou zakonceny zpetnym lomitkem
-        // uzivatel doplni vlastni zpetne lomitko, takze jsou ve vysledku v ceste dve
-        RemoveDoubleBackslahesFromPath(buffer); // setreseme dvojita zpetna lomitka na jedno
+        // the EXECUTE_WINDIR, EXECUTE_SYSDIR, and EXECUTE_SALDIR variables end with a backslash
+        // the user adds their own backslash, so the resulting path contains two of them
+        RemoveDoubleBackslahesFromPath(buffer); // trim double backslashes down to one
         return TRUE;
     }
     else
@@ -417,7 +417,7 @@ BOOL ExecuteEditor(const char* tempFile)
     char longName[MAX_PATH];
     char dosName[MAX_PATH];
 
-    // expandujeme initdir
+    // expand the initdir
     SG->CutDirectory(strcpy(longName, tempFile));
     if (!GetShortPathName(longName, dosName, MAX_PATH))
         dosName[0] = 0;
@@ -431,7 +431,7 @@ BOOL ExecuteEditor(const char* tempFile)
         !ExpandInitDir(InitDir, directory, longName, dosName))
         return FALSE;
 
-    // expandujeme arguments
+    // expand the arguments
     if (!GetShortPathName(tempFile, dosName, MAX_PATH))
         dosName[0] = 0;
 
@@ -439,7 +439,7 @@ BOOL ExecuteEditor(const char* tempFile)
         !ExpandArguments(Arguments, arguments, tempFile, dosName))
         return FALSE;
 
-    // spustime command
+    // run the command
     if (!*command)
         return Error(IDS_PROCESS);
     TBuffer<char> cmdLine;

--- a/src/plugins/regedt/export.cpp
+++ b/src/plugins/regedt/export.cpp
@@ -18,18 +18,18 @@ BOOL ExportKey(LPWSTR fullName)
         if (dlg.Execute() != IDOK)
             return FALSE;
 
-        // vyseparujeme z FS path user part
+        // separate the user part from the FS path
         if (!direct)
         {
             if (!RemoveFSNameFromPath(fullName))
             {
                 Error(IDS_NOTREGEDTPATH);
-                continue; // zobrazime dialog znova
+                continue; // show the dialog again
             }
             if (!wcslen(fullName))
             {
                 Error(IDS_BADPATH);
-                continue; // zobrazime dialog znova
+                continue; // show the dialog again
             }
         }
 
@@ -39,7 +39,7 @@ BOOL ExportKey(LPWSTR fullName)
             if (!wcslen(fullName))
             {
                 Error(IDS_BADPATH);
-                continue; // zobrazime dialog znova
+                continue; // show the dialog again
             }
         }
 
@@ -48,10 +48,10 @@ BOOL ExportKey(LPWSTR fullName)
         if (!ParseFullPath(fullName, key, root))
         {
             Error(IDS_BADPATH);
-            continue; // zobrazime dialog znova
+            continue; // show the dialog again
         }
 
-        // overime, ze klic existuje
+        // verify that the key exists
         if (root != -1)
         {
             HKEY hKey;
@@ -59,37 +59,37 @@ BOOL ExportKey(LPWSTR fullName)
             if (err != ERROR_SUCCESS)
             {
                 ErrorL(err, IDS_OPEN);
-                continue; // zobrazime dialog znova
+                continue; // show the dialog again
             }
             RegCloseKey(hKey);
         }
 
-        // overime, zda cilovy soubor neexistuje
+        // verify that the target file does not exist
         DWORD attr = SG->SalGetFileAttributes(file);
         if (attr != -1)
         {
             if (attr & FILE_ATTRIBUTE_DIRECTORY)
             {
                 Error(IDS_FILENAMEISDIR);
-                continue; // zobrazime dialog znova
+                continue; // show the dialog again
             }
             if (SG->DialogQuestion(GetParent(), BUTTONS_YESNOCANCEL, file, LoadStr(IDS_OVERWRITE), LoadStr(IDS_OVERWRITETITLE)) != DIALOG_YES)
-                continue; // zobrazime dialog znova
+                continue; // show the dialog again
             SG->ClearReadOnlyAttr(file);
             if (!DeleteFile(file))
             {
                 Error(IDS_REPLACEERROR);
-                continue; // zobrazime dialog znova
+                continue; // show the dialog again
             }
         }
 
         SG->CutDirectory(strcpy(LastExportPath, file));
 
         char command[4096];
-        if (root != -1) // regedit.exe umi "export all", takze ho pro tuto ulohu pouzijeme i od XP dal
+        if (root != -1) // regedit.exe can do "export all", so we'll use it for this task even after XP
         {
-            // od XP zavolame command line reg.exe, viz https://forum.altap.cz/viewtopic.php?f=24&t=5682
-            // vyhoda reg.exe je, ze od Vista dal nevyzaduje UAC eskalaci pro exporty
+            // starting with XP we invoke the reg.exe command line, see https://forum.altap.cz/viewtopic.php?f=24&t=5682
+            // the advantage of reg.exe is that from Vista onward it does not require UAC elevation for exports
             char sysdir[MAX_PATH];
             if (!GetSystemDirectory(sysdir, MAX_PATH))
                 *sysdir = 0;
@@ -137,7 +137,7 @@ BOOL ExportKey(LPWSTR fullName)
         CloseHandle(pi.hProcess);
         CloseHandle(pi.hThread);
 
-        // ohlasime zmenu na ceste (pribyl nas soubor)
+        // announce the change on the path (our file was added)
         char changedPath[MAX_PATH];
         lstrcpyn(changedPath, file, MAX_PATH);
         SG->CutDirectory(changedPath);

--- a/src/plugins/regedt/finddlg.h
+++ b/src/plugins/regedt/finddlg.h
@@ -18,7 +18,7 @@ protected:
     int BaseLen;
     BOOL Dirty;
     BOOL UpdateInIdle;
-    CCS Section; // kriticka sekce pro pristup k textovemu bufferu
+    CCS Section; // critical section for accessing the text buffer
     int Width;
     int TextWidth;
     int Height;
@@ -29,11 +29,11 @@ public:
     virtual ~CStatusBar();
     void AllocateBitmap();
 
-    // nastavi zaklad, ke kteremu pomoci Set pripojuje dalsi text
+    // set the base to which Set appends additional text
     void SetBase(LPCWSTR text, BOOL updateInIdle = FALSE);
-    // pripojovani k zakladu nastavenemu pres SetBase
+    // append to the base set via SetBase
     void Set(LPCWSTR text, BOOL updateInIdle = FALSE);
-    // vraci komplet string
+    // returns the complete string
     //void Get(char *buf, int bufSize);
 
     void OnEnterIdle();
@@ -47,7 +47,7 @@ public:
 // CFoundFilesListView
 //
 
-// indexy sloupcu
+// column indices
 
 #define CI_NAME 0
 #define CI_TYPE 1
@@ -67,8 +67,8 @@ struct CFoundFilesData
     unsigned Allocated : 1;
     FILETIME Time;
     BOOL IsDir;
-    DWORD State;          // pro ulozeni state stavu
-    unsigned Default : 1; // jde o default polozku
+    DWORD State;          // stores the item state
+    unsigned Default : 1; // denotes the default item
 
     CFoundFilesData()
     {
@@ -98,10 +98,10 @@ struct CFoundFilesData
     //char *GetFullPath(char *buffer, int size, BOOL skipName = FALSE);
 };
 
-#define SYMBOL_CX 16 // rozmery bitmap
+#define SYMBOL_CX 16 // bitmap dimensions
 #define SYMBOL_CY 16
 
-#define ICON_CX 16 // rozmery ikon v panelech a v cache-bitmape
+#define ICON_CX 16 // icon dimensions in panels and in the cache bitmap
 #define ICON_CY 16
 
 class CFindDialog;
@@ -110,7 +110,7 @@ class CFoundFilesListView : public CWindow
 {
 protected:
     TIndirectArray<CFoundFilesData> Data;
-    CCS DataCriticalSection; // kriticka sekce pro pristup k datum
+    CCS DataCriticalSection; // critical section for accessing the data
     CFindDialog* SearchDialog;
 
 public:
@@ -142,8 +142,8 @@ public:
 //
 // CComboboxEdit
 //
-// Protoze je combobox vyprasenej, nelze klasickou cestou (CB_GETEDITSEL) zjistit
-// po opusteni focusu, jaka byla selection. To resi tento control.
+// Because the combo box is emptied, the classic way (CB_GETEDITSEL) cannot
+// determine what the selection was after it loses focus. This control handles it.
 //
 
 class CComboboxEdit: public CWindow
@@ -176,7 +176,7 @@ class CFindDialog : public CDialogEx
 protected:
     LPWSTR LookInInit;
 
-    // layoutovaci parametry
+    // layout parameters
     int MinDlgW;
     int MinDlgH;
     int HMargin;
@@ -195,10 +195,10 @@ protected:
 
     CStatusBar* StatusBar;
     CFoundFilesListView* List;
-    CFindDialog** ZeroOnDestroy; // hodnota ukazatele bude pri destrukci nulovana
+    CFindDialog** ZeroOnDestroy; // the pointer value will be cleared during destruction
     //CComboboxEdit * LookIn;
 
-    // parametry dotazu
+    // query parameters
     WCHAR Pattern[MAX_KEYNAME];
     TIndirectArray<WCHAR> LookInList;
     BOOL IncludeSubkeys;
@@ -281,7 +281,7 @@ class CFindThread : public CThread
     CFindDialog* FindDialog;
     HANDLE CancelEvent;
 
-    // pro pro preklad unicode retezce pri hledani pomoci regexp
+    // used to translate a Unicode string when searching with a regexp
     TBuffer<char> AsciiBuffer;
 
     CSalamanderBMSearchData* BMForPatternA;

--- a/src/plugins/regedt/finddlg2.cpp
+++ b/src/plugins/regedt/finddlg2.cpp
@@ -146,43 +146,43 @@ void CFindDialog::LayoutControls(BOOL showOrHideControls)
     HDWP hdwp = BeginDeferWindowPos(8);
     if (hdwp != NULL)
     {
-        // umistim Status Bar
+        // place the status bar
         hdwp = DeferWindowPos(hdwp, StatusBar->HWindow, NULL,
                               0, clientRect.bottom, clientRect.right, StatusHeight,
                               SWP_NOZORDER);
 
-        // natahnu combobox Search For
+        // stretch the Search For combo box
         hdwp = DeferWindowPos(hdwp, GetDlgItem(HWindow, IDC_PATTERN), NULL,
                               0, 0, clientRect.right - CombosX - HMargin - FindNowW - HMargin, CombosH,
                               SWP_NOZORDER | SWP_NOMOVE);
 
-        // umistim tlacitko Find Now
+        // place the Find Now button
         hdwp = DeferWindowPos(hdwp, GetDlgItem(HWindow, IDOK), NULL, //IDC_FIND_FINDNOW
                               clientRect.right - HMargin - FindNowW, FindNowY, 0, 0,
                               SWP_NOZORDER | SWP_NOSIZE);
 
-        // natahnu combobox Look In
+        // stretch the Look In combo box
         hdwp = DeferWindowPos(hdwp, GetDlgItem(HWindow, IDC_LOOKIN), NULL,
                               0, 0, clientRect.right - CombosX - HMargin - FindNowW - HMargin, CombosH,
                               SWP_NOZORDER | SWP_NOMOVE);
 
-        // umistim tlacitko Add
+        // place the Add button
         hdwp = DeferWindowPos(hdwp, GetDlgItem(HWindow, IDHELP), NULL, //IDC_FIND_FINDNOW
                               clientRect.right - HMargin - FindNowW, AddY, 0, 0,
                               SWP_NOZORDER | SWP_NOSIZE);
 
-        // umistim a natahnu list view
+        // place and stretch the list view
         hdwp = DeferWindowPos(hdwp, GetDlgItem(HWindow, IDC_RESULTS), NULL,
                               HMargin, resultsY, clientRect.right - 2 * HMargin,
                               clientRect.bottom - resultsY - VMargin,
                               SWP_NOZORDER);
 
-        // umistim a titulek nad list view
+        // place the label above the list view
         hdwp = DeferWindowPos(hdwp, GetDlgItem(HWindow, IDC_FOUND_FILES), NULL,
                               HMargin, resultsY - FoundItemsH - 2, 0, 0,
                               SWP_NOZORDER | SWP_NOSIZE);
 
-        // umistim checkbox Options
+        // place the Options checkbox
         hdwp = DeferWindowPos(hdwp, GetDlgItem(HWindow, IDC_OPTIONS), NULL,
                               clientRect.right - HMargin - OptionsW, OptionsY, 0, 0,
                               SWP_NOZORDER | SWP_NOSIZE);
@@ -224,10 +224,10 @@ void CFindDialog::UpdateListViewItems()
     {
         int count = List->GetCount();
 
-        // reknu listview novy pocet polozek
+        // tell the list view the new item count
         ListView_SetItemCountEx(List->HWindow, count, LVSICF_NOINVALIDATEALL | LVSICF_NOSCROLL);
-        // pokud jde o prvni pridana data, vyberem nultou polozku vyberu
-        // a nastavime fokus do listview
+        // if this is the first added data, select the first item in the selection
+        // and set the focus to the list view
         if (FoundVisibleCount == 0 && count > 0)
         {
             ListView_SetItemState(List->HWindow, 0,
@@ -235,13 +235,13 @@ void CFindDialog::UpdateListViewItems()
                 SendMessage(HWindow, WM_NEXTDLGCTL, (WPARAM)List->HWindow, TRUE);
         }
 
-        // napisu pocet polozek nad listview
+        // write the item count above the list view
         char buff[50];
         SalPrintf(buff, 50, LoadStr(IDS_FOUNDITEMS2), count);
         SetWindowText(GetDlgItem(HWindow, IDC_FOUND_FILES), buff);
 
         /*
-    // pokud jsme minimalizovany, zobrazim pocet polozek do hlavicky
+    // if we are minimized, display the item count in the caption
     if (IsIconic(HWindow))
     {
       char buf[MAX_PATH+100];
@@ -256,7 +256,7 @@ void CFindDialog::UpdateListViewItems()
     }
     */
 
-        // slouzi pro hledaci thread - aby vedel, kdy nas ma priste upozornit
+        // used by the search thread so it knows when to notify us next
         FoundVisibleCount = count;
         NextUpdate = GetTickCount() + 500;
     }
@@ -319,7 +319,7 @@ void CFindDialog::StartSearch()
     FoundVisibleCount = 0;
     NextUpdate = GetTickCount();
 
-    // pripravime vzorek pro hledani
+    // prepare the pattern for searching
     char patternA[MAX_KEYNAME];
     char patternW[MAX_KEYNAME * 2];
     int patternALen, patternWLen;
@@ -410,14 +410,14 @@ BOOL ValidateTimeString(char* time)
     CALL_STACK_MESSAGE1("ValidateTimeString()");
     char* s = time + strlen(time);
 
-    // orezeme mezery z konce
+    // trim spaces from the end
     while (isspace(s[-1]))
         s--;
     *s = 0;
 
     s = time;
 
-    // nacteme cteme cas
+    // read the time
     if (s[1] == ':' || s[2] == ':')
     {
         // hh
@@ -440,7 +440,7 @@ BOOL ValidateTimeString(char* time)
         s++;
     }
 
-    // nacteme datum
+    // read the date
 
     // dd
     if (!isdigit(*s++))
@@ -485,7 +485,7 @@ BOOL ParseTimeString(const char* timeString, SYSTEMTIME& st, BOOL maxTime)
 
     memset(&st, 0, sizeof(st));
 
-    // nacteme cteme cas
+    // read the time
     if (s[1] == ':' || s[2] == ':')
     {
         // hh
@@ -514,7 +514,7 @@ BOOL ParseTimeString(const char* timeString, SYSTEMTIME& st, BOOL maxTime)
         }
     }
 
-    // nacteme datum
+    // read the date
 
     // dd
     st.wDay = st.wDay + *s++ - '0';
@@ -538,7 +538,7 @@ BOOL ParseTimeString(const char* timeString, SYSTEMTIME& st, BOOL maxTime)
     TRACE_I("ParseTimeString: " << st.wHour << " " << st.wMinute << " " << st.wSecond
                                 << " " << st.wDay << " " << st.wMonth << " " << st.wYear);
 
-    // overime spravnost zadaneho casu
+    // verify the correctness of the entered time
     FILETIME ft;
     if (SystemTimeToFileTime(&st, &ft))
         return TRUE;
@@ -620,7 +620,7 @@ void CFindDialog::Transfer(CTransferInfoEx& ti)
     }
     else
     {
-        // nacteme z LookIn jednotlive polozky
+        // read individual items from LookIn
         LookInList.DestroyMembers();
         BOOL more = TRUE;
         LPWSTR end = lookIn;
@@ -646,8 +646,8 @@ void CFindDialog::Transfer(CTransferInfoEx& ti)
             end++;
         }
 
-        // nacteme casy
-        UseMinTime = UseMaxTime = FALSE; // def hodnoty
+        // read the times
+        UseMinTime = UseMaxTime = FALSE; // default values
         char buffer[20];
         ti.EditLine(IDC_MINTIME, buffer, MAX_KEYNAME);
         if (strlen(buffer))
@@ -686,9 +686,9 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         //DialogStackPush(HWindow);
 
-        //InstallWordBreakProc(GetDlgItem(HWindow, IDC_PATTERN), TRUE); // instalujeme WordBreakProc do comboboxu
+        //InstallWordBreakProc(GetDlgItem(HWindow, IDC_PATTERN), TRUE); // install WordBreakProc into the combo box
 
-        // priradim oknu ikonku
+        // assign an icon to the window
         HICON findIcon = NULL;
         HINSTANCE iconsDLL = NULL;
         if (WindowsVistaAndLater)
@@ -708,7 +708,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (iconsDLL != NULL)
             FreeLibrary(iconsDLL);
 
-        // konstrukce listview
+        // construct the list view
         List = new CFoundFilesListView(this);
         if (List == NULL)
         {
@@ -719,7 +719,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         List->AttachToControl(HWindow, IDC_RESULTS);
 
-        // vytvorim status bar
+        // create the status bar
         //StatusBar = CStatusBar::Create(HWindow, IDC_STATUS);
         StatusBar = new CStatusBar();
         if (StatusBar == NULL)
@@ -738,7 +738,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                             DLLInstance,
                             StatusBar);
 
-        // nactu paramatry pro layoutovani okna
+        // load the parameters for laying out the window
         GetLayoutParams();
 
         if (DialogWidth != -1 && DialogHeight != -1)
@@ -755,7 +755,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         //CenterWindow(HWindow, SG->GetMainWindowHWND(), TRUE);
 
-        // zmenou pozice okna dojde k distribuci zprav, takze uz musi existovat objekty konstruovane vejs, jinak to hazelo exception
+        // changing the window position triggers message dispatching, so objects constructed earlier must already exist, otherwise it threw an exception
         if (AlwaysOnTop)
             SetWindowPos(HWindow, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 
@@ -782,7 +782,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
         case IDOK:
         {
-            if (SearchInProgress) // jde o Stop?
+            if (SearchInProgress) // is this Stop?
             {
                 if (IsIconic(HWindow))
                 {
@@ -792,7 +792,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 StopSearch();
                 return TRUE;
             }
-            else // ne, jde o start
+            else // no, this is Start
             {
                 if (!ValidateData() || !TransferData(ttDataFromWindow))
                     return TRUE;
@@ -858,7 +858,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 CFoundFilesData* data = List->At(index);
 
-                // podivame se zda existuje
+                // check whether it exists
                 WCHAR pathW[MAX_FULL_KEYNAME + 1] = L"\\";
                 wcscpy(pathW + 1, data->Path);
                 if (data->IsDir)
@@ -1072,10 +1072,10 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_SEARCH_FINISHED:
     {
-        // hledani zkoncilo
+        // the search has finished
         SearchInProgress = FALSE;
         SetWindowText(GetDlgItem(HWindow, IDOK), LoadStr(IDS_START));
-        CloseHandle(CancelEvent); // uz ho nebudeme potrebovat
+        CloseHandle(CancelEvent); // we will not need it anymore
         UpdateListViewItems();
         //UpdateStatusText();
         EnableControls(TRUE);
@@ -1122,9 +1122,9 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_DESTROY:
     {
         if (SearchInProgress)
-            TRACE_E("to se nemelo stat");
+            TRACE_E("This should not have happened");
 
-        // ulozime si rozmery okna
+        // save the window dimensions
         WINDOWPLACEMENT wndpl;
         wndpl.length = sizeof(WINDOWPLACEMENT);
         if (GetWindowPlacement(HWindow, &wndpl))
@@ -1134,11 +1134,11 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             Maximized = wndpl.showCmd == SW_SHOWMAXIMIZED;
         }
 
-        // uvolnime handle, jinak by ho ListView vzalo s sebou do pekel
+        // release the handle; otherwise the ListView would take it to hell with it
         ListView_SetImageList(List->HWindow, NULL, LVSIL_SMALL);
 
-        // uvolnime data nez se zavre okno, jinak by se mohlo stat, ze by nas
-        // thread salamander sestrelil driv nez zkonci
+        // free the data before the window closes, otherwise the Salamander thread
+        // could take us down before it finishes
         List->DestroyMembers();
         ListView_SetItemCountEx(List->HWindow, 0, 0);
 
@@ -1165,13 +1165,13 @@ CFindDialogThread::Body()
     HWND wnd = dlg->Create();
     if (!wnd)
     {
-        TRACE_E("Nepodarilo se vytvorit CFindDialog");
+        TRACE_E("Failed to create CFindDialog");
         delete dlg;
         return 0;
     }
-    dlg->SetZeroOnDestroy(&dlg); // pri WM_DESTROY bude ukazatel vynulovan
-                                 // obrana pred pristupem na neplatny ukazatel
-                                 // z message loopy po destrukci okna
+    dlg->SetZeroOnDestroy(&dlg); // the pointer will be cleared during WM_DESTROY
+                                 // protection against accessing an invalid pointer
+                                 // from the message loop after the window is destroyed
 
     SetForegroundWindow(wnd);
 
@@ -1182,7 +1182,7 @@ CFindDialogThread::Body()
     }
 
     MSG msg;
-    BOOL haveMSG = FALSE; // FALSE pokud se ma volat GetMessage() v podmince cyklu
+    BOOL haveMSG = FALSE; // FALSE means GetMessage() should be called in the loop condition
     while (haveMSG || IsWindow(wnd) && GetMessage(&msg, NULL, 0, 0))
     {
         haveMSG = FALSE;
@@ -1196,10 +1196,10 @@ CFindDialogThread::Body()
         if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
         {
             if (msg.message == WM_QUIT)
-                break;      // ekvivalent situace, kdy GetMessage() vraci FALSE
-            haveMSG = TRUE; // mame zpravu, jdeme ji zpracovat (bez volani GetMessage())
+                break;      // equivalent to GetMessage() returning FALSE
+            haveMSG = TRUE; // we have a message; process it without calling GetMessage()
         }
-        else // pokud ve fronte neni zadna message, provedeme Idle processing
+        else // if there is no message in the queue, perform idle processing
         {
             if (dlg != NULL)
                 dlg->OnEnterIdle();

--- a/src/plugins/regedt/fs.cpp
+++ b/src/plugins/regedt/fs.cpp
@@ -3,7 +3,7 @@
 
 #include "precomp.h"
 
-// image-list pro jednoduche ikony FS
+// image list for simple FS icons
 HIMAGELIST ImageList = NULL;
 
 const char* Str_REG_BINARY = "BINARY";
@@ -32,7 +32,7 @@ int Len_REG_SZ;
 int Len_REG_FULL_RESOURCE_DESCRIPTOR;
 int Len_REG_RESOURCE_REQUIREMENTS_LIST;
 
-// pro combo do NewKeyDialogu
+// entries for the NewKeyDialog combo box
 CRegTypeText RegTypeTexts[] =
     {
         {Str_REG_SZ, REG_SZ, 1, 1},
@@ -73,13 +73,13 @@ BOOL InitFS()
     ImageList = ImageList_Create(16, 16, ILC_MASK | SG->GetImageListColorFlags(), 4, 0);
     if (ImageList == NULL)
     {
-        TRACE_E("Nepodarilo se vytvorit image list.");
+        TRACE_E("Failed to create the image list.");
         return FALSE;
     }
-    ImageList_SetImageCount(ImageList, 4); // inicializace
+    ImageList_SetImageCount(ImageList, 4); // initialization
     ImageList_SetBkColor(ImageList, SG->GetCurrentColor(SALCOL_ITEM_BK_NORMAL));
 
-    // ikonu adresare ziskame ze Salamandera
+    // obtain the directory icon from Salamander
     HICON hIcon = SG->GetSalamanderIcon(SALICON_DIRECTORY, SALICONSIZE_16);
     if (hIcon != NULL)
     {
@@ -87,7 +87,7 @@ BOOL InitFS()
         DestroyIcon(hIcon);
     }
 
-    // ostatni ikonky jsou hard-coded
+    // the other icons are hard coded
     ImageList_ReplaceIcon(ImageList, 1, LoadIcon(DLLInstance, MAKEINTRESOURCE(IDI_SZ)));
     ImageList_ReplaceIcon(ImageList, 2, LoadIcon(DLLInstance, MAKEINTRESOURCE(IDI_BIN)));
     ImageList_ReplaceIcon(ImageList, 3, LoadIcon(DLLInstance, MAKEINTRESOURCE(IDI_UNKNOWN)));
@@ -125,7 +125,7 @@ void ReleaseFS()
 void CTopIndexMem::Push(LPCWSTR path, int topIndex)
 {
     CALL_STACK_MESSAGE2("CTopIndexMem::Push(, %d)", topIndex);
-    // zjistime, jestli path navazuje na Path (path==Path+"\\jmeno")
+    // determine whether path continues Path (path==Path+"\\name")
     LPCWSTR s = path + wcslen(path);
     if (s > path && *(s - 1) == L'\\')
         s--;
@@ -146,9 +146,9 @@ void CTopIndexMem::Push(LPCWSTR path, int topIndex)
              CompareStringW(LOCALE_USER_DEFAULT, NORM_IGNORECASE, path, l, Path, l) == CSTR_EQUAL;
     }
 
-    if (ok) // navazuje -> zapamatujeme si dalsi top-index
+    if (ok) // continues -> remember the next top index
     {
-        if (TopIndexesCount == TOP_INDEX_MEM_SIZE) // je potreba vyhodit z pameti prvni top-index
+        if (TopIndexesCount == TOP_INDEX_MEM_SIZE) // need to drop the first top index from memory
         {
             int i;
             for (i = 0; i < TOP_INDEX_MEM_SIZE - 1; i++)
@@ -158,7 +158,7 @@ void CTopIndexMem::Push(LPCWSTR path, int topIndex)
         wcscpy(Path, path);
         TopIndexes[TopIndexesCount++] = topIndex;
     }
-    else // nenavazuje -> prvni top-index v rade
+    else // does not continue -> first top index in the sequence
     {
         wcscpy(Path, path);
         TopIndexesCount = 1;
@@ -169,7 +169,7 @@ void CTopIndexMem::Push(LPCWSTR path, int topIndex)
 BOOL CTopIndexMem::FindAndPop(LPCWSTR path, int& topIndex)
 {
     CALL_STACK_MESSAGE2("CTopIndexMem::FindAndPop(, %d)", topIndex);
-    // zjistime, jestli path odpovida Path (path==Path)
+    // determine whether path matches Path (path==Path)
     int l1 = (int)wcslen(path);
     if (l1 > 0 && path[l1 - 1] == L'\\')
         l1--;
@@ -192,13 +192,13 @@ BOOL CTopIndexMem::FindAndPop(LPCWSTR path, int& topIndex)
             topIndex = TopIndexes[--TopIndexesCount];
             return TRUE;
         }
-        else // tuto hodnotu jiz nemame (nebyla ulozena nebo mala pamet->byla vyhozena)
+        else // we no longer have this value (it wasn't stored or low memory removed it)
         {
             Clear();
             return FALSE;
         }
     }
-    else // dotaz na jinou cestu -> vycistime pamet, doslo k dlouhemu skoku
+    else // query for another path -> clear the memory after a long jump
     {
         Clear();
         return FALSE;
@@ -232,7 +232,7 @@ void CPluginInterfaceForFS::CloseFS(CPluginFSInterfaceAbstract* fs)
 void CPluginInterfaceForFS::ExecuteChangeDriveMenuItem(int panel)
 {
     CALL_STACK_MESSAGE2("CPluginInterfaceForFS::ExecuteChangeDriveMenuItem(%d)", panel);
-    // zmenime cestu v aktualnim panelu na AssignedFSName:ConnectPath
+    // change the path in the active panel to AssignedFSName:ConnectPath
     SG->ChangePanelPathToPluginFS(panel, AssignedFSName, "", NULL);
 }
 
@@ -257,7 +257,7 @@ void EditValue(int root, LPWSTR key, LPWSTR name, BOOL rawEdit)
 
     if (name)
     {
-        // zjistime velikost dat
+        // determine the size of the data
         ret = RegQueryValueExW(hKey, name, 0, &type, NULL, &size);
         if (ret != ERROR_SUCCESS)
         {
@@ -268,7 +268,7 @@ void EditValue(int root, LPWSTR key, LPWSTR name, BOOL rawEdit)
 
         if (!rawEdit)
         {
-            // otestujeme, zda nejsou SZ data moc velika
+            // verify that the SZ data are not too large
             if ((type == REG_SZ || type == REG_EXPAND_SZ) && size / 2 > 0x7FFFFFFE)
             {
                 RegCloseKey(hKey);
@@ -277,7 +277,7 @@ void EditValue(int root, LPWSTR key, LPWSTR name, BOOL rawEdit)
             }
         }
 
-        // allokujeme buffer na data
+        // allocate a buffer for the data
         data = (LPBYTE)malloc(size);
         if (!data)
         {
@@ -286,7 +286,7 @@ void EditValue(int root, LPWSTR key, LPWSTR name, BOOL rawEdit)
             return;
         }
 
-        // nacteme data
+        // read the data
         ret = RegQueryValueExW(hKey, name, 0, &type, data, &size);
         if (ret != ERROR_SUCCESS)
         {
@@ -304,7 +304,7 @@ void EditValue(int root, LPWSTR key, LPWSTR name, BOOL rawEdit)
 
     if (!rawEdit)
     {
-        // overime spravnost dat
+        // verify the correctness of the data
         switch (type)
         {
         case REG_DWORD_BIG_ENDIAN:
@@ -362,7 +362,7 @@ void EditValue(int root, LPWSTR key, LPWSTR name, BOOL rawEdit)
             }
             break;
 
-        default: // zatim neumime primo, ale pouze pres externi editor
+        default: // we cannot handle it directly yet; only via an external editor
             rawEdit = TRUE;
         }
     }
@@ -421,14 +421,14 @@ void CPluginInterfaceForFS::ExecuteOnFS(int panel, CPluginFSInterfaceAbstract* p
         fs->GetCurrentPathW(newPath, MAX_FULL_KEYNAME);
         if (isDir == 2) // up-dir
         {
-            if (CutDirectory(newPath, cutDir, MAX_KEYNAME)) // zkratime cestu o posl. komponentu
+            if (CutDirectory(newPath, cutDir, MAX_KEYNAME)) // shorten the path by the last component
             {
                 if (WStrToStr(cutDirA, MAX_KEYNAME, cutDir) > 0)
                     focus = cutDirA;
-                // zmenime cestu v panelu
+                // update the path in the panel
                 if (fs->SetNewPath(newPath))
                 {
-                    int topIndex; // pristi top-index, -1 -> neplatny
+                    int topIndex; // next top index, -1 -> invalid
                     if (!fs->TopIndexMem.FindAndPop(newPath, topIndex))
                         topIndex = -1;
 
@@ -437,21 +437,21 @@ void CPluginInterfaceForFS::ExecuteOnFS(int panel, CPluginFSInterfaceAbstract* p
                 }
             }
         }
-        else // podadresar
+        else // subdirectory
         {
-            // zaloha udaju pro TopIndexMem (backupPath + topIndex)
+            // backup of the data for TopIndexMem (backupPath + topIndex)
             WCHAR backupPath[MAX_FULL_KEYNAME];
             wcscpy(backupPath, newPath);
             int topIndex = SG->GetPanelTopIndex(panel);
 
-            if (PathAppend(newPath, pluginData->Name, MAX_FULL_KEYNAME)) // nastavime cestu
+            if (PathAppend(newPath, pluginData->Name, MAX_FULL_KEYNAME)) // set the path
             {
-                // zmenime cestu v panelu
+                // update the path in the panel
                 if (fs->SetNewPath(newPath))
                 {
                     if (SG->ChangePanelPathToPluginFS(panel, pluginFSName, "?"))
                     {
-                        fs->TopIndexMem.Push(backupPath, topIndex); // zapamatujeme top-index pro navrat
+                        fs->TopIndexMem.Push(backupPath, topIndex); // remember the top index for return
                     }
                 }
             }

--- a/src/plugins/regedt/fs5.cpp
+++ b/src/plugins/regedt/fs5.cpp
@@ -5,7 +5,7 @@
 
 // ****************************************************************************
 //
-// CPluginFSInterface - treti cast
+// CPluginFSInterface - third part
 //
 //
 
@@ -16,7 +16,7 @@ BOOL SafeOpenKey(int root, LPWSTR key, DWORD sam, HKEY& hKey,
                  int errorTitle, LPBOOL skip, LPBOOL skipAll)
 {
     CALL_STACK_MESSAGE_NONE
-    //  CALL_STACK_MESSAGE4("SafeOpenKey(%d, , 0x%X, , %d, , )", root, sam, errorTitle); // Petr: prilis pomaly call-stack
+    //  CALL_STACK_MESSAGE4("SafeOpenKey(%d, , 0x%X, , %d, , )", root, sam, errorTitle); // Petr: call-stack too slow
     while (1)
     {
         int res = RegOpenKeyExW(PredefinedHKeys[root].HKey, key, 0, sam, &hKey);
@@ -56,12 +56,12 @@ BOOL SafeQueryInfoKey(HKEY hKey, int root, LPWSTR key, LPWSTR className,
 {
     CALL_STACK_MESSAGE_NONE
     //  CALL_STACK_MESSAGE5("SafeQueryInfoKey(, %d, , , , , %d, %d, %d)", root,
-    //                      errorTitle, skip, skipAll);  // Petr: prilis pomaly call-stack
+    //                      errorTitle, skip, skipAll);  // Petr: call-stack too slow
     while (1)
     {
         DWORD classSize = MAX_PATH;
         if (className)
-            *className = L'\0'; // preventivne ho zakoncime
+            *className = L'\0'; // terminate it proactively
         int res = RegQueryInfoKeyW(hKey, className, &classSize, NULL, NULL, NULL, NULL, NULL, NULL, maxData, NULL, time);
         if (res != ERROR_SUCCESS)
         {
@@ -80,7 +80,7 @@ BOOL SafeQueryInfoKey(HKEY hKey, int root, LPWSTR key, LPWSTR className,
                     WStrToStr(classNameA, MAX_PATH, className);
                 else
                     classNameA[0] = 0;
-                TRACE_I("registry klic " << keyNameA << " ma nastaveny class name: " << classNameA);
+                TRACE_I("registry key " << keyNameA << " has the class name set to: " << classNameA);
             }
 #endif // _DEBUG
             break;
@@ -95,7 +95,7 @@ BOOL SafeEnumValue(HKEY hKey, int root, LPWSTR key, DWORD& index,
 {
     //  CALL_STACK_MESSAGE9("SafeEnumValue(, %d, , 0x%X, , 0x%X, , 0x%X, %d, %d, %d, "
     //                      "%d)", root, index, type, size, errorTitle, skip,
-    //                      skipAll, noMoreItems);  // Petr: prilis pomaly call-stack, zjednoduseny kvuli rychlosti + ignorujeme ze je pomaly (stvou me TRACE_E, ktery to generuje)
+    //                      skipAll, noMoreItems);  // Petr: call-stack too slow, simplified for performance + ignoring that it is slow (TRACE_E that generates it annoys me)
     SLOW_CALL_STACK_MESSAGE1("SafeEnumValue()");
     while (1)
     {
@@ -130,7 +130,7 @@ BOOL TestValue(HKEY hKey, int root, LPWSTR key, LPWSTR name,
                LPBOOL overwriteAll, LPBOOL skipAllOvewrites)
 {
     //  CALL_STACK_MESSAGE4("TestValue(, %d, , , %d, , , %d, , , , )", root,
-    //                      sourceRoot, errorTitle);  // Petr: prilis pomaly call-stack, zjednoduseny kvuli rychlosti + ignorujeme ze je pomaly (stvou me TRACE_E, ktery to generuje)
+    //                      sourceRoot, errorTitle);  // Petr: call-stack too slow, simplified for performance + ignoring that it is slow (TRACE_E that generates it annoys me)
     SLOW_CALL_STACK_MESSAGE1("TestValue()");
     while (1)
     {
@@ -156,7 +156,7 @@ BOOL TestValue(HKEY hKey, int root, LPWSTR key, LPWSTR name,
                 return FALSE;
             }
 
-            // dotaz na prepis
+            // prompt to overwrite
             char fullFSPath[MAX_FULL_KEYNAME];
             char rootName[MAX_PREDEF_KEYNAME];
             char path[MAX_KEYNAME];
@@ -209,7 +209,7 @@ BOOL SafeSetValue(HKEY hKey, int root, LPWSTR key,
                   int errorTitle, LPBOOL skip, LPBOOL skipAll)
 {
     //  CALL_STACK_MESSAGE5("SafeSetValue(, %d, , , 0x%X, , 0x%X, %d, , )", root,
-    //                      type, size, errorTitle); // Petr: prilis pomaly call-stack, zjednoduseny kvuli rychlosti + ignorujeme ze je pomaly (stvou me TRACE_E, ktery to generuje)
+    //                      type, size, errorTitle); // Petr: call-stack too slow, simplified for performance + ignoring that it is slow (TRACE_E that generates it annoys me)
     SLOW_CALL_STACK_MESSAGE1("SafeSetValue()");
     while (1)
     {
@@ -230,7 +230,7 @@ BOOL SafeEnumKey(HKEY hKey, int root, LPWSTR key, DWORD& index,
                  int errorTitle, BOOL& skip, BOOL& skipAll, BOOL& noMoreItems)
 {
     //  CALL_STACK_MESSAGE7("SafeEnumKey(, %d, , 0x%X, , , %d, %d, %d, %d)", root,
-    //                      index, errorTitle, skip, skipAll, noMoreItems); // Petr: prilis pomaly call-stack, zjednoduseny kvuli rychlosti + ignorujeme ze je pomaly (stvou me TRACE_E, ktery to generuje)
+    //                      index, errorTitle, skip, skipAll, noMoreItems); // Petr: call-stack too slow, simplified for performance + ignoring that it is slow (TRACE_E that generates it annoys me)
     SLOW_CALL_STACK_MESSAGE1("SafeEnumKey()");
     while (1)
     {
@@ -287,21 +287,21 @@ BOOL CopyOrMoveKey(int sourceRoot, LPWSTR source, int targetRoot, LPWSTR target,
     //  CALL_STACK_MESSAGE10("CopyOrMoveKey(%d, , %d, , %d, %d, %d, %d, %d, %d, %d, , )",
     //                       sourceRoot, targetRoot, move, skip, skipAllErrors,
     //                       skipAllLongNames, skipAllOverwrites, overwriteAll,
-    //                       skipAllClassNames); // Petr: prilis pomaly call-stack, zjednoduseny kvuli rychlosti
+    //                       skipAllClassNames); // Petr: call-stack too slow, simplified for performance
     CALL_STACK_MESSAGE1("CopyOrMoveKey()");
-    // test na preruseni uzivatelem
+    // check for user cancellation
     if (TestForCancel())
         return skip = FALSE;
 
     HKEY sourceHKey, targetHKey;
     int errorTitle = move ? IDS_MOVEKEY : IDS_COPYKEY;
 
-    // otevreme zdrojovy klic
+    // open the source key
     if (!SafeOpenKey(sourceRoot, source, KEY_READ, sourceHKey,
                      errorTitle, &skip, &skipAllErrors))
         return FALSE;
 
-    // nacteme jmeno tridy a max data
+    // load the class name and maximum data size
     DWORD maxData;
     WCHAR sourceClassName[MAX_PATH];
     if (!SafeQueryInfoKey(sourceHKey, sourceRoot, source, sourceClassName,
@@ -311,11 +311,11 @@ BOOL CopyOrMoveKey(int sourceRoot, LPWSTR source, int targetRoot, LPWSTR target,
         return FALSE;
     }
 
-    // MS nekdy vraci polovicni velikost (pozorovano na MULTI_SZ v
-    // klici HKEY_LOCAL_MACHINE\SYSTEM\ControlSet002\Services\NetBT\Linkage
+    // Microsoft sometimes returns half the size (observed on MULTI_SZ in
+    // key HKEY_LOCAL_MACHINE\SYSTEM\ControlSet002\Services\NetBT\Linkage
     maxData *= 2;
 
-    // vytvorime cilovy klic
+    // create the target key
     if (!SafeCreateKey(targetRoot, target, sourceClassName, KEY_WRITE | KEY_READ, targetHKey,
                        errorTitle, skip, skipAllErrors))
     {
@@ -323,7 +323,7 @@ BOOL CopyOrMoveKey(int sourceRoot, LPWSTR source, int targetRoot, LPWSTR target,
         return FALSE;
     }
 
-    // overime, ze novy klic ma stejne jmeno tridy
+    // verify that the new key has the same class name
     if (!skipAllClassNames)
     {
         WCHAR targetClassName[MAX_PATH];
@@ -356,7 +356,7 @@ BOOL CopyOrMoveKey(int sourceRoot, LPWSTR source, int targetRoot, LPWSTR target,
         }
     }
 
-    // zkopirujeme obsah klice - nejprve hodnoty
+    // copy the key contents - values first
     void* data = malloc(maxData);
     if (!data)
     {
@@ -397,7 +397,7 @@ BOOL CopyOrMoveKey(int sourceRoot, LPWSTR source, int targetRoot, LPWSTR target,
                 break;
         }
 
-        // test na preruseni uzivatelem
+        // check for user cancellation
         if (TestForCancel())
             break;
     }
@@ -411,16 +411,16 @@ BOOL CopyOrMoveKey(int sourceRoot, LPWSTR source, int targetRoot, LPWSTR target,
         return skip = FALSE;
     }
 
-    // jeste zkopirujeme rekurzivne podklice
+    // copy the subkeys recursively as well
 
-    // nejprve naenumerujeme vsechny klice na stack
+    // first enumerate all keys onto the stack
     int sourceLen = (int)wcslen(source), targetLen = (int)wcslen(target);
     LPWSTR sourceSubkey = source + sourceLen, targetSubkey = target + targetLen;
     *sourceSubkey++ = L'\\';
     *targetSubkey++ = L'\\';
     int maxSubkey = min(MAX_KEYNAME - sourceLen - 2, MAX_KEYNAME - targetLen - 2);
     index = 0;
-    int top = stack.Count; // ulozime si ukazatel na vrsek zasobniku
+    int top = stack.Count; // store a pointer to the top of the stack
     while (1)
     {
         if (SafeEnumKey(sourceHKey, sourceRoot, source, index, name, NULL,
@@ -478,7 +478,7 @@ BOOL CopyOrMoveKey(int sourceRoot, LPWSTR source, int targetRoot, LPWSTR target,
                 break;
         }
 
-        // test na preruseni uzivatelem
+        // check for user cancellation
         if (TestForCancel())
             break;
     }
@@ -490,7 +490,7 @@ BOOL CopyOrMoveKey(int sourceRoot, LPWSTR source, int targetRoot, LPWSTR target,
         return skip = FALSE;
     }
 
-    // zkopirujeme klice ulozene na stacku
+    // copy the keys stored on the stack
     int i;
     for (i = stack.Count - 1; i >= top; i--)
     {
@@ -580,12 +580,12 @@ BOOL CopyOrMoveValue(int sourceRoot, LPWSTR sourcePath, LPWSTR sourceName,
     HKEY sourceHKey, targetHKey;
     int errorTitle = move ? IDS_MOVEVALUE : IDS_COPYVALUE;
 
-    // otevreme zdrojovy klic
+    // open the source key
     if (!SafeOpenKey(sourceRoot, sourcePath, KEY_READ | (move ? KEY_WRITE : 0), sourceHKey,
                      errorTitle, skip, skipAllErrors))
         return FALSE;
 
-    // otevreme cilovy klic
+    // open the target key
     if (!SafeOpenKey(targetRoot, targetPath, KEY_READ | KEY_WRITE, targetHKey,
                      errorTitle, skip, skipAllErrors))
     {
@@ -593,7 +593,7 @@ BOOL CopyOrMoveValue(int sourceRoot, LPWSTR sourcePath, LPWSTR sourceName,
         return FALSE;
     }
 
-    // otestujeme moznost prepisu
+    // test whether overwriting is possible
     if (!TestValue(targetHKey, targetRoot, targetPath, targetName,
                    sourceRoot, sourcePath, sourceName,
                    errorTitle, skip, skipAllErrors, overwriteAll, skipAllOverwrites))
@@ -603,7 +603,7 @@ BOOL CopyOrMoveValue(int sourceRoot, LPWSTR sourcePath, LPWSTR sourceName,
         return FALSE;
     }
 
-    // nacteme velikost hodnoty
+    // read the value size
     DWORD size = 0, type;
     if (!SafeQueryValue(sourceHKey, sourceRoot, sourcePath, sourceName, type, NULL, size,
                         errorTitle, skip, skipAllErrors))
@@ -613,7 +613,7 @@ BOOL CopyOrMoveValue(int sourceRoot, LPWSTR sourcePath, LPWSTR sourceName,
         return FALSE;
     }
 
-    // nacteme hodnotu
+    // read the value
     void* data = malloc(size);
     if (!data)
     {
@@ -632,7 +632,7 @@ BOOL CopyOrMoveValue(int sourceRoot, LPWSTR sourcePath, LPWSTR sourceName,
         return FALSE;
     }
 
-    // nastavime hodnotu
+    // set the value
     if (!SafeSetValue(targetHKey, targetRoot, targetPath, targetName, type, data, size,
                       errorTitle, skip, skipAllErrors))
     {
@@ -645,7 +645,7 @@ BOOL CopyOrMoveValue(int sourceRoot, LPWSTR sourcePath, LPWSTR sourceName,
     free(data);
     RegCloseKey(targetHKey);
 
-    // jde-li o move hodnotu smazeme ve zdrojovem klici
+    // for a move delete the value in the source key
     BOOL ret = move ? SafeDeleteValue(sourceHKey, sourceRoot, sourcePath, sourceName,
                                       errorTitle, skip, skipAllErrors)
                     : TRUE;
@@ -734,21 +734,21 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
     cancelOrHandlePath = TRUE;
 
     WCHAR targetPathW[MAX_FULL_KEYNAME];
-    // cilova cesta zadana pres drag&drop
+    // target path specified via drag&drop
     if (mode == 5 && MultiByteToWideChar(CP_ACP, 0, targetPath, -1, targetPathW, MAX_FULL_KEYNAME) <= 0)
         return TRUE;
 
-    // pro jistotu
+    // just to be sure
     if (mode != 1 && mode != 5)
         return TRUE;
 
     if (CurrentKeyRoot == -1)
-        return TRUE; //HKEY_XXX nejde kopirovat
+        return TRUE; //HKEY_XXX cannot be copied
 
     WCHAR enteredTargetPathW[MAX_FULL_KEYNAME];
     int targetPanel = (panel == PANEL_LEFT ? PANEL_RIGHT : PANEL_LEFT);
 
-    // podivame se jestli jsou v druhem panelu otevrene registry
+    // check whether the second panel shows the registry
     CPluginFSInterface* targetFS = (CPluginFSInterface*)SG->GetPanelPluginFS(targetPanel);
     if (mode != 5 && targetFS && targetFS->CurrentKeyRoot != -1)
     {
@@ -757,7 +757,7 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
         else
             swprintf_s(enteredTargetPathW, L"%hs:\\%s\\", fsName, PredefinedHKeys[targetFS->CurrentKeyRoot].KeyName);
 
-        SG->SetUserWorkedOnPanelPath(PANEL_TARGET); // default akce = prace s cestou v cilovem panelu
+        SG->SetUserWorkedOnPanelPath(PANEL_TARGET); // default action = work with the path in the target panel
     }
     else
         *enteredTargetPathW = L'\0';
@@ -766,10 +766,10 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
     while (1)
     {
         if (!firstRound && mode == 5)
-            return TRUE; // chyba na ceste zadane drag&dropem, koncime
+            return TRUE; // error on the drag&drop path, abort
         firstRound = FALSE;
 
-        // zjistime od uzivatele cestu
+        // ask the user for the path
         BOOL direct = FALSE;
         WCHAR text[MAX_KEYNAME + 200];
         ExpandPluralFilesDirs(text, MAX_KEYNAME + 200, selectedFiles, selectedDirs, panel, focused, copy);
@@ -780,7 +780,7 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
         if (mode != 5)
             wcscpy(targetPathW, enteredTargetPathW);
 
-        // vyseparujeme z FS path user part
+        // separate the user part from the FS path
         if (!direct)
         {
             if (!RemoveFSNameFromPath(targetPathW))
@@ -795,8 +795,8 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
             }
         }
 
-        // relativni cestu prevedeme na uplnou
-        BOOL success; // FALSE v pripade chyby nebo preruseni uzivatelem
+        // convert the relative path to an absolute one
+        BOOL success; // FALSE in case of an error or user cancellation
         GetFullFSPathW(targetPathW, MAX_FULL_KEYNAME, success);
         if (!success)
             continue;
@@ -815,12 +815,12 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
             continue;
         }
 
-        WCHAR targetName[MAX_KEYNAME]; // jmeno ciloveho souboru (pokud je vybran pouze jeden soubor)
+        WCHAR targetName[MAX_KEYNAME]; // name of the target file (when exactly one file is selected)
         BOOL useTargetName = FALSE;
         int len = (int)wcslen(key), err;
         HKEY hKey;
 
-        // zjistime o jaky typ operace jde
+        // determine what type of operation it is
         if (len > 0)
         {
             len--;
@@ -828,9 +828,9 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
             {
                 if ((err = RegOpenKeyExW(PredefinedHKeys[root].HKey, key, 0, KEY_READ, &hKey)) != ERROR_SUCCESS)
                 {
-                    // pokud cesta nezakoncena lomitkem neexistuje, povazujeme posledni cast cesty, za
-                    // jmeno ciloveho souboru (masky neumime), dava smysl pouze pokud je vybran jen
-                    // jeden soubor
+                    // if a path without a trailing slash does not exist, treat the last part of the path as
+                    // the name of the target file (wildcards unsupported), makes sense only when just
+                    // one file
                     if (err != ERROR_FILE_NOT_FOUND)
                     {
                         ErrorL(err, IDS_ACCESS, PredefinedHKeys[root].KeyName, key);
@@ -852,10 +852,10 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                     RegCloseKey(hKey);
             }
             else
-                key[len] = L'\0'; // ostranime lomitko z konce cesty
+                key[len] = L'\0'; // remove the slash from the end of the path
         }
 
-        // overime, zda cilova cesta existuje
+        // verify whether the target path exists
         if ((err = RegOpenKeyExW(PredefinedHKeys[root].HKey, key, 0, KEY_READ, &hKey)) != ERROR_SUCCESS)
         {
             if (err != ERROR_FILE_NOT_FOUND)
@@ -864,28 +864,28 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                 continue;
             }
 
-            // cesta neexistuje, zeptame se, zda ji mame vytvorit
+            // path does not exist, ask whether to create it
             char message[MAX_KEYNAME + 200];
             SalPrintf(message, MAX_KEYNAME, LoadStr(IDS_CREATETARGET), PredefinedHKeys[root].KeyName, key);
             if (SG->SalMessageBox(GetParent(), message, LoadStr(title), MB_YESNO) != IDYES)
                 continue;
 
-            // vytvorime ji
+            // create it
             if (!CreateTargetPath(root, key, errorTitle))
                 continue;
         }
         else
             RegCloseKey(hKey);
 
-        // vyzvedneme hodnoty "Confirm on" z konfigurace
+        // retrieve the "Confirm on" values from the configuration
         SG->GetConfigParameter(SALCFG_CNFRMFILEOVER, &ConfirmOnFileOverwrite, 4, NULL);
         SG->GetConfigParameter(SALCFG_CNFRMSHFILEOVER, &ConfirmOnSystemHiddenFileOverwrite, 4, NULL);
         SG->GetConfigParameter(SALCFG_CNFRMCREATEPATH, &ConfirmOnCreateTargetPath, 4, NULL);
         //ConfirmOnOverwrite = ConfirmOnFileOverwrite || ConfirmOnSystemHiddenFileOverwrite;
         ConfirmOnOverwrite = TRUE;
 
-        const CFileData* f = NULL; // ukazatel na soubor/adresar v panelu, ktery se ma zpracovat
-        BOOL isDir = FALSE;        // TRUE pokud 'f' je adresar
+        const CFileData* f = NULL; // pointer to the file/directory in the panel to process
+        BOOL isDir = FALSE;        // TRUE when 'f' is a directory
         int index = 0;
         BOOL skipAllErrors = FALSE; // skip all errors
         BOOL skipAllOverwrites = FALSE;
@@ -896,13 +896,13 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
         nextFocus[0] = 0;
         BOOL sourceEqualsTarget = FALSE;
 
-        // overime, ze nekopirujeme soubor do sebe sameho
+        // ensure we are not copying the file onto itself
         if (root == CurrentKeyRoot &&
             CompareStringW(LOCALE_USER_DEFAULT, NORM_IGNORECASE,
                            key, -1,
                            CurrentKeyName, -1) == CSTR_EQUAL)
         {
-            // vyzvedneme data o prvnim zpracovavanem souboru
+            // fetch data about the first processed file
             int index2 = 0;
             if (focused)
                 f = SG->GetPanelFocusedItem(panel, &isDir);
@@ -919,7 +919,7 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                 continue;
             }
 
-            // jde o rename
+            // this is a rename
             if (!copy)
                 WStrToStr(nextFocus, 2 * MAX_PATH, targetName);
             sourceEqualsTarget = TRUE;
@@ -931,24 +931,24 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
         int sourceLen = (int)wcslen(sourceKey), targetLen = (int)wcslen(key);
         LPWSTR sourceSubkey = sourceKey + sourceLen, targetSubkey = key + targetLen;
         int maxSubkey = min(MAX_KEYNAME - sourceLen - 2, MAX_KEYNAME - targetLen - 2);
-        // zasobnik na enumerovana jmena podklicu
-        // (podklice se musi nejpreve vsechny najednou naenumerovat
-        // a potom se mohou mazat (pri presunu)
+        // stack for enumerated subkey names
+        // (subkeys must all be enumerated at once
+        // and then they can be deleted (during a move)
         TIndirectArray<WCHAR> stack(100, 100);
 
-        GetAsyncKeyState(VK_ESCAPE); // init GetAsyncKeyState - viz help
+        GetAsyncKeyState(VK_ESCAPE); // init GetAsyncKeyState - see help
         SG->CreateSafeWaitWindow(LoadStr(copy ? IDS_COPYPROGRESS : IDS_MOVEPROGRESS),
                                  LoadStr(IDS_PLUGINNAME), 500, TRUE, SG->GetMainWindowHWND());
 
         while (1)
         {
-            // vyzvedneme data o zpracovavanem souboru
+            // fetch data about the processed file
             if (focused)
                 f = SG->GetPanelFocusedItem(panel, &isDir);
             else
                 f = SG->GetPanelSelectedItem(panel, &index, &isDir);
 
-            // provedeme copy/move na souboru/adresari
+            // perform copy/move on the file/directory
             if (f != NULL)
             {
                 CPluginData* pd = (CPluginData*)f->PluginData;
@@ -1001,7 +1001,7 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                         else
                             wcscpy(targetSubkey, useTargetName ? targetName : pd->Name);
 
-                        // jeste overime, ze sourceKey neni prefixem targetKey
+                        // also verify that sourceKey is not a prefix of targetKey
                         unsigned sourceLen2 = (int)wcslen(sourceKey);
                         if (root == sourceRoot &&
                             sourceLen2 <= wcslen(key) &&
@@ -1039,7 +1039,7 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                 }
                 else
                 {
-                    // nebudeme zpracovavat defaultni hodnotu pokud neni nastavena
+                    // do not process the default value if it is not set
                     if (pd->Name != NULL || pd->Type != REG_NONE)
                     {
                         success = CopyOrMoveValue(sourceRoot, sourceKey, pd->Name,
@@ -1050,7 +1050,7 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                 }
             }
 
-            // zjistime jestli ma cenu pokracovat (pokud neni cancel a existuje jeste nejaka dalsi oznacena polozka)
+            // determine whether it makes sense to continue (if not cancelled and another selected item exists)
             if (!success || focused || f == NULL)
                 break;
         }
@@ -1059,7 +1059,7 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
 
         if (success)
         {
-            strcpy(targetPath, nextFocus); // uspech
+            strcpy(targetPath, nextFocus); // success
             cancelOrHandlePath = FALSE;
         }
         else
@@ -1096,13 +1096,13 @@ BOOL CPluginFSInterface::OpenFindDialog(const char* fsName, int panel)
 
 void CPluginFSInterface::OpenActiveFolder(const char* fsName, HWND parent)
 {
-    // regedit nema parametr, kterym by bylo mozne nastavit cestu v Registry, ktera by se mela zobrazit
-    // lze mu ale nastavit HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Applets\Regedit\LastKey
-    // ve tvaru (napr) "Computer\HKEY_CURRENT_USER\AppEvents\Schemes\Apps"
-    // POZOR: slovo "Computer" je na českých Win7 lokalizováno jako "Počítač", nastesti ale regedit.exe
-    // toto slovo nevyzaduje a cesta muze zacinat az rootem HKEY_*
+    // regedit has no parameter to set which Registry path should be displayed
+    // but we can set HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Applets\Regedit\LastKey
+    // in the form (e.g.) "Computer\HKEY_CURRENT_USER\AppEvents\Schemes\Apps"
+    // NOTE: the word "Computer" is localized as "Počítač" on Czech Win7, fortunately regedit.exe
+    // does not require the word and the path may start directly at the HKEY_* root
 
-    // aktualni cestu v panelu vlozime do LastKey hodnoty pro RegEdit
+    // store the current panel path into the LastKey value for RegEdit
     HKEY hKey;
     DWORD disp;
     RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Regedit", 0, NULL,
@@ -1115,7 +1115,7 @@ void CPluginFSInterface::OpenActiveFolder(const char* fsName, HWND parent)
     RegSetValueEx(hKey, "LastKey", 0, REG_SZ, (LPBYTE)path2, lstrlen(path2) + 1);
     RegCloseKey(hKey);
 
-    // spustime regedit s moznosti eskalace (vista/7)
+    // launch regedit with optional elevation (Vista/7)
     char regEditPath[MAX_PATH];
     if (!GetWindowsDirectory(regEditPath, MAX_PATH))
         *regEditPath = 0;

--- a/src/plugins/regedt/menu.cpp
+++ b/src/plugins/regedt/menu.cpp
@@ -21,12 +21,12 @@ BOOL CPluginInterfaceForMenuExt::PostFocusCommand(const char* path,
 
     SG->PostMenuExtCommand(MID_FOCUS, TRUE);
 
-    // dojde k prepnuti do jineho okna, takze teoreticky tenhle Sleep
-    // nicemu nebude vadit
+    // switching to another window happens, so theoretically this Sleep
+    // should not cause any harm
     Sleep(500);
 
-    // po 0.5 sekunde uz o fokus nestojime (resi pripad, kdy jsme trefili
-    // zacatek BUSY rezimu Salamandera)
+    // after 0.5 seconds we are no longer interested in the focus (handles
+    // the case when we hit the start of Salamander's BUSY mode)
     Path[0] = 0;
     Name[0] = 0;
 
@@ -112,7 +112,7 @@ BOOL CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstrac
 
     case MID_FOCUS:
     {
-        // jen pokud jsme nemeli smulu (netrefili jsme zacatek BUSY rezimu Salamandera)
+        // only if we were lucky enough not to hit the start of Salamander's BUSY mode
         if (Path[0] != 0)
         {
             SetForegroundWindow(SG->GetMainWindowHWND());

--- a/src/plugins/regedt/precomp.cpp
+++ b/src/plugins/regedt/precomp.cpp
@@ -3,9 +3,9 @@
 
 #include "precomp.h"
 
-// projekt Regedit obsahuje ctyri skupiny modulu
+// the Regedit project contains four groups of modules
 //
-// 1) modul precomp.cpp, ktery postavi regedit.pch (/Yc"precomp.h")
-// 2) moduly vyuzivajici regedit.pch (/Yu"precomp.h")
-// 3) commony maji vlastni, automaticky generovany
+// 1) the precomp.cpp module that builds regedit.pch (/Yc"precomp.h")
+// 2) modules that use regedit.pch (/Yu"precomp.h")
+// 3) common files have their own automatically generated
 //    WINDOWS.PCH (/YX"windows.h" /Fp"$(OutDir)\WINDOWS.PCH")

--- a/src/plugins/regedt/regedt.h
+++ b/src/plugins/regedt/regedt.h
@@ -5,7 +5,7 @@
 
 #define CURRENT_CONFIG_VERSION 1
 
-// definice IDs do menu
+// menu ID definitions
 #define MID_FIND 1
 #define MID_NEWKEY 2
 #define MID_NEWVAL 3
@@ -13,11 +13,11 @@
 #define MID_FOCUS 5
 
 #ifndef REG_QWORD
-// viz. winnt.h
+// see winnt.h
 #define REG_QWORD (11) // 64-bit number
 #endif
 
-// viz. winreg.h
+// see winreg.h
 #ifndef HKEY_PERFORMANCE_TEXT
 #define HKEY_PERFORMANCE_TEXT ((HKEY)0x80000050)
 #endif
@@ -31,18 +31,18 @@
 #define MAX_FULL_KEYNAME (MAX_KEYNAME + MAX_PREDEF_KEYNAME + 1)
 #define MAX_VAL_DATA 32767
 
-// objekt interfacu pluginu, jeho metody se volaji ze Salamandera
+// plugin interface object whose methods Salamander invokes
 class CPluginInterface;
 extern CPluginInterface PluginInterface;
 class CPluginInterfaceForMenuExt;
 extern CPluginInterfaceForMenuExt InterfaceForMenuExt;
 
-// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+// general Salamander interface - valid from plugin startup until shutdown
 extern CSalamanderGeneralAbstract* SG;
 
 extern CSalamanderGUIAbstract* SalGUI;
 
-// FS-name pridelene Salamanderem po loadu pluginu
+// FS name assigned by Salamander after loading the plugin
 extern char AssignedFSName[MAX_PATH];
 
 class CWindowQueueEx : public CWindowQueue
@@ -55,7 +55,7 @@ public:
         CS.Enter();
         HWND w = NULL;
         CWindowQueueItem* next = Head;
-        if (next != NULL) // najdeme posledni okno
+        if (next != NULL) // find the last window
         {
             while (next->Next)
                 next = next->Next;
@@ -97,7 +97,7 @@ int SalPrintfW(LPWSTR buffer, unsigned count, LPCWSTR format, ...);
 
 // ****************************************************************************
 //
-// Interface pluginu
+// Plug-in interface
 //
 
 class CPluginInterface : public CPluginInterfaceAbstract
@@ -132,7 +132,7 @@ public:
 
 class CPluginInterfaceForMenuExt : public CPluginInterfaceForMenuExtAbstract
 {
-    // pouzite pro fokuseni polozek z jineho nez hlavniho threadu
+    // used to focus items from a non-main thread
     char Path[MAX_FULL_KEYNAME + 1];
     char Name[MAX_KEYNAME];
 
@@ -235,18 +235,19 @@ public:
 //
 // CTopIndexMem
 //
-// pamet top-indexu listboxu v panelu - pouziva CPluginFSInterface pro korektni
-// chovani ExecuteOnFS (zachovani top-indexu po vstupu a vystupu z podadresare)
+// listbox top-index cache in the panel - used by CPluginFSInterface to keep
+// ExecuteOnFS behavior correct (preserve the top index when entering and
+// leaving a subdirectory)
 
-#define TOP_INDEX_MEM_SIZE 50 // pocet pamatovanych top-indexu (urovni), minimalne 1
+#define TOP_INDEX_MEM_SIZE 50 // number of remembered top indexes (levels), at least 1
 
 class CTopIndexMem
 {
 protected:
-    // cesta pro posledni zapamatovany top-index
+    // path for the last remembered top index
     WCHAR Path[MAX_PATH];
-    int TopIndexes[TOP_INDEX_MEM_SIZE]; // zapamatovane top-indexy
-    int TopIndexesCount;                // pocet zapamatovanych top-indexu
+    int TopIndexes[TOP_INDEX_MEM_SIZE]; // cached top indexes
+    int TopIndexesCount;                // number of cached top indexes
 
 public:
     CTopIndexMem() { Clear(); }
@@ -254,9 +255,9 @@ public:
     {
         Path[0] = L'\0';
         TopIndexesCount = 0;
-    } // vycisti pamet
-    void Push(LPCWSTR path, int topIndex);        // uklada top-index pro danou cestu
-    BOOL FindAndPop(LPCWSTR path, int& topIndex); // hleda top-index pro danou cestu, FALSE->nenalezeno
+    } // clear the cache
+    void Push(LPCWSTR path, int topIndex);        // store the top index for the given path
+    BOOL FindAndPop(LPCWSTR path, int& topIndex); // find the top index for the given path, FALSE -> not found
 };
 
 // ****************************************************************************
@@ -298,14 +299,14 @@ class CPluginFSInterface : public CPluginFSInterfaceAbstract
 public:
     int CurrentKeyRoot;
     WCHAR CurrentKeyName[MAX_KEYNAME];
-    CTopIndexMem TopIndexMem; // pamet top-indexu pro ExecuteOnFS()
+    CTopIndexMem TopIndexMem; // top-index cache for ExecuteOnFS()
     BOOL FocusFirstNewItem;
 
 protected:
     BOOL PathError;
     WCHAR NewPath[MAX_KEYNAME];
     BOOL NewPathValid;
-    BOOL FirstChangePath; // pri prvnim volani ChangePath ignorujeme chyby
+    BOOL FirstChangePath; // ignore errors on the first ChangePath call
 
 public:
     CPluginFSInterface();
@@ -427,7 +428,7 @@ public:
 
 struct CPluginData
 {
-    WCHAR* Name; // jmeno v unicode
+    WCHAR* Name; // name in Unicode
     DWORD Type;
     DWORD_PTR Data;
     unsigned Allocated : 1;
@@ -494,8 +495,8 @@ class CPluginDataInterface : public CPluginDataInterfaceAbstract
 
 // ****************************************************************************
 
-extern HINSTANCE DLLInstance; // handle k SPL-ku - jazykove nezavisle resourcy
-extern HINSTANCE HLanguage;   // handle k SLG-cku - jazykove zavisle resourcy
+extern HINSTANCE DLLInstance; // handle to SPL - language-independent resources
+extern HINSTANCE HLanguage;   // handle to SLG - language-dependent resources
 extern BOOL WindowsVistaAndLater;
 
 char* LoadStr(int resID);


### PR DESCRIPTION
## Summary
- finish translating change monitor, configuration, and search dialog comments and messages to English in the registry editor plug-in.
- rewrite filesystem helper, interface header, and utility documentation to English so the behavior and error handling are clearer.

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e23609fab08322b244f36369085949