### PR TITLE
undelete: translate exFAT ReadSectors FIXME note

### DIFF
--- a/src/plugins/undelete/dialogs.cpp
+++ b/src/plugins/undelete/dialogs.cpp
@@ -220,7 +220,7 @@ INT_PTR CCopyProgressDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
-        break; // chci focus od DefDlgProc
+        break; // request focus from DefDlgProc
     }
 
     case WM_COMMAND:
@@ -545,7 +545,7 @@ void CConnectDialog::OnImageBrowse()
     openInfo.hwndOwner = HWindow;
     openInfo.lpstrFilter = "Image Files (*.img;*.ima)\0*.IMG;*.IMA\0AllFiles (*.*)\0*.*\0\0\0";
     openInfo.lpstrFile = Volume;
-    // TODO: porad to tady smrdi, kdyz je volume treba C:\Work\Altap\, tak init dir je svinstvo kvuli lpstrFile
+    // TODO: this still feels wrong; when the volume is e.g. C:\Work\Altap\, the initial dir becomes garbage because of lpstrFile
     openInfo.lpstrInitialDir = Volume;
     openInfo.nMaxFile = MAX_PATH;
     openInfo.Flags = OFN_FILEMUSTEXIST | OFN_READONLY;
@@ -747,8 +747,8 @@ INT_PTR CRestoreDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SalamanderGeneral->GetCommonFSOperSourceDescr(text2, MAX_PATH + 100, PANEL_SOURCE, files, dirs, NULL, FALSE, FALSE);
         GetDlgItemText(HWindow, IDC_LABEL_SOURCE, text1, 200);
         BOOL labelSet = FALSE;
-        // pokud jde o "file \"name.txt\"" nebo "directory \"name\"" najdeme jmeno a zbytek
-        // retezce pridame do text1, aby sla pouzit CSalamanderGUI::SetSubjectTruncatedText
+        // if it is "file \"name.txt\"" or "directory \"name\"" we find the name and the remaining text
+        // we add the strings to text1 so that CSalamanderGUI::SetSubjectTruncatedText can be used
         if (files + dirs <= 1)
         {
             char* beg = strchr(text2, '"');

--- a/src/plugins/undelete/fs2.cpp
+++ b/src/plugins/undelete/fs2.cpp
@@ -636,7 +636,7 @@ BOOL CFileList::RenameDuplicateFiles()
 BOOL CPluginFSInterface::AppendPath(char* buffer, char* path, char* name, BOOL* ret)
 {
     CALL_STACK_MESSAGE1("CPluginFSInterface::AppendPath(, , , )");
-    // spojeni cesty a jmena a kontrola delky
+    // join the path and name and check the length
     lstrcpyn(buffer, path, MAX_PATH);
     if (!SalamanderGeneral->SalPathAppend(buffer, name, MAX_PATH))
     {
@@ -1498,12 +1498,12 @@ void CPluginFSInterface::ContextMenu(const char* fsName, HWND parent, int menuX,
     const CFileData* fd = SalamanderGeneral->GetPanelFocusedItem(panel, &focusIsDir);
     DIR_ITEM_I<char>* di = (DIR_ITEM_I<char>*)fd->PluginData;
 
-    // vytvorime menu
+    // create the menu
     CGUIMenuPopupAbstract* ctxMenu = SalamanderGUI->CreateMenuPopup();
     if (ctxMenu == NULL)
         return;
 
-    // vlozeni prikazu Salamandera
+    // insert Salamander commands
     char cmdName[300];
     int salIndex = 0;
     int index = 0;

--- a/src/plugins/undelete/library/exfat.h
+++ b/src/plugins/undelete/library/exfat.h
@@ -1449,7 +1449,7 @@ DWORD CExFATSnapshot<CHAR>::GetFATItem(DWORD index)
     // for simplicity we can read over on end of FAT
     if (!this->Volume->ReadSectors(FATCache, this->Volume->ExFATBoot.FATOffset + firstSector, cacheSectors))
     {
-        // JRYFIXME - projit ostatni volani ReadSectors(), resime navratove hodnoty?? Pokud ano, meli bychom zde vracet BOOL
+        // JRYFIXME - review the other ReadSectors() calls, are we handling the return values? If so, we should return BOOL here.
         String<CHAR>::Error(IDS_UNDELETE, IDS_ERRORREADINGFAT);
         return 0;
     }

--- a/src/plugins/undelete/undelete.cpp
+++ b/src/plugins/undelete/undelete.cpp
@@ -162,13 +162,13 @@ BOOL CTopIndexMem::FindAndPop(const char* path, int& topIndex)
 
 void InitIconOverlays()
 {
-    // 48x48 az od XP (brzy bude obsolete, pobezime jen na XP+, pak zahodit)
-    // ve skutecnosti jsou velke ikonky podporeny uz davno, lze je nahodit
-    // Desktop/Properties/???/Large Icons; pozor, nebude pak existovat system image list
-    // pro ikonky 32x32; navic bychom meli ze systemu vytahnout realne velikosti ikonek
-    // zatim na to kasleme a 48x48 povolime az od XP, kde jsou bezne dostupne
+    // 48x48 only from XP onward (will soon be obsolete; we'll run on XP+ only, then drop this)
+    // in fact large icons have been supported for a long time, they can be enabled
+    // Desktop/Properties/???/Large Icons; beware, the system image list will not exist then
+    // for 32x32 icons; additionally we should pull the actual icon sizes from the system
+    // for now we ignore it and enable 48x48 only from XP where they are commonly available
     int iconSizes[3] = {16, 32, 48};
-    if (!SalIsWindowsVersionOrGreater(5, 1, 0)) // neni WindowsXPAndLater: neni XP and later
+    if (!SalIsWindowsVersionOrGreater(5, 1, 0)) // not WindowsXPAndLater: this is not XP or later
         iconSizes[2] = 32;
 
     HICON iconOverlays[3];
@@ -179,7 +179,7 @@ void InitIconOverlays()
                                            SalamanderGeneral->GetIconLRFlags());
     }
 
-    // POZN.: pri chybe loadu ikon SetPluginIconOverlays() selze, ale platne ikony z iconOverlays[] uvolni
+    // NOTE: if loading icons fails, SetPluginIconOverlays() returns failure but releases the valid icons from iconOverlays[]
     SalamanderGeneral->SetPluginIconOverlays(1, iconOverlays);
 }
 
@@ -328,8 +328,8 @@ void WINAPI CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* s
     salamander->SetPluginIcon(0);
     salamander->SetPluginMenuAndToolbarIcon(0);
 
-    /* slouzi pro skript export_mnu.py, ktery generuje salmenu.mnu pro Translator
-   udrzovat synchronizovane s volani salamander->AddMenuItem() dole...
+    /* used by the export_mnu.py script, which generates salmenu.mnu for Translator
+   keep synchronized with the salamander->AddMenuItem() calls below...
 MENU_TEMPLATE_ITEM PluginMenu[] = 
 {
 	{MNTT_PB, 0


### PR DESCRIPTION
## Summary
- rewrite the remaining Czech FIXME in the exFAT snapshot helper into English
- keep the guidance about handling ReadSectors return values while matching existing tone

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e234ff99c48322b48791187c7be444