### PR TITLE
dbviewer Translate remaining resource comments to English

### DIFF
--- a/src/plugins/dbviewer/const.h
+++ b/src/plugins/dbviewer/const.h
@@ -3,23 +3,23 @@
 
 #pragma once
 
-// [0, 0] - pro otevrena okna viewru: konfigurace pluginu se zmenila
+// [0, 0] - for open viewer windows: the plugin configuration changed
 #define WM_USER_VIEWERCFGCHNG WM_APP + 3246
-// [0, 0] - pro otevrena okna viewru: je treba podriznou historie
+// [0, 0] - for open viewer windows: the history needs to be cleared
 #define WM_USER_CLEARHISTORY WM_APP + 3247
-// [0, 0] - pro otevrena okna vieweru: Salamander pregeneroval fonty, mame zavolat SetFont() listam
+// [0, 0] - for open viewer windows: Salamander regenerated fonts, lists should call SetFont()
 #define WM_USER_SETTINGCHANGE WM_APP + 3248
 
 char* LoadStr(int resID);
 
-// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+// generic Salamander interface - valid from plugin start until shutdown
 extern CSalamanderGeneralAbstract* SalGeneral;
 
-extern HINSTANCE DLLInstance; // handle k SPL-ku - jazykove nezavisle resourcy
-extern HINSTANCE HLanguage;   // handle k SLG-cku - jazykove zavisle resourcy
+extern HINSTANCE DLLInstance; // handle to SPL - language-independent resources
+extern HINSTANCE HLanguage;   // handle to SLG - language-dependent resources
 
 // Configuration variables
 extern BOOL CfgUseCustomFont;
-extern LOGFONT CfgLogFont;                 // popis fontu pouzivaneho pro panel
-extern BOOL CfgSavePosition;               // ukladat pozici okna/umistit dle hlavniho okna
-extern WINDOWPLACEMENT CfgWindowPlacement; // neplatne, pokud CfgSavePosition != TRUE
+extern LOGFONT CfgLogFont;                 // description of the font used for the panel
+extern BOOL CfgSavePosition;               // store the window position/place according to the main window
+extern WINDOWPLACEMENT CfgWindowPlacement; // invalid if CfgSavePosition != TRUE

--- a/src/plugins/dbviewer/data.cpp
+++ b/src/plugins/dbviewer/data.cpp
@@ -40,7 +40,7 @@ BOOL CDatabase::Open(const char* fileName)
 
     BOOL ret = TRUE;
 
-    // zkusim soubor otevrit jako DBF
+    // try to open the file as a DBF
     Parser = new CParserInterfaceDBF();
     if (Parser != NULL)
     {
@@ -48,7 +48,7 @@ BOOL CDatabase::Open(const char* fileName)
         status = Parser->OpenFile(fileName);
         if (status != psOK)
         {
-            // nevyslo to, zkusim ho otevrit jako CSV
+            // if that failed, try to open it as a CSV
             delete Parser;
             CParserInterfaceCSV* pCSVParser;
             Parser = pCSVParser = new CParserInterfaceCSV(&Renderer->Viewer->CfgCSV);
@@ -79,7 +79,7 @@ BOOL CDatabase::Open(const char* fileName)
             DWORD i;
             for (i = 0; i < Parser->GetFieldCount(); i++)
             {
-                // vytahneme potrebnou velikost bufferu pro nazev sloupce
+                // retrieve the required buffer size for the column name
                 fieldInfo.Name = NULL;
                 if (!Parser->GetFieldInfo(i, &fieldInfo))
                     break;
@@ -97,7 +97,7 @@ BOOL CDatabase::Open(const char* fileName)
                     break;
                 }
 
-                // vytahneme nazev sloupce
+                // retrieve the column name
                 Parser->GetFieldInfo(i, &fieldInfo);
 
                 column.Name = fieldInfo.Name;
@@ -106,15 +106,15 @@ BOOL CDatabase::Open(const char* fileName)
                 column.FieldLen = fieldInfo.FieldLen;
                 column.Decimals = fieldInfo.Decimals;
 
-                // sirku sloupce napocitame z poctu znaku v sloupci
-                // pokud je sirsi hlavicka sloupce, pouzijeme tu
+                // compute the column width from the number of characters in the column
+                // if the column header is wider, use that instead
                 if (!IsUnicode)
                     GetTextExtentPoint32A(hDC, column.Name, (int)strlen(column.Name), &sz);
                 else
                     GetTextExtentPoint32W(hDC, (LPWSTR)column.Name, (int)wcslen((LPWSTR)column.Name), &sz);
                 column.Width = sz.cx;
 
-                // pokud parser dokaze odhadnout maximalni pocet znaku, odhadneme sirku sloupce
+                // if the parser can estimate the maximum number of characters, estimate the column width
                 if (fieldInfo.TextMax > 0)
                 {
                     int width = Renderer->CharAvgWidth * fieldInfo.TextMax;
@@ -219,7 +219,7 @@ BOOL CDatabase::GetFileInfo(HWND hEdit)
 {
     if (Parser == NULL)
     {
-        TRACE_E("Chybne volani CDatabase::GetFileInfo: Parser == NULL");
+        TRACE_E("Invalid call to CDatabase::GetFileInfo: Parser == NULL");
         return 0;
     }
     return Parser->GetFileInfo(hEdit);
@@ -229,7 +229,7 @@ int CDatabase::GetRowCount()
 {
     if (Parser == NULL)
     {
-        TRACE_E("Chybne volani CDatabase::GetRowCount: Parser == NULL");
+        TRACE_E("Invalid call to CDatabase::GetRowCount: Parser == NULL");
         return 0;
     }
     return Parser->GetRecordCount();
@@ -302,7 +302,7 @@ BOOL CDatabase::FetchRecord(HWND hParent, DWORD rowIndex)
 {
     if (Parser == NULL)
     {
-        TRACE_E("Chybne volani CDatabase::FetchRecord");
+        TRACE_E("Invalid call to CDatabase::FetchRecord");
         return FALSE;
     }
 
@@ -324,7 +324,7 @@ CDatabase::GetCellText(const CDatabaseColumn* column, size_t* textLen)
 {
     if (Parser == NULL)
     {
-        TRACE_E("Chybne volani CDatabase::GetCellText");
+        TRACE_E("Invalid call to CDatabase::GetCellText");
         return FALSE;
     }
     return Parser->GetCellText(column->OriginalIndex, textLen);
@@ -335,7 +335,7 @@ CDatabase::GetCellTextW(const CDatabaseColumn* column, size_t* textLen)
 {
     if (Parser == NULL)
     {
-        TRACE_E("Chybne volani CDatabase::GetCellTextW");
+        TRACE_E("Invalid call to CDatabase::GetCellTextW");
         return FALSE;
     }
     return Parser->GetCellTextW(column->OriginalIndex, textLen);
@@ -345,7 +345,7 @@ BOOL CDatabase::IsRecordDeleted()
 {
     if (Parser == NULL)
     {
-        TRACE_E("Chybne volani CDatabase::IsRecordDeleted()");
+        TRACE_E("Invalid call to CDatabase::IsRecordDeleted()");
         return FALSE;
     }
     return Parser->IsRecordDeleted();

--- a/src/plugins/dbviewer/data.h
+++ b/src/plugins/dbviewer/data.h
@@ -11,25 +11,25 @@
 class CDatabaseColumn
 {
 public:
-    char* Name;        // alokovany nazev sloupce
-    BOOL LeftAlign;    // TRUE = obsah sloupce zarovnany vlevo; FALSE = vpravo
-    BOOL Visible;      // bude sloupec zobrazen v tabulce?
-    int Width;         // sirka sloupce v bodech
-    int OriginalIndex; // na ktere pozici je sloupec podle databaze
-    int Length;        // maximalni zobrazovany pocet znaku ve sloupci
+    char* Name;        // allocated column name
+    BOOL LeftAlign;    // TRUE = column content aligned to the left; FALSE = to the right
+    BOOL Visible;      // should the column be displayed in the table?
+    int Width;         // column width in points
+    int OriginalIndex; // column position according to the database
+    int Length;        // maximum number of characters shown in the column
     int FieldLen;      // # of bytes in the file used by this field/column
-    char* Type;        // alokovany popis typu sloupce
-    int Decimals;      // pocet cislic za desetinnout teckou nebo -1, pokud neni znam
+    char* Type;        // allocated description of the column type
+    int Decimals;      // number of digits after the decimal point or -1 if unknown
 };
 
 //****************************************************************************
 //
 // CDatabase
 //
-// Oddeleni mezi skutecnou databazi a viewerem. V pripade, ze uzivatel nezmeni
-// poradi razeni a chce videt vsechny polozky, dochazi k suchemu volani DBFLib.
-// V opacnem pripade se pouzije pole Rows, ktere se na zaklade pozadavku (potlaceni
-// smazanych polozek, sort) naplni a slouzi pro premapovani.
+// Separation between the actual database and the viewer. If the user does not
+// change the sort order and wants to see all items, DBFLib is called directly.
+// Otherwise the Rows array is used, which is filled on demand (hide deleted
+// items, sorting) and serves for remapping.
 //
 
 class CRendererWindow;
@@ -38,16 +38,16 @@ class CParserInterfaceAbstract;
 class CDatabase
 {
 private:
-    // alokovany nazev prave otevrene databaze
-    char* FileName; // jmeno otevreneho souboru nebo NULL
+    // allocated name of the currently opened database
+    char* FileName; // name of the opened file or NULL
     CParserInterfaceAbstract* Parser;
-    CRendererWindow* Renderer; // ukazatel na vlastnika
+    CRendererWindow* Renderer; // pointer to the owner
 
-    // sloupce vyctene ze struktury databaze
+    // columns read from the database structure
     TDirectArray<CDatabaseColumn> Columns;
-    // index viditelnych sloupcu -- plni s v UpdateColumnsInfo
+    // indices of visible columns -- filled in UpdateColumnsInfo
     TDirectArray<DWORD> VisibleColumns;
-    // pokud doslo k zmene v poli Columns
+    // set if the Columns array changed
     BOOL ColumnsDirty;
     BOOL IsUnicode;
     BOOL IsUTF8;
@@ -61,35 +61,35 @@ public:
 
     void SetRenderer(CRendererWindow* renderer) { Renderer = renderer; }
 
-    // otevre soubor a vrati TRUE, pokud se to povedlo
+    // open a file and return TRUE on success
     BOOL Open(const char* fileName);
     void Close();
 
-    // vraci TRUE, pokud je databaze otevrena a vsechny promenne inicializovany
+    // return TRUE if the database is open and all variables are initialized
     BOOL IsOpened() { return Parser != NULL; }
 
     // "", "dbf", "csv"
     const char* GetParserName();
 
-    // vraci nazev otevrene databaze nebo NULL
+    // return the opened database name or NULL
     const char* GetFileName() { return FileName; }
 
-    // naplni predhozeny edit control informacema o databazi
+    // fill the supplied edit control with database information
     BOOL GetFileInfo(HWND hEdit);
 
     BOOL GetIsUnicode() { return IsUnicode; };
     BOOL GetIsUTF8() { return IsUTF8; };
 
-    // vraci pocet sloupcu nactenych z databaze
+    // return the number of columns read from the database
     int GetColumnCount() { return Columns.Count; }
-    // vraci odpovidajici sloupec
+    // return the corresponding column
     const CDatabaseColumn* GetColumn(int index) { return &Columns[index]; }
     void SetColumn(int index, const CDatabaseColumn* column)
     {
         Columns[index] = *column;
         ColumnsDirty = TRUE;
     }
-    // vraci odpovidajici viditelny sloupec
+    // return the corresponding visible column
     const CDatabaseColumn* GetVisibleColumn(int index);
     void SetVisibleColumn(int index, const CDatabaseColumn* column)
     {
@@ -97,31 +97,31 @@ public:
         ColumnsDirty = TRUE;
     }
 
-    // napocita VisibleColumnCount a VisibleColumnsWidth
+    // compute VisibleColumnCount and VisibleColumnsWidth
     void UpdateColumnsInfo();
 
-    // vraci sirku viditelnych sloupcu
+    // return the width of visible columns
     int GetVisibleColumnsWidth();
-    // vraci pocet zobrazenych sloupcu
+    // return the number of displayed columns
     int GetVisibleColumnCount();
-    // vraci X souradnici sloupce
+    // return the X coordinate of a column
     int GetVisibleColumnX(int colIndex);
 
-    // vraci skutecny pocet recordu v databazi
+    // return the real number of records in the database
 
-    // vraci pocet zobrazovanych radku
+    // return the number of displayed rows
     int GetRowCount();
 
-    // vytahne do bufferu odpovidajici zaznam a vrati TRUE
-    // v pripade chyby vrati FALSE a zobrazi chybu k oknu hParent
+    // load the corresponding record into the buffer and return TRUE
+    // on failure return FALSE and show an error for the hParent window
     BOOL FetchRecord(HWND hParent, DWORD rowIndex);
 
-    // operace nad vytazenym radkem
+    // operations on the fetched row
     BOOL IsRecordDeleted();
 
-    // operace nad vytazenym radkem
-    // column urcuje sloupce, pro ktery bude vytazen text
-    // do promenne len bude nastavena delka radku
+    // operations on the fetched row
+    // column selects the column for which the text will be retrieved
+    // len is set to the row length
     const char* GetCellText(const CDatabaseColumn* column, size_t* textLen);
     const wchar_t* GetCellTextW(const CDatabaseColumn* column, size_t* textLen);
 };

--- a/src/plugins/dbviewer/dbviewer.h
+++ b/src/plugins/dbviewer/dbviewer.h
@@ -109,22 +109,22 @@ enum CViewerWindowEnablerEnum
 class CViewerWindow : public CWindow
 {
 public:
-    HANDLE Lock; // 'lock' objekt nebo NULL (do signaled stavu az zavreme soubor)
+    HANDLE Lock; // 'lock' object or NULL (goes to the signaled state once the file is closed)
     CRendererWindow Renderer;
-    int ConversionsCount; // pocet konverzi vytazenych vcetna Don't covnert; bez separatoru
+    int ConversionsCount; // number of conversions retrieved including "Don't convert"; without separators
     CCSVConfig CfgCSV;
     CFindDialog FindDialog;
 
-    HWND HRebar; // drzi MenuBar a ToolBar
+    HWND HRebar; // holds the MenuBar and ToolBar
     CGUIMenuPopupAbstract* MainMenu;
     CGUIMenuBarAbstract* MenuBar;
     CGUIToolBarAbstract* ToolBar;
 
-    HIMAGELIST HGrayToolBarImageList; // toolbar a menu v sedivem provedeni (pocitano z barevneho)
-    HIMAGELIST HHotToolBarImageList;  // toolbar a menu v barevnem provedeni
+    HIMAGELIST HGrayToolBarImageList; // toolbar and menu in a gray variant (derived from the colored one)
+    HIMAGELIST HHotToolBarImageList;  // toolbar and menu in a colored variant
 
     DWORD Enablers[vweCount];
-    BOOL IsSrcFileSelected; // platne jen je-li Enablers[vweSelSrcFile]==TRUE: TRUE/FALSE zdrojovy soubor je selected/unselected
+    BOOL IsSrcFileSelected; // valid only if Enablers[vweSelSrcFile]==TRUE: TRUE/FALSE source file is selected/unselected
 
 public:
     CViewerWindow(int enumFilesSourceUID, int enumFilesCurrentIndex);

--- a/src/plugins/dbviewer/dbviewer.rh2
+++ b/src/plugins/dbviewer/dbviewer.rh2
@@ -7,7 +7,7 @@
 #endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
 
 #define IDC_STATIC_1 13000
-#include "statics.rh2"   // 13000 az 13039 jsou timto zabrane !!!
+#include "statics.rh2"   // the range 13000 to 13039 is already taken by this include
 
 // Bitmaps
 #define IDB_TOOLBAR16               9970

--- a/src/plugins/dbviewer/dialogs.cpp
+++ b/src/plugins/dbviewer/dialogs.cpp
@@ -51,7 +51,7 @@ void HistoryComboBox(HWND hWindow, CTransferInfo& ti, int ctrlID, char* Text,
             SendMessage(hwnd, CB_LIMITTEXT, textLen - 1, 0);
             SendMessage(hwnd, WM_SETTEXT, 0, (LPARAM)Text);
 
-            // vse o.k. zalozime do historie
+            // everything is OK, add it to the history
             if (ti.IsGood())
             {
                 if (Text[0] != 0)
@@ -62,8 +62,8 @@ void HistoryComboBox(HWND hWindow, CTransferInfo& ti, int ctrlID, char* Text,
                     {
                         if (history[i] != NULL)
                         {
-                            if (strcmp(history[i], Text) == 0) // je-li uz v historii
-                            {                                  // pujde na 0. pozici
+                            if (strcmp(history[i], Text) == 0) // if already in the history
+                            {                                  // move it to position 0
                                 if (i > 0)
                                 {
                                     char* swap = history[i];
@@ -97,7 +97,7 @@ void HistoryComboBox(HWND hWindow, CTransferInfo& ti, int ctrlID, char* Text,
         }
 
         int i;
-        for (i = 0; i < historySize; i++) // naplneni listu combo-boxu
+        for (i = 0; i < historySize; i++) // fill the combo box list
             if (history[i] != NULL)
                 SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM)history[i]);
             else
@@ -127,10 +127,10 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
     {
-        // horizontalni i vertikalni vycentrovani dialogu k parentu
+        // horizontally and vertically center the dialog relative to the parent
         if (Parent != NULL)
             SalGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
-        break; // chci focus od DefDlgProc
+        break; // let DefDlgProc handle focus
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);
@@ -197,7 +197,7 @@ CGoToDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 // CCSVOptionsDialog
 //
 
-// slouzi pro neustale prepisovani jednoho povoleneho znaku
+// used to repeatedly overwrite a single allowed character
 class COneCharEditLine : public CWindow
 {
 public:
@@ -250,7 +250,7 @@ void CCSVOptionsDialog::MyTransfer(CTransferInfo& ti, CCSVConfig* cfg)
     }
     ti.EditLine(IDE_CSV_OTHER, buff, 2);
     if (ti.Type == ttDataFromWindow)
-        cfg->ValueSeparatorChar = buff[0]; // kdyz bude prazdny retezec, bude to '\0'
+        cfg->ValueSeparatorChar = buff[0]; // if the string is empty, this becomes '\0'
 
     ti.RadioButton(IDC_CSV_AS_FR, 0, cfg->FirstRowAsName);
     ti.RadioButton(IDC_CSV_ASHEADER, 1, cfg->FirstRowAsName);
@@ -378,7 +378,7 @@ void CConfigurationDialog::SetFontText()
 
     HWND hEdit = GetDlgItem(HWindow, IDE_CFG_FONT);
     int oldHeight = logFont.lfHeight;
-    logFont.lfHeight = SalamanderGUI->GetWindowFontHeight(hEdit); // pro prezentaci fontu v edit line pouzijeme jeji velikost fontu
+    logFont.lfHeight = SalamanderGUI->GetWindowFontHeight(hEdit); // for presenting the font in the edit line use its font size
     if (HFont != NULL)
         DeleteObject(HFont);
     HFont = CreateFontIndirect(&logFont);
@@ -413,8 +413,8 @@ CConfigurationDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
         case IDB_CFG_FONT:
         {
-            /* slouzi pro skript export_mnu.py, ktery generuje salmenu.mnu pro Translator
-   udrzovat synchronizovane s volanim InsertMenu() dole...
+            /* used by the export_mnu.py script that generates salmenu.mnu for Translator
+   keep it synchronized with the InsertMenu() calls below...
 MENU_TEMPLATE_ITEM ConfigurationDialogMenu[] = 
 {
   {MNTT_PB, 0
@@ -480,7 +480,7 @@ CColumnsDialog::CColumnsDialog(HWND hParent, CRendererWindow* renderer)
     Renderer = renderer;
     HListView = NULL;
     DisableNotification = FALSE;
-    // natahneme si sloupce k nam, abychom nad nima mohli konfigurovat
+    // pull the columns locally so that we can configure them
     int i;
     for (i = 0; i < Renderer->Database.GetColumnCount(); i++)
         MyColumns.Add(*Renderer->Database.GetColumn(i));
@@ -546,7 +546,7 @@ void CColumnsDialog::Transfer(CTransferInfo& ti)
     }
     else
     {
-        // vratime zmenene sloupce do okna
+        // send the modified columns back to the window
         int i;
         for (i = 0; i < MyColumns.Count; i++)
             Renderer->Database.SetColumn(i, &MyColumns[i]);
@@ -556,7 +556,7 @@ void CColumnsDialog::Transfer(CTransferInfo& ti)
 
 void CColumnsDialog::Validate(CTransferInfo& ti)
 {
-    // alespon jeden sloupec musi zustat zobrazeny
+    // at least one column must remain visible
     BOOL visible = FALSE;
     int i;
     for (i = 0; i < MyColumns.Count; i++)
@@ -652,12 +652,12 @@ CColumnsDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DWORD origFlags = ListView_GetExtendedListViewStyle(HListView);
         ListView_SetExtendedListViewStyle(HListView, origFlags | exFlags); // 4.71
 
-        // zjistim velikost listview
+        // determine the list view size
         RECT r;
         GetClientRect(HListView, &r);
         int colWidth = (int)(r.right / 4);
 
-        // naleju do listview sloupce Name
+        // populate the list view with the Name column
         LVCOLUMN lvc;
         lvc.mask = LVCF_TEXT | LVCF_WIDTH | LVCF_FMT;
         lvc.pszText = LoadStr(IDS_COLUMNS_NAME);
@@ -694,7 +694,7 @@ CColumnsDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (LOWORD(wParam) == IDC_COL_RESTORE)
         {
-            // nahazime originalni hodnoty
+            // load the original values
             int i;
             for (i = 0; i < MyColumns.Count; i++)
             {
@@ -704,11 +704,11 @@ CColumnsDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     if (Renderer->Database.GetColumn(j)->OriginalIndex == i)
                     {
                         MyColumns[i] = *Renderer->Database.GetColumn(j);
-                        MyColumns[i].Visible = TRUE; // na zacatku byly vsechny sloupce viditelne
+                        MyColumns[i].Visible = TRUE; // initially all columns were visible
                         break;
                     }
                 }
-                // promitneme do LV
+                // reflect it in the list view
                 SetLVTexts(i);
             }
             return 0;
@@ -815,9 +815,9 @@ void CFindDialog::Transfer(CTransferInfo& ti)
                     FIND_HISTORY_SIZE, FindHistory);
     /*
   if (ti.Type == ttDataToWindow)
-  { // inicializace hledaneho textu podle oznaceni ve viewru (parent tohoto dialogu)
+  { // initialize the searched text according to the selection in the viewer (parent of this dialog)
     CWindowsObject *win = WindowsManager.GetWindowPtr(Parent);
-    if (win != NULL && win->Is(otViewerWindow))  // pro jistotu test je-li to okno viewru
+    if (win != NULL && win->Is(otViewerWindow))  // double-check that this is a viewer window
     {
       CViewerWindow *view = (CViewerWindow *)win;
       char buf[FIND_TEXT_LEN];

--- a/src/plugins/dbviewer/dialogs.h
+++ b/src/plugins/dbviewer/dialogs.h
@@ -5,14 +5,14 @@
 
 class CRendererWindow;
 
-#define FIND_HISTORY_SIZE 10 // pocet pamatovanych stringu
+#define FIND_HISTORY_SIZE 10 // number of remembered strings
 extern char* FindHistory[FIND_HISTORY_SIZE];
 
 //****************************************************************************
 //
 // CCommonDialog
 //
-// Dialog centrovany k parentu
+// Dialog centered relative to the parent
 //
 
 class CCommonDialog : public CDialog
@@ -111,7 +111,7 @@ public:
 protected:
     INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-    void SetFontText(); // na zaklade aktualniho fontu nastavi text v okenku
+    void SetFontText(); // set the text in the control based on the current font
 };
 
 //****************************************************************************
@@ -125,7 +125,7 @@ protected:
     CRendererWindow* Renderer;
     HWND HListView;
     BOOL DisableNotification;
-    TDirectArray<CDatabaseColumn> MyColumns; // kopie sloupcu pro ucely konfigurace
+    TDirectArray<CDatabaseColumn> MyColumns; // copy of columns for configuration purposes
     DWORD MinDlgW, MinDlgH, PrevDlgW, PrevDlgH;
 
 public:
@@ -141,7 +141,7 @@ protected:
 
     void RecalcLayout(DWORD NewDlgW, DWORD NewDlgH);
 
-    void SetLVTexts(int index); // podle MyColumns nastavi sloupce v LV
+    void SetLVTexts(int index); // configure list view columns according to MyColumns
 };
 
 // ****************************************************************************

--- a/src/plugins/dbviewer/help/hh/salamander_help_shared.css
+++ b/src/plugins/dbviewer/help/hh/salamander_help_shared.css
@@ -206,14 +206,14 @@
 
 #help_page td.hdr
 {
-  /* tmavsi seda na leve strane */
+  /* darker gray on the left side */
   margin: .25em;
   background: #dddddd;
   vertical-align: top;
   padding: 2px 4px;
   font-weight: bold;
-  width: 10%;           /* zuzime levou stranu tabulky na minimum */
-  padding-right :10px;  /* ale nechame tam alespon 10 bodu, at to trochu vypada */
+  width: 10%;           /* shrink the left side of the table to the minimum */
+  padding-right :10px;  /* but keep at least 10 points so it still looks good */
   white-space: nowrap;
 }
 

--- a/src/plugins/dbviewer/parser.cpp
+++ b/src/plugins/dbviewer/parser.cpp
@@ -179,20 +179,20 @@ CParserInterfaceDBF::OpenFile(const char* fileName)
     if (Dbf != NULL)
         CloseFile();
 
-    // otevreme soubor v read-only rezimu
+    // open the file in read-only mode
     Dbf = new cDBF(fileName, TRUE);
     if (Dbf != NULL)
     {
         if (Dbf->GetStatus() == DBFE_OK)
         {
-            // naplnime pole sloupcu
+            // populate the column array
             DBF_HEADER* hdr = Dbf->GetHeader();
             DBF_FIELD* field = Dbf->GetFields();
 
             DbfHdr = hdr;
             DbfFields = field;
 
-            // pripravime buffer pro prijem dat
+            // prepare a buffer for receiving data
             if (Record != NULL)
             {
                 free(Record);
@@ -208,7 +208,7 @@ CParserInterfaceDBF::OpenFile(const char* fileName)
         else
         {
             status = TranslateDBFStatus(Dbf->GetStatus());
-            CloseFile(); // po Close bude Dbf=NULL
+            CloseFile(); // after Close Dbf will be NULL
         }
     }
     else
@@ -243,7 +243,7 @@ BOOL CParserInterfaceDBF::GetFileInfo(HWND hEdit)
 {
     if (Dbf == NULL)
     {
-        TRACE_E("Chybne volani CParserInterfaceDBF::GetFileInfo: Dbf == NULL");
+        TRACE_E("Invalid call to CParserInterfaceDBF::GetFileInfo: Dbf == NULL");
         return FALSE;
     }
 
@@ -256,7 +256,7 @@ BOOL CParserInterfaceDBF::GetFileInfo(HWND hEdit)
     sprintf(buff, "%s\r\n\r\n", FileName);
     SendMessage(hEdit, EM_REPLACESEL, FALSE, (LPARAM)buff);
 
-    // zjistime informace o souboru (size, date&time)
+    // obtain file information (size, date & time)
     HANDLE file = CreateFile(FileName, GENERIC_READ,
                              FILE_SHARE_READ | FILE_SHARE_WRITE,
                              NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -266,7 +266,7 @@ BOOL CParserInterfaceDBF::GetFileInfo(HWND hEdit)
         CQuadWord fileSize;
         GetFileTime(file, NULL, NULL, &fileTime);
         DWORD err;
-        SalGeneral->SalGetFileSize(file, fileSize, err); // chyby ignorujeme
+        SalGeneral->SalGetFileSize(file, fileSize, err); // ignore errors
         CloseHandle(file);
 
         SYSTEMTIME st;
@@ -342,7 +342,7 @@ CParserInterfaceDBF::GetRecordCount()
 {
     if (Dbf == NULL)
     {
-        TRACE_E("Chybne volani CParserInterfaceDBF::GetRecordCount: Dbf == NULL");
+        TRACE_E("Invalid call to CParserInterfaceDBF::GetRecordCount: Dbf == NULL");
         return 0;
     }
     return DbfHdr->recordsCnt;
@@ -353,7 +353,7 @@ CParserInterfaceDBF::GetFieldCount()
 {
     if (Dbf == NULL)
     {
-        TRACE_E("Chybne volani CParserInterfaceDBF::GetFieldCount: Dbf == NULL");
+        TRACE_E("Invalid call to CParserInterfaceDBF::GetFieldCount: Dbf == NULL");
         return 0;
     }
     return DbfHdr->fieldsCnt;
@@ -363,7 +363,7 @@ BOOL CParserInterfaceDBF::GetFieldInfo(DWORD index, CFieldInfo* info)
 {
     if (Dbf == NULL || info == NULL || index >= DbfHdr->fieldsCnt)
     {
-        TRACE_E("Chybne volani CParserInterfaceDBF::GetFieldInfo");
+        TRACE_E("Invalid call to CParserInterfaceDBF::GetFieldInfo");
         return FALSE;
     }
 
@@ -464,7 +464,7 @@ BOOL CParserInterfaceDBF::GetFieldInfo(DWORD index, CFieldInfo* info)
     if (field->type == DBF_FTYPE_NUM)
         info->Decimals = field->decimals;
     else
-        info->Decimals = -1; // nezobrazime nic
+        info->Decimals = -1; // show nothing
 
     return TRUE;
 }
@@ -474,7 +474,7 @@ CParserInterfaceDBF::FetchRecord(DWORD index)
 {
     if (Dbf == NULL || index >= DbfHdr->recordsCnt)
     {
-        TRACE_E("Chybne volani CParserInterfaceDBF::FetchRecord");
+        TRACE_E("Invalid call to CParserInterfaceDBF::FetchRecord");
         return psCount;
     }
 
@@ -496,10 +496,10 @@ char* Int64ToCurrency(char* buffer, __int64 number)
   else
   {
     DecimalSeparatorLen--;
-    DecimalSeparator[DecimalSeparatorLen] = 0;  // posychrujeme nulu na konci
+    DecimalSeparator[DecimalSeparatorLen] = 0;  // ensure a zero terminator at the end
   }
   */
-    // ostatni hodnoty v DBF obsahuji '.' jako desetinny oddelovac, takze nepouzijeme systemovy
+    // other DBF values use '.' as the decimal separator, so we do not use the system one
     int DecimalSeparatorLen = 1;
     char DecimalSeparator[1] = {'.'};
 
@@ -562,7 +562,7 @@ CParserInterfaceDBF::GetCellText(DWORD index, size_t* textLen)
 {
     if (Dbf == NULL || textLen == NULL || index >= DbfHdr->fieldsCnt)
     {
-        TRACE_E("Chybne volani CParserInterfaceDBF::GetCellText");
+        TRACE_E("Invalid call to CParserInterfaceDBF::GetCellText");
         if (textLen != NULL)
             *textLen = 0;
         return "";
@@ -740,7 +740,7 @@ CParserInterfaceDBF::GetCellText(DWORD index, size_t* textLen)
 const wchar_t*
 CParserInterfaceDBF::GetCellTextW(DWORD index, size_t* textLen)
 {
-    TRACE_E("Chybne volani CParserInterfaceDBF::GetCellTextW");
+    TRACE_E("Invalid call to CParserInterfaceDBF::GetCellTextW");
     if (textLen != NULL)
         *textLen = 0;
     return L"";
@@ -787,7 +787,7 @@ BOOL CParserInterfaceDBF::IsRecordDeleted()
 {
     if (Dbf == NULL)
     {
-        TRACE_E("Chybne volani CParserInterfaceDBF::IsRecordDeleted()");
+        TRACE_E("Invalid call to CParserInterfaceDBF::IsRecordDeleted()");
         return FALSE;
     }
     return Record[0] == '*';
@@ -814,8 +814,8 @@ CParserInterfaceCSV::OpenFile(const char* fileName)
     if (Csv != NULL)
         CloseFile();
 
-    // otevreme soubor
-    char separator = ','; // default hodnota, pokud selze autodetekce
+    // open the file
+    char separator = ','; // default value if auto-detection fails
     BOOL autoSeparator = FALSE;
     switch (Config->ValueSeparator)
     {
@@ -839,7 +839,7 @@ CParserInterfaceCSV::OpenFile(const char* fileName)
         break;
     }
 
-    CCSVParserTextQualifier qualifier = CSVTQ_QUOTE; // default hodnota, pokud selze autodetekce
+    CCSVParserTextQualifier qualifier = CSVTQ_QUOTE; // default value if auto-detection fails
     BOOL autoQualifier = FALSE;
     switch (Config->TextQualifier)
     {
@@ -953,7 +953,7 @@ BOOL CParserInterfaceCSV::GetFileInfo(HWND hEdit)
 {
     if (Csv == NULL)
     {
-        TRACE_E("Chybne volani CParserInterfaceCSV::GetFileInfo: Csv == NULL");
+        TRACE_E("Invalid call to CParserInterfaceCSV::GetFileInfo: Csv == NULL");
         return FALSE;
     }
 
@@ -966,7 +966,7 @@ BOOL CParserInterfaceCSV::GetFileInfo(HWND hEdit)
     sprintf(buff, "%s\r\n\r\n", FileName);
     SendMessage(hEdit, EM_REPLACESEL, FALSE, (LPARAM)buff);
 
-    // zjistime informace o souboru (size, date&time)
+    // obtain file information (size, date & time)
     HANDLE file = CreateFile(FileName, GENERIC_READ,
                              FILE_SHARE_READ | FILE_SHARE_WRITE,
                              NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -976,7 +976,7 @@ BOOL CParserInterfaceCSV::GetFileInfo(HWND hEdit)
         CQuadWord fileSize;
         GetFileTime(file, NULL, NULL, &fileTime);
         DWORD err;
-        SalGeneral->SalGetFileSize(file, fileSize, err); // chyby ignorujeme
+        SalGeneral->SalGetFileSize(file, fileSize, err); // ignore errors
         CloseHandle(file);
 
         SYSTEMTIME st;
@@ -1009,7 +1009,7 @@ CParserInterfaceCSV::GetRecordCount()
 {
     if (Csv == NULL)
     {
-        TRACE_E("Chybne volani CParserInterfaceCSV::GetRecordCount: Csv == NULL");
+        TRACE_E("Invalid call to CParserInterfaceCSV::GetRecordCount: Csv == NULL");
         return 0;
     }
     return Csv->GetRecordsCnt();
@@ -1020,7 +1020,7 @@ CParserInterfaceCSV::GetFieldCount()
 {
     if (Csv == NULL)
     {
-        TRACE_E("Chybne volani CParserInterfaceCSV::GetFieldCount: Csv == NULL");
+        TRACE_E("Invalid call to CParserInterfaceCSV::GetFieldCount: Csv == NULL");
         return 0;
     }
 
@@ -1031,7 +1031,7 @@ BOOL CParserInterfaceCSV::GetFieldInfo(DWORD index, CFieldInfo* info)
 {
     if (Csv == NULL || index >= Csv->GetColumnsCnt())
     {
-        TRACE_E("Chybne volani CParserInterfaceCSV::GetFieldInfo");
+        TRACE_E("Invalid call to CParserInterfaceCSV::GetFieldInfo");
         return FALSE;
     }
 
@@ -1086,7 +1086,7 @@ CParserInterfaceCSV::FetchRecord(DWORD index)
 {
     if (Csv == NULL || index >= Csv->GetRecordsCnt())
     {
-        TRACE_E("Chybne volani CParserInterfaceCSV::FetchRecord");
+        TRACE_E("Invalid call to CParserInterfaceCSV::FetchRecord");
         return psCount;
     }
     return TranslateCSVStatus(Csv->FetchRecord(index));
@@ -1097,7 +1097,7 @@ CParserInterfaceCSV::GetCellText(DWORD index, size_t* textLen)
 {
     if (IsUnicode || Csv == NULL || index >= Csv->GetColumnsCnt())
     {
-        TRACE_E("Chybne volani CParserInterfaceCSV::GetCellText");
+        TRACE_E("Invalid call to CParserInterfaceCSV::GetCellText");
         *textLen = 0;
         return "";
     }
@@ -1109,7 +1109,7 @@ CParserInterfaceCSV::GetCellTextW(DWORD index, size_t* textLen)
 {
     if (!IsUnicode || Csv == NULL || index >= Csv->GetColumnsCnt())
     {
-        TRACE_E("Chybne volani CParserInterfaceCSV::GetCellTextW");
+        TRACE_E("Invalid call to CParserInterfaceCSV::GetCellTextW");
         *textLen = 0;
         return L"";
     }
@@ -1153,6 +1153,6 @@ CParserInterfaceCSV::TranslateCSVStatus(CCSVParserStatus status)
 
 BOOL CParserInterfaceCSV::IsRecordDeleted()
 {
-    // CSV format nepodporuje tento stav
+    // the CSV format does not support this state
     return FALSE;
 }

--- a/src/plugins/dbviewer/precomp.cpp
+++ b/src/plugins/dbviewer/precomp.cpp
@@ -3,9 +3,9 @@
 
 #include "precomp.h"
 
-// projekt Salamander obsahuje ctyri skupiny modulu
+// the Salamander project contains four groups of modules
 //
-// 1) modul precomp.cpp, ktery postavi salamand.pch (/Yc"precomp.h")
-// 2) moduly vyuzivajici salamand.pch (/Yu"precomp.h")
-// 3) commony a tasklist.cpp maji vlastni, automaticky generovany
+// 1) precomp.cpp module that builds salamand.pch (/Yc"precomp.h")
+// 2) modules that use salamand.pch (/Yu"precomp.h")
+// 3) commons and tasklist.cpp have their own automatically generated
 //    WINDOWS.PCH (/YX"windows.h" /Fp"$(OutDir)\WINDOWS.PCH")

--- a/src/plugins/dbviewer/renderer.h
+++ b/src/plugins/dbviewer/renderer.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-extern BOOL IsAlphaNumeric[256]; // pole TRUE/FALSE pro znaky (FALSE = neni pismeno ani cislice)
+extern BOOL IsAlphaNumeric[256]; // TRUE/FALSE table for characters (FALSE = neither a letter nor a digit)
 extern BOOL IsAlpha[256];
 
 //****************************************************************************
@@ -14,38 +14,38 @@ extern BOOL IsAlpha[256];
 class CSelection
 {
 private:
-    int FocusX;  // X souradnice focusu
-    int FocusY;  // Y souradnice focusu
-    int AnchorX; // pokud je tazen select, druhy roh proti focusu
-    int AnchorY; // pokud je tazen select, druhy roh proti focusu
-    // v pripade, ze je vybrana pouze jedna polozka, je Anchor? == Focus?
+    int FocusX;  // X coordinate of the focus
+    int FocusY;  // Y coordinate of the focus
+    int AnchorX; // if the selection is dragged, opposite corner to the focus
+    int AnchorY; // if the selection is dragged, opposite corner to the focus
+    // if only one item is selected, Anchor? == Focus?
 
-    RECT Rect; // normalizovany obdelnik
+    RECT Rect; // normalized rectangle
 
 public:
     CSelection();
 
     CSelection& operator=(const CSelection& s);
 
-    // vrati TRUE, pokud bunka [x,y] lezi uvnitr vyberu
+    // return TRUE if cell [x,y] lies inside the selection
     BOOL Contains(int x, int y)
     {
         return x >= Rect.left && x <= Rect.right && y >= Rect.top && y <= Rect.bottom;
     }
 
-    // vrati TRUE, pokud sloupec x lezi uvnitr vyberu
+    // return TRUE if column x lies inside the selection
     BOOL ContainsColumn(int x)
     {
         return x >= Rect.left && x <= Rect.right;
     }
 
-    // vrati TRUE, pokud radek y lezi uvnitr vyberu
+    // return TRUE if row y lies inside the selection
     BOOL ContainsRow(int y)
     {
         return y >= Rect.top && y <= Rect.bottom;
     }
 
-    // vrati TRUE, pokud bunka [x,y] odpovida focused bunce
+    // return TRUE if cell [x,y] is the focused cell
     BOOL IsFocus(int x, int y)
     {
         return x == FocusX && y == FocusY;
@@ -96,16 +96,16 @@ public:
         return FocusX == AnchorX && FocusY == AnchorY;
     }
 
-    // vrati TRUE, pokud bunka [x,y] mela v oldSelection jiny stav
+    // return TRUE if cell [x,y] had a different state in oldSelection
     BOOL Changed(const CSelection* old, int x, int y)
     {
-        // pokud se zmenil selected stav
+        // if the selection state changed
         BOOL sel = x >= Rect.left && x <= Rect.right && y >= Rect.top && y <= Rect.bottom;
         BOOL oldSel = x >= old->Rect.left && x <= old->Rect.right && y >= old->Rect.top && y <= old->Rect.bottom;
-        // nebo focused stav
+        // or if the focus state changed
         BOOL foc = FocusX == x && FocusY == y;
         BOOL oldFoc = old->FocusX == x && old->FocusY == y;
-        // vratime TRUE; jinak FALSE
+        // return TRUE; otherwise FALSE
         return foc != oldFoc || sel != oldSel;
     }
 
@@ -123,7 +123,7 @@ public:
         return sel != oldSel;
     }
 
-    // orizne vyber tak, aby nepresahoval sirku urcenou promennou maxX
+    // trim the selection so it does not exceed the width defined by maxX
     void Clip(int maxX)
     {
         if (FocusX > maxX)
@@ -134,8 +134,8 @@ public:
     }
 
 private:
-    // napocita promennou Rect na zaklade Focus? a Anchor?
-    // je treba zavolat po kazde zmene Focus? nebo Anchor?
+    // compute Rect based on Focus? and Anchor?
+    // must be called after each change of Focus? or Anchor?
     void Normalize();
 };
 
@@ -147,8 +147,8 @@ private:
 struct CBookmark
 {
 public:
-    int X; // X souradnice bookmarku
-    int Y; // Y souradnice bookmarku
+    int X; // X coordinate of the bookmark
+    int Y; // Y coordinate of the bookmark
 };
 
 //****************************************************************************
@@ -185,10 +185,10 @@ private:
 
 enum CDragSelectionMode
 {
-    dsmNormal,  // rolovani v obou smerech
-    dsmColumns, // rolovani horiznotalne
-    dsmRows,    // rolovani vertiklane
-    dsmNone     // nerolujeme
+    dsmNormal,  // scrolling in both directions
+    dsmColumns, // scrolling horizontally
+    dsmRows,    // scrolling vertically
+    dsmNone     // no scrolling
 };
 
 class CViewerWindow;
@@ -196,50 +196,50 @@ class CViewerWindow;
 class CRendererWindow : public CWindow
 {
 public:
-    CDatabase Database; // rozhrani pro praci s otevrenou databazi
+    CDatabase Database; // interface for working with the opened database
     CViewerWindow* Viewer;
 
-    // grafika
+    // graphics
     HPEN HGrayPen;
     HPEN HLtGrayPen;
     HPEN HSelectionPen;
     HPEN HBlackPen;
-    HFONT HFont; // zakladni font
+    HFONT HFont; // base font
     HICON HDeleteIcon;
     HICON HMarkedIcon;
-    int RowHeight;           // vyska radku
-    int CharAvgWidth;        // prumerna sirka znaku
-    int TopTextMargin;       // posunuti textu v ramci radku
-    int LeftTextMargin;      // posunuti textu v ramci radku
+    int RowHeight;           // row height
+    int CharAvgWidth;        // average character width
+    int TopTextMargin;       // vertical text offset within a row
+    int LeftTextMargin;      // horizontal text offset within a row
     int Width;               // client width
     int Height;              // client height
-    int RowsOnPage;          // pocet plne viditelnych radek na strance
-    int TopIndex;            // index prvni zobrazene radky
-    int XOffset;             // X souradnice prvniho zobrazeneho bodu
-    CSelection Selection;    // umisteni focusu a vyberu
-    CSelection OldSelection; // stare umisteni focusu a vyberu
-    CBookmarkList Bookmarks; // Bookmarky
+    int RowsOnPage;          // number of fully visible rows on the page
+    int TopIndex;            // index of the first displayed row
+    int XOffset;             // X coordinate of the first displayed point
+    CSelection Selection;    // focus and selection placement
+    CSelection OldSelection; // previous focus and selection placement
+    CBookmarkList Bookmarks; // bookmarks
 
-    CDragSelectionMode DragMode; // prave mysi tahneme selection
+    CDragSelectionMode DragMode; // selection is currently dragged with the mouse
     DWORD_PTR ScrollTimerID;
 
-    int DragColumn;       // pokud je ruzne od -1, tahneme sirku tohoto viditelneho sloupce
-    int DragColumnOffset; // ma vyznam pouze je-li DragColumn != -1
+    int DragColumn;       // if not -1, we drag the width of this visible column
+    int DragColumnOffset; // meaningful only when DragColumn != -1
 
-    BOOL Creating; // okno se vytvari -- zatim nemazat pozadi
+    BOOL Creating; // window is being created -- do not erase background yet
 
     BOOL AutoSelect;
     char Coding[210];
     char DefaultCoding[210];
-    BOOL UseCodeTable; // ma se prekodovavat podle CodeTable?
-    // CodeTable ma vyznam pouze je-li UseCodeTable rovno TRUE
-    char CodeTable[256]; // kodovaci tabulka
+    BOOL UseCodeTable; // should the CodeTable be used for recoding?
+    // CodeTable matters only when UseCodeTable is TRUE
+    char CodeTable[256]; // translation table
 
 protected:
-    int EnumFilesSourceUID;    // UID zdroje pro enumeraci souboru ve vieweru
-    int EnumFilesCurrentIndex; // index aktualniho souboru ve vieweru ve zdroji
+    int EnumFilesSourceUID;    // source UID for enumerating viewer files
+    int EnumFilesCurrentIndex; // index of the current file in the source
 
-    // slouzi pro akumulaci mikrokroku pri otaceni koleckem mysi, viz
+    // accumulates micro-steps when turning the mouse wheel, see
     // http://msdn.microsoft.com/en-us/library/ms997498.aspx (Best Practices for Supporting Microsoft Mouse and Keyboard Devices)
     int MouseWheelAccumulator;  // vertical
     int MouseHWheelAccumulator; // horizontal
@@ -254,21 +254,21 @@ public:
 
     BOOL OpenFile(const char* name, BOOL useDefaultConfig);
 
-    // nastavi info scrollbaram
+    // update scroll bar information
     void SetupScrollBars(DWORD update = UPDATE_VERT_SCROLL | UPDATE_HORZ_SCROLL);
 
-    void RebuildGraphics(); // volame pri zmene konfigurace
+    void RebuildGraphics(); // called when the configuration changes
 
-    // nakopci aktualni selection na clipboard
+    // copy the current selection to the clipboard
     void CopySelectionToClipboard();
 
-    // nastavi Selection tak, aby byl pres vsechny bunky a prekresli obrazovku
+    // set the selection to cover all cells and redraw the screen
     void SelectAll();
 
-    // pokud je conversion == NULL, bude nastaveno "Don't Convert"
+    // if conversion == NULL, "Don't Convert" will be applied
     void SelectConversion(const char* conversion);
 
-    // vola dialog pro spravu sloupcu
+    // invoke the column management dialog
     void ColumnsWasChanged();
 
     // Bookmarks
@@ -292,53 +292,53 @@ protected:
     void EnsureColumnIsVisible(int x);
     void EnsureRowIsVisible(int y);
 
-    void CreateGraphics();  // inicializace handlu
-    void ReleaseGraphics(); // jejich destrukce
+    void CreateGraphics();  // initialize handles
+    void ReleaseGraphics(); // destroy handles
 
-    // [x,y] jsou client souradnice okna; vrati [column,row] - souradnice bunky
-    // pokud je getNearest TRUE, vrati nejblizsi bunku i v pripade, ze neni primo pod bodem
-    // vraci TRUE, pokud nasel bunku a nastavil promenne column a row
+    // [x,y] are client coordinates of the window; returns [column,row] - cell coordinates
+    // if getNearest is TRUE, returns the nearest cell even if it is not directly under the point
+    // returns TRUE when a cell was found and the column and row values were set
     BOOL HitTest(int x, int y, int* column, int* row, BOOL getNearest);
     BOOL HitTestRow(int y, int* row, BOOL getNearest);
     BOOL HitTestColumn(int x, int* column, BOOL getNearest);
-    // vrati TRUE, pokud je x priblizne nad delicim sloupcem
-    // column a offset mohou byt NULL
+    // return TRUE if x is approximately above a divider between columns
+    // column and offset can be NULL
     BOOL HitTestColumnSplit(int x, int* column, int* offset);
 
-    // zahaji editaci bunky pod focusem
+    // start editing the cell under the focus
     //    void OnEditCell();
 
-    // najde sloupec s indexem visibleIndex a pokud ho najde,
-    // nastavi index dle jeho umisteni v poli Database.Column a xPos na
-    // jeho x souradnici a vrati TRUE
-    // jinak vrati FALSE
+    // find the column with the visibleIndex; if found,
+    // set index according to its position in Database.Column and xPos to
+    // its X coordinate and return TRUE;
+    // otherwise return FALSE
     BOOL GetColumnInfo(int visibleIndex, int* index, int* xPos);
 
-    // zapina a vypina casovac a stavove promenne behem tazeni bloku
+    // enable/disable the timer and state variables during block dragging
     void BeginSelectionDrag(CDragSelectionMode mode);
     void EndSelectionDrag();
     void OnTimer(WPARAM wParam);
 
-    // ukoncuje tazeni sirky sloupce
+    // finish column-width dragging
     void EndColumnDrag();
 
     void OnHScroll(int scrollCode, int pos);
     void OnVScroll(int scrollCode, int pos);
 
-    // volame po zmene velikosti okna, aby nedoslo k nesmyslnemu odrolovani
+    // called after resizing the window to prevent nonsensical scrolling
     void CheckAndCorrectBoundaries();
 
-    // pripravi buffer a necha Salamander rozpoznat kodovou stranku
+    // prepare the buffer and let Salamander detect the code page
     void RecognizeCodePage();
-    // konverti znaky v bufferu text
+    // convert characters in the text buffer
     void CodeCharacters(char* text, size_t textLen);
 
     void SetViewerTitle();
 
-    // vrati bod nad focusem nebo vybranym blokem
+    // return the point above the focus or the selected block
     void GetContextMenuPos(POINT* p);
 
-    // na souradnici 'p' vybali kontextove menu pro oznaceny blok
+    // display the context menu for the selected block at position 'p'
     void OnContextMenu(const POINT* p);
 
     void ResetMouseWheelAccumulator()

--- a/src/plugins/dbviewer/renpaint.cpp
+++ b/src/plugins/dbviewer/renpaint.cpp
@@ -38,13 +38,13 @@ void CRendererWindow::PaintTopMargin(HDC hDC, HRGN hUpdateRgn, const RECT* clipR
     {
         if (!selChangeOnly)
         {
-            // nakreslime nulty sloupec
+            // draw the zeroth column
             SelectClipRgn(hDC, hUpdateRgn);
             r.left = x;
             r.right = x + RowHeight - 1;
             ExtTextOut(hDC, x + LeftTextMargin, TopTextMargin, ETO_OPAQUE,
                        &r, "", 0, NULL);
-            // nakreslime oddelovaci cary
+            // draw separator lines
             MoveToEx(hDC, r.left, r.bottom, NULL);
             LineTo(hDC, r.right, r.bottom);
             LineTo(hDC, r.right, r.top - 1);
@@ -74,7 +74,7 @@ void CRendererWindow::PaintTopMargin(HDC hDC, HRGN hUpdateRgn, const RECT* clipR
                         inSelection = TRUE;
                     }
 
-                    // zobrazime text
+                    // display the text
 
                     if (selChangeOnly && x < RowHeight && !leftExcluded)
                     {
@@ -106,7 +106,7 @@ void CRendererWindow::PaintTopMargin(HDC hDC, HRGN hUpdateRgn, const RECT* clipR
                                     &r, colName, (UINT)wcslen(colName), NULL);
                     }
 
-                    // nakreslime oddelovaci cary
+                    // draw separator lines
                     MoveToEx(hDC, r.left, r.bottom, NULL);
                     LineTo(hDC, r.right, r.bottom);
                     LineTo(hDC, r.right, r.top - 1);
@@ -125,7 +125,7 @@ void CRendererWindow::PaintTopMargin(HDC hDC, HRGN hUpdateRgn, const RECT* clipR
 
     if (x < Width)
     {
-        // dokreslime prazdne misto za hlavickou
+        // fill the empty space behind the header
         r.left = x;
         r.right = Width;
         r.bottom++;
@@ -168,7 +168,7 @@ void CRendererWindow::PaintBody(HDC hDC, HRGN hUpdateRgn, const RECT* clipRect, 
             {
                 if (!selChangeOnly || Selection.ChangedRow(&OldSelection, i))
                 {
-                    // nakreslim levy sloupec
+                    // draw the left column
                     COLORREF oldBkColor2;
                     if (Selection.ContainsRow(i))
                     {
@@ -200,7 +200,7 @@ void CRendererWindow::PaintBody(HDC hDC, HRGN hUpdateRgn, const RECT* clipRect, 
                         DrawIconEx(hDC, (RowHeight - 16) / 2 + 1, r.top + (RowHeight - 16) / 2 + 1,
                                    HDeleteIcon, 0, 0, 0, NULL, DI_NORMAL);
                     }
-                    // nakreslime oddelovaci cary
+                    // draw separator lines
                     MoveToEx(hDC, r.left, r.bottom, NULL);
                     LineTo(hDC, r.right, r.bottom);
                     LineTo(hDC, r.right, r.top - 1);
@@ -213,7 +213,7 @@ void CRendererWindow::PaintBody(HDC hDC, HRGN hUpdateRgn, const RECT* clipRect, 
             SelectObject(hDC, HLtGrayPen);
             x = RowHeight - XOffset;
 
-            // nakreslim viditelne sloupce
+            // draw visible columns
             int visibleIndex = 0;
             int j;
             for (j = 0; j < Database.GetColumnCount(); j++)
@@ -227,7 +227,7 @@ void CRendererWindow::PaintBody(HDC hDC, HRGN hUpdateRgn, const RECT* clipRect, 
                         if (!selChangeOnly || Selection.Changed(&OldSelection, visibleIndex, i))
                         {
                             //              TRACE_I("Paint row="<<i<<" col="<<j);
-                            // vytahneme text
+                            // retrieve the text
                             if (fetchedIndex != i)
                             {
                                 if (!Database.FetchRecord(HWindow, i))
@@ -263,7 +263,7 @@ void CRendererWindow::PaintBody(HDC hDC, HRGN hUpdateRgn, const RECT* clipRect, 
                                     CodeCharacters(textBuffer, textLen);
                                 }
 
-                                // namerime sirku textu
+                                // measure the text width
                                 GetTextExtentPoint32A(hDC, textBuffer, (int)textLen, &sz);
                             }
                             else
@@ -272,7 +272,7 @@ void CRendererWindow::PaintBody(HDC hDC, HRGN hUpdateRgn, const RECT* clipRect, 
                                 GetTextExtentPoint32W(hDC, textW, (int)textLen, &sz);
                             }
 
-                            // nakreslime text
+                            // draw the text
                             int xOffset = 0;
                             if (!column->LeftAlign)
                                 xOffset = r.right - r.left - 2 * LeftTextMargin - sz.cx;
@@ -313,7 +313,7 @@ void CRendererWindow::PaintBody(HDC hDC, HRGN hUpdateRgn, const RECT* clipRect, 
                                 }
                             }
 
-                            // nakreslime oddelovaci cary
+                            // draw separator lines
                             MoveToEx(hDC, r.left, r.bottom, NULL);
                             LineTo(hDC, r.right, r.bottom);
                             LineTo(hDC, r.right, r.top - 1);
@@ -326,7 +326,7 @@ void CRendererWindow::PaintBody(HDC hDC, HRGN hUpdateRgn, const RECT* clipRect, 
 
             if (x < Width)
             {
-                // dokreslime zbytek prazdneho radku
+                // fill the remainder of the empty row
                 RECT r2;
                 r2 = r;
                 r2.left = x;
@@ -345,7 +345,7 @@ void CRendererWindow::PaintBody(HDC hDC, HRGN hUpdateRgn, const RECT* clipRect, 
 
     if (r.top < Height)
     {
-        // dokreslime prazdny prostor pod tabulkou
+        // fill the empty space below the table
         SelectClipRgn(hDC, hUpdateRgn);
         r.left = 0;
         r.right = Width;
@@ -388,7 +388,7 @@ void CRendererWindow::Paint(HDC hDC, HRGN hUpdateRgn, BOOL selChangeOnly)
         SelectObject(hDC, hOldFont);
 
         if (hUpdateRgn != NULL)
-            SelectClipRgn(hDC, NULL); // vykopneme clip region, pokud jsme ho nastavili
+            SelectClipRgn(hDC, NULL); // remove the clip region if it was set
 
         if (releaseDC)
             ReleaseDC(HWindow, hDC);

--- a/src/plugins/dbviewer/versinfo.rh2
+++ b/src/plugins/dbviewer/versinfo.rh2
@@ -13,7 +13,7 @@
 #define VERSINFO_MINORA      2
 #define VERSINFO_MINORB      4
 
-#include "spl_vers.h" // vytahneme cisla verzi + buildu
+#include "spl_vers.h" // retrieve the version and build numbers
 
 #define VERSINFO_COPYRIGHT   "Copyright © 2003-2023 Open Salamander Authors"
 #define VERSINFO_COMPANY     "Open Salamander"


### PR DESCRIPTION
## Summary
- translate the remaining Czech annotation in `dbviewer.rh2` to document the reserved resource ID range in English
- rewrite the CSV help stylesheet comments so layout hints and spacing notes are expressed in English
- convert the version info include note to English so the build metadata description is clear

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e231cb66e083229ac45e3a2cea8799