### PR TITLE
filecomp Translate additional comment blocks

### DIFF
--- a/src/plugins/filecomp/controls.h
+++ b/src/plugins/filecomp/controls.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-extern HFONT EnvFont;     // font prostredi (edit, toolbar, header, status)
-extern int EnvFontHeight; // vyska fontu
+extern HFONT EnvFont;     // environment font (edit, toolbar, header, status)
+extern int EnvFontHeight; // font height
 extern HBRUSH HDitheredBrush;
 
 // ****************************************************************************

--- a/src/plugins/filecomp/cwbase.h
+++ b/src/plugins/filecomp/cwbase.h
@@ -44,9 +44,9 @@ protected:
     };
     typedef std::vector<CCharProxy<CChar>> CStrictCompareData;
 
-    HWND MainWindow; // okno, ktere dostane WM_USER_WORKERNOTIFIES
+    HWND MainWindow; // window that receives WM_USER_WORKERNOTIFIES
     CCompareOptions& Options;
-    const int& CancelFlag; // 0 ... jedeme dal, jinak konec
+    const int& CancelFlag; // 0 ... keep going, otherwise finish
     CFCFileData Files[2];
 
     // work buffers for StrictCompare are to prevent offten re-allocation when

--- a/src/plugins/filecomp/cwoptim.cpp
+++ b/src/plugins/filecomp/cwoptim.cpp
@@ -7,7 +7,8 @@
 
 using namespace std;
 
-#if (_MSC_VER < 1910) // MSVC 2017 rve kvuli nestandardnimu namespace std::tr1 (deprecated), jde zrejme jen o unordered_map, ktere drive bylo jen v std::tr1 a ted je primo v std
+#if (_MSC_VER < 1910) // MSVC 2017 complains about the non-standard namespace std::tr1 (deprecated);
+                      // it is apparently just unordered_map, which used to live in std::tr1 and is now directly in std
 using namespace std::tr1;
 #endif
 
@@ -147,7 +148,7 @@ void CFilecompCoWorkerOptimized<CChar>::IdentifyLines(CFilecompCoWorkerBase<CCha
     int i;
     for (i = 0; i < 2; ++i)
     {
-        // rezerve space
+        // reserve space
         compareData[i].resize(files[i].Lines.size() - 1);
         // indentify each line
         typename CLineBuffer::iterator line = files[i].Lines.begin();
@@ -237,7 +238,7 @@ void CFilecompCoWorkerOptimized<CChar>::Compare(CTextFileReader (&reader)[2])
       }
     }*/
 
-        // shift-boundaries, volat pred RemoveSingleCharMatches
+        // shift-boundaries, call before RemoveSingleCharMatches
         this->ShiftBoundaries(editScript, compareData);
     }
 
@@ -267,19 +268,19 @@ void CFilecompCoWorkerOptimized<CChar>::Compare(CTextFileReader (&reader)[2])
 
     for (CEditScript::iterator esi = editScript.begin();; ++esi)
     {
-        // zpracujeme spolecnou cast
+        // process the shared part
         mend = esi >= editScript.end() ? this->Files[0].Lines.size() - 1 : esi->DeletePos;
         for (; li[0] < mend; li[0]++, li[1]++)
         {
             script[0].push_back(CLineSpec(CLineSpec::lcCommon, int(li[0])));
             script[1].push_back(CLineSpec(CLineSpec::lcCommon, int(li[1])));
         }
-        // konec?
+        // the end?
         if (esi >= editScript.end())
             break;
         if (this->CancelFlag)
             throw CFilecompWorker::CAbortByUserException();
-        // zpracujeme rozdilnou cast
+        // process the differing part
         if ((this->Options.IgnoreSpaceChange || this->Options.IgnoreAllSpace) &&
             IsChangeIgnorable(*esi))
         {
@@ -295,7 +296,7 @@ void CFilecompCoWorkerOptimized<CChar>::Compare(CTextFileReader (&reader)[2])
         else
         {
             changes.push_back(*esi);
-            changesToLines.push_back((int)script[0].size()); // oba by tu meli byt stejne dlouhe
+            changesToLines.push_back((int)script[0].size()); // both should have the same length here
             if (esi->Length[0] && esi->Length[1] && this->Options.DetailedDifferences)
             {
                 this->ScrictCompare(esi->Position, esi->Length, script, CLineSpec::lcChange);
@@ -315,7 +316,7 @@ void CFilecompCoWorkerOptimized<CChar>::Compare(CTextFileReader (&reader)[2])
             changesLengths.push_back(
                 (int)max(script[0].size(), script[1].size()) - changesToLines.back());
         }
-        // dorovname kratsi script
+        // align the shorter script
         int s = script[0].size() < script[1].size() ? 0 : 1;
         fill_n(back_inserter(script[s]),
                script[1 - s].size() - script[s].size(),

--- a/src/plugins/filecomp/dialogs.cpp
+++ b/src/plugins/filecomp/dialogs.cpp
@@ -10,7 +10,7 @@ ComDlgHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
                         lParam);
     if (uiMsg == WM_INITDIALOG)
     {
-        // SalamanderGUI->ArrangeHorizontalLines(hdlg);  // pro Windows common dialogy tohle nedelame
+        // SalamanderGUI->ArrangeHorizontalLines(hdlg);  // we do not do this for Windows common dialogs
         CenterWindow(hdlg);
         return 1;
     }
@@ -22,7 +22,7 @@ ComDlgHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
 // CCompareFilesDialog
 //
 
-// historie pro kombace
+// history for combo boxes
 
 TCHAR CBHistory[MAX_HISTORY_ENTRIES][MAX_PATH];
 int CBHistoryEntries;
@@ -32,7 +32,7 @@ void AddToHistory(LPCTSTR path)
     CALL_STACK_MESSAGE2(_T("AddToHistory(%s)"), path);
     int toMove = __min(CBHistoryEntries, MAX_HISTORY_ENTRIES - 1);
     int enlarge = 1;
-    // podivame jestli uz stejna cesta neni v historii
+    // check whether the same path is already in the history
     int i;
     for (i = 0; i < CBHistoryEntries; i++)
     {
@@ -43,7 +43,7 @@ void AddToHistory(LPCTSTR path)
             break;
         }
     }
-    // vytvorime misto pro cestu kterou budeme ukladat
+    // create space for the path we are going to store
     int j;
     for (j = toMove; j > 0; j--)
         _tcscpy(CBHistory[j], CBHistory[j - 1]);
@@ -119,7 +119,7 @@ OFNHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
   CALL_STACK_MESSAGE4("OFNHookProc(, 0x%X, 0x%IX, 0x%IX)", uiMsg, wParam, lParam);
   if (uiMsg == WM_INITDIALOG)
   {
-    // SalamanderGUI->ArrangeHorizontalLines(hdlg);  // pro Windows common dialogy tohle nedelame
+    // SalamanderGUI->ArrangeHorizontalLines(hdlg);  // we do not do this for Windows common dialogs
     HWND hwnd = GetParent(hdlg);
     CenterWindow(hdlg);
     return 1;
@@ -167,8 +167,8 @@ CCompareFilesDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         HWND hWnd1 = GetDlgItem(HWindow, IDE_PATH1), hWnd2 = GetDlgItem(HWindow, IDE_PATH2);
 
-        SG->InstallWordBreakProc(hWnd1); // instalujeme WordBreakProc do comboboxu
-        SG->InstallWordBreakProc(hWnd2); // instalujeme WordBreakProc do comboboxu
+        SG->InstallWordBreakProc(hWnd1); // install WordBreakProc into the combo box
+        SG->InstallWordBreakProc(hWnd2); // install WordBreakProc into the combo box
 
         // I believe OldEditProc1 and OldEditProc2 are equal. But I am rather paranoic...
         OldEditProc1 = (WNDPROC)GetWindowLongPtr(hWnd1, GWLP_WNDPROC);
@@ -180,11 +180,11 @@ CCompareFilesDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         SetWindowPos(HWindow, AlwaysOnTop ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 
-        // incializujeme historii
+        // initialize the history
         int i = 0;
         if (CBHistoryEntries > 1)
         {
-            // v druhem kombaci ulozime prvni dve cesty v obracenem poradi
+            // store the first two paths in the second combo box in reverse order
             for (; i < 2; i++)
             {
                 SendMessage(GetDlgItem(HWindow, IDE_PATH1), CB_ADDSTRING, 0, (LPARAM)CBHistory[i]);

--- a/src/plugins/filecomp/dialogs.h
+++ b/src/plugins/filecomp/dialogs.h
@@ -63,17 +63,17 @@ protected:
 
 struct CColorsCfgButton
 {
-    int TextID;         // nazev tlacitka
-    int ColorLineNumFG; // index FG barvy pro 1. tlacitko nebo -1 (FG nelze konfigurovat)
-    int ColorLineNumBK; // index BK barvy pro 1. tlacitko nebo -1 (tlaciko nebude videt)
-    int ColorTextFG;    // index FG barvy pro 2. tlacitko nebo -1 (FG nelze konfigurovat)
-    int ColorTextBK;    // index BK barvy pro 2. tlacitko nebo -1 (tlaciko nebude videt)
+    int TextID;         // button label identifier
+    int ColorLineNumFG; // index of the FG color for the first button or -1 (FG cannot be configured)
+    int ColorLineNumBK; // index of the BG color for the first button or -1 (the button will not be visible)
+    int ColorTextFG;    // index of the FG color for the second button or -1 (FG cannot be configured)
+    int ColorTextBK;    // index of the BG color for the second button or -1 (the button will not be visible)
 };
 
 struct CColorsCfgItem
 {
-    int TextID;       // nazev polozky
-    int ButtonsCount; // pocet pouzitych tlacitek
+    int TextID;       // item label identifier
+    int ButtonsCount; // number of buttons used
     CColorsCfgButton* Buttons;
 };
 
@@ -181,7 +181,7 @@ protected:
 //
 // CTextArrowButton
 //
-// klasicky text, za kterym je jeste sipka - slouzi pro rozbaleni menu
+// plain text followed by an arrow - used to expand a menu
 //
 
 // class CTextArrowButton : public CButton
@@ -197,7 +197,7 @@ protected:
 //
 // CColorArrowButton
 //
-// pozadi s textem, za kterym je jeste sipka - slouzi pro rozbaleni menu
+// background with text followed by an arrow - used to expand a menu
 //
 
 // class CColorArrowButton : public CButton

--- a/src/plugins/filecomp/dialogs2.cpp
+++ b/src/plugins/filecomp/dialogs2.cpp
@@ -188,20 +188,20 @@ void CPropPageColors::ChooseColor(int item, int colorFG, int colorBK, const RECT
     HMENU hMenu, hSubMenu;
     if (colorFG == -1)
     {
-        // vybirame jen jednu barvu
+        // pick only one color
         hMenu = LoadMenu(HLanguage, MAKEINTRESOURCE(IDM_CTX_1COLOR_MENU));
         hSubMenu = GetSubMenu(hMenu, 0);
     }
     else
     {
-        // vybirame dve barvy
+        // pick two colors
         hMenu = LoadMenu(HLanguage, MAKEINTRESOURCE(IDM_CTX_2COLOR_MENU));
         hSubMenu = GetSubMenu(hMenu, 0);
         automatic = GetFValue(TempColors[colorFG]) & SCF_DEFAULT;
         CheckMenuItem(hSubMenu, CM_CUSTOMTEXT, MF_BYCOMMAND | (automatic ? MF_UNCHECKED : MF_CHECKED));
         CheckMenuItem(hSubMenu, CM_AUTOTEXT, MF_BYCOMMAND | (automatic ? MF_CHECKED : MF_UNCHECKED));
 
-        // podivame se, zda existuje defaultni hodnota k teto barve
+        // check whether there is a default value for this color
         automatic = GetFValue(DefaultColors[colorFG]) & SCF_DEFAULT;
         EnableMenuItem(hSubMenu, CM_AUTOTEXT, MF_BYCOMMAND | (automatic ? MF_ENABLED : MF_GRAYED));
     }
@@ -209,7 +209,7 @@ void CPropPageColors::ChooseColor(int item, int colorFG, int colorBK, const RECT
     CheckMenuItem(hSubMenu, CM_CUSTOMBACKGROUND, MF_BYCOMMAND | (automatic ? MF_UNCHECKED : MF_CHECKED));
     CheckMenuItem(hSubMenu, CM_AUTOBACKGROUND, MF_BYCOMMAND | (automatic ? MF_CHECKED : MF_UNCHECKED));
 
-    // podivame se, zda existuje defaultni hodnota k teto barve
+    // check whether there is a default value for this color
     automatic = GetFValue(DefaultColors[colorBK]) & SCF_DEFAULT;
     EnableMenuItem(hSubMenu, CM_AUTOBACKGROUND, MF_BYCOMMAND | (automatic ? MF_ENABLED : MF_GRAYED));
 
@@ -221,7 +221,7 @@ void CPropPageColors::ChooseColor(int item, int colorFG, int colorBK, const RECT
                              btnRect->right, btnRect->top, HWindow, &tpmPar))
     {
     case CM_CUSTOMTEXT:
-        color = colorFG; // jedeme dal...
+        color = colorFG; // keep going...
     case CM_CUSTOMBACKGROUND:
     {
         CHOOSECOLOR cc;
@@ -276,10 +276,10 @@ CPropPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             ColorButtons[i][LINENUM_COLOR_BTN] = SalGUI->AttachColorArrowButton(HWindow, LineNumIDs[i], TRUE);
             ColorButtons[i][TEXT_COLOR_BTN] = SalGUI->AttachColorArrowButton(HWindow, TextIDs[i], TRUE);
-            // #pragma message(__FILE__ "(280) : Honzo, az tohle implementujes, tak nasledujici kod odkomentuj. Dik, Lukas.")
-            // j.r. FIXME: zatim jsem na to nemel cas, hazim pragmu do komentare, at nestrasi v buildu
-            // l.c., 13.2.2011 jen jsem na zkousku tu pragmu zas odkomentoval, estli jsi to nahodou mezitim nenakodil:)
-            // j.r., 23.3.2011 nizka priorita, zatim nebudeme resit
+            // #pragma message(__FILE__ "(280) : Honzo, once you implement this, uncomment the code below. Thanks, Lukas.")
+            // j.r. FIXME: I have not had time yet, so I am putting the pragma into a comment so it does not haunt the build
+            // l.c., 13.2.2011 I only uncommented the pragma as a test in case you coded it in the meantime :)
+            // j.r., 23.3.2011 low priority, we will not deal with it for now
             // ColorButtons[i][LINENUM_COLOR_BTN]->SetPalette(&HPalette, &UsePalette);
             // ColorButtons[i][TEXT_COLOR_BTN]->SetPalette(&HPalette, &UsePalette);
         }
@@ -359,9 +359,9 @@ CPropPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_NOTIFY:
     {
-        if (((NMHDR*)lParam)->code == PSN_SETACTIVE) // aktivace stranky
+        if (((NMHDR*)lParam)->code == PSN_SETACTIVE) // page activation
         {
-            // nastavime font pro preview
+            // set the font for the preview
             Preview1->SetFont(PageGeneral->GetCurrentFont());
             Preview2->SetFont(PageGeneral->GetCurrentFont());
             break;
@@ -372,10 +372,10 @@ CPropPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         LRESULT i = SendMessage(GetDlgItem(HWindow, IDC_ITEMS), CB_GETCURSEL, 0, 0);
         UpdateColors(int(i));
-        // #pragma message(__FILE__ "(375) : Honzo, az overis, ze se v CGUIColorArrowButton obnovuji pera automaticky, tak nasleduji komentar vymaz (nezamenovat s odkomentuj:). Dik Lukas")
-        // j.r. FIXME: zatim jsem na to nemel cas, hazim pragmu do komentare, at nestrasi v buildu
-        // l.c., 13.2.2011 jen jsem na zkousku tu pragmu zas odkomentoval, estli jsi to nahodou mezitim nenakodil:)
-        // j.r., 23.3.2011 nizka priorita, zatim nebudeme resit
+        // #pragma message(__FILE__ "(375) : Honzo, once you verify that CGUIColorArrowButton refreshes pens automatically, delete the following comment (do not confuse with uncomment :). Thanks, Lukas")
+        // j.r. FIXME: I have not had time yet, so I am putting the pragma into a comment so it does not haunt the build
+        // l.c., 13.2.2011 I only uncommented the pragma as a test in case you coded it in the meantime :)
+        // j.r., 23.3.2011 low priority, we will not deal with it for now
         // for (i = 0; i < 3; i++)
         // {
         //   ColorButtons[i][LINENUM_COLOR_BTN]->ColorsChanged();
@@ -522,7 +522,7 @@ void CPreviewWindow::RePaint()
 void CPreviewWindow::SetFont(LOGFONT* font)
 {
     CALL_STACK_MESSAGE1("CPreviewWindow::SetFont()");
-    // nacteme font
+    // load the font
     if (HFont)
         DeleteObject(HFont);
     HDC hdc = GetDC(NULL);
@@ -560,11 +560,11 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         IntersectClipRect(dc, cr.left, cr.top, cr.right, cr.bottom);
 
-        RECT r1; // cislo radky
+        RECT r1; // line number
         r1.left = 0;
         r1.right = (2 + 1) * FontWidth + BORDER_WIDTH;
-        r1.bottom = 0; // abychom meli pozdeji platna data, kdyby kreslici smycka vubec neprobehla
-        RECT r2;       // vlastni radek textu
+        r1.bottom = 0; // have valid data later if the drawing loop never runs
+        RECT r2;       // the actual text line
         r2.left = r1.right;
         r2.right = cr.right;
         int text_y;
@@ -582,12 +582,12 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (PreviewScript[i].TextColor == TEXT_FG_LEFT_CHANGE_FOCUSED ||
                 i > 0 && PreviewScript[i - 1].TextColor == TEXT_FG_LEFT_FOCUSED)
             {
-                // vykreslime cast ohraniceni aktivni difference na hornim okraji radku
-                // hrana ve sloupci s cisly radek
+                // draw part of the active difference border on the top edge of the line
+                // edge in the column with the line numbers
                 hOldPen = (HPEN)SelectObject(dc, HLineNumBorderPen);
                 MoveToEx(dc, r1.left, r1.top, NULL);
                 LineTo(dc, r1.right, r1.top);
-                // hrana ve casti s textem souboru
+                // edge in the file text area
                 (HPEN) SelectObject(dc, HBorderPen);
                 LineTo(dc, r2.right, r1.top);
                 SelectObject(dc, hOldPen);
@@ -595,14 +595,14 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 r2.top++;
             }
 
-            // nakreslime cislo radky
+            // draw the line number
             char num[2 + 1];
             sprintf(num, "%*d", 2, lineNum);
             SetTextColor(dc, GetPALETTERGB(Colors[PreviewScript[i].LineNumFGColor + side]));
             SetBkColor(dc, GetPALETTERGB(Colors[PreviewScript[i].LineNumBKColor + side]));
             ExtTextOut(dc, BORDER_WIDTH, text_y, ETO_OPAQUE | ETO_CLIPPED, &r1, num, 2, NULL);
 
-            // nakreslime text
+            // draw the text
             SetTextColor(dc, GetPALETTERGB(Colors[PreviewScript[i].TextColor + side]));
             SetBkColor(dc, GetPALETTERGB(Colors[PreviewScript[i].BkgndColor + side]));
             char* text = LoadStr(PreviewScript[i].TextID);
@@ -886,22 +886,22 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //       {
 //         clR.right--;
 //         clR.bottom--;
-//         // svetla vlevo a nahore
+//         // light on the left and top
 //         HPEN hOldPen = (HPEN)SelectObject(dc, BtnHilightPen);
 //         MoveToEx(dc, clR.left, clR.bottom - 1, NULL);
 //         LineTo(dc, clR.left, clR.top);
 //         LineTo(dc, clR.right, clR.top);
-//         // trochu tmavsi uvnitr
+//         // slightly darker inside
 //         SelectObject(dc, Btn3DLightPen);
 //         MoveToEx(dc, clR.left + 1, clR.bottom - 2, NULL);
 //         LineTo(dc, clR.left + 1, clR.top + 1);
 //         LineTo(dc, clR.right - 1, clR.top + 1);
-//         // tmava vpravo a dole
+//         // dark on the right and bottom
 //         SelectObject(dc, BtnShadowPen);
 //         MoveToEx(dc, clR.right - 1, clR.top + 1, NULL);
 //         LineTo(dc, clR.right - 1, clR.bottom - 1);
 //         LineTo(dc, clR.left, clR.bottom - 1);
-//         // nejtmavsi uplne venku
+//         // the darkest completely on the outside
 //         SelectObject(dc, WndFramePen);
 //         MoveToEx(dc, clR.left, clR.bottom, NULL);
 //         LineTo(dc, clR.right, clR.bottom);
@@ -1081,7 +1081,7 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //
 // CTextArrowButton
 //
-// klasicky text, za kterym je jeste sipka - slouzi pro rozbaleni menu
+// plain text followed by an arrow - used to expand a menu
 //
 
 // CTextArrowButton::CTextArrowButton(HWND hDlg, int ctrlID, CObjectOrigin origin)
@@ -1095,11 +1095,11 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //   CALL_STACK_MESSAGE_NONE
 //   RECT r = *rect;
 //
-//   // vytahnu text tlacitka
+//   // fetch the button text
 //   char buff[200];
 //   GetWindowText(HWindow, buff, 199);
 //
-//   // vytahnu aktualni font
+//   // fetch the current font
 //   HFONT hFont = (HFONT)SendMessage(HWindow, WM_GETFONT, 0, 0);
 //
 //   r.right -= 8;
@@ -1122,7 +1122,7 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //
 // CColorArrowButton
 //
-// pozadi s textem, za kterym je jeste sipka - slouzi pro rozbaleni menu
+// background with text followed by an arrow - used to expand a menu
 //
 
 // CColorArrowButton::CColorArrowButton(HWND hDlg, int ctrlID, HPALETTE &hPalette, CObjectOrigin origin)
@@ -1174,11 +1174,11 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 //
 //   RECT r = *rect;
 //
-//   // vytahnu text tlacitka
+//   // fetch the button text
 //   char buff[200];
 //   GetWindowText(HWindow, buff, 199);
 //
-//   // vytahnu aktualni font
+//   // fetch the current font
 //   HFONT hFont = (HFONT)SendMessage(HWindow, WM_GETFONT, 0, 0);
 //
 //   r.right -= 8;

--- a/src/plugins/filecomp/dialogs4.cpp
+++ b/src/plugins/filecomp/dialogs4.cpp
@@ -86,11 +86,11 @@ void CPropPageGeneral::LoadControls(BOOL initCombo)
 {
     CALL_STACK_MESSAGE2("CPropPageGeneral::LoadControls(%d)", initCombo);
 
-    // inicializuje edit linu pro ukazku fontu
+    // initialize the edit line for displaying the font sample
     HWND hEdit = GetDlgItem(HWindow, IDE_FONT);
     LOGFONT logFont;
     logFont = LogFont;
-    logFont.lfHeight = SalGUI->GetWindowFontHeight(hEdit); // pro prezentaci fontu v edit line pouzijeme jeji velikost fontu
+    logFont.lfHeight = SalGUI->GetWindowFontHeight(hEdit); // use the edit line font size to present the font
     if (HFont)
         DeleteObject(HFont);
     HFont = CreateFontIndirect(&logFont);
@@ -103,7 +103,7 @@ void CPropPageGeneral::LoadControls(BOOL initCombo)
             LogFont.lfFaceName);
     SetWindowText(hEdit, logFont.lfFaceName);
 
-    // inicializuje comba pro vyber znaku
+    // initialize the combo boxes for character selection
     HWND whiteSpace = GetDlgItem(HWindow, IDC_WHITESPACE);
     SendMessage(whiteSpace, WM_SETFONT, (WPARAM)HFont, FALSE);
     if (initCombo)
@@ -202,7 +202,7 @@ CPropPageGeneral::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 // CConfigurationDialog
 //
 
-// pomocny objekt pro centrovani konfiguracniho dialogu k parentovi
+// helper object for centering the configuration dialog over its parent
 class CCenteredPropertyWindow : public CWindow
 {
 protected:
@@ -218,10 +218,10 @@ protected:
             break;
         }
 
-        case WM_APP + 1000: // mame se odpojit od dialogu (uz je vycentrovano)
+        case WM_APP + 1000: // we should detach from the dialog (centering is done)
         {
             DetachWindow();
-            delete this; // trochu prasarna, ale uz se 'this' nikdo ani nedotkne, takze pohoda
+            delete this; // a bit of a hack, but nothing will touch 'this' anymore so it's fine
             return 0;
         }
         }
@@ -247,25 +247,25 @@ typedef struct DLGTEMPLATEEX
 #include <poppack.h>
 #endif // LPDLGTEMPLATEEX
 
-// pomocny call-back pro centrovani konfiguracniho dialogu k parentovi a vyhozeni '?' buttonku z captionu
+// helper callback for centering the configuration dialog over the parent and removing the '?' button from the caption
 int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
 {
     CALL_STACK_MESSAGE3("CenterCallback(, 0x%X, 0x%IX)", uMsg, lParam);
-    if (uMsg == PSCB_INITIALIZED) // pripojime se na dialog
+    if (uMsg == PSCB_INITIALIZED) // attach to the dialog
     {
         CCenteredPropertyWindow* wnd = new CCenteredPropertyWindow;
         if (wnd != NULL)
         {
             wnd->AttachToWindow(HWindow);
             if (wnd->HWindow == NULL)
-                delete wnd; // okno neni pripojeny, zrusime ho uz tady
+                delete wnd; // the window is not attached, delete it right here
             else
             {
-                PostMessage(wnd->HWindow, WM_APP + 1000, 0, 0); // pro odpojeni CCenteredPropertyWindow od dialogu
+                PostMessage(wnd->HWindow, WM_APP + 1000, 0, 0); // detach CCenteredPropertyWindow from the dialog
             }
         }
     }
-    if (uMsg == PSCB_PRECREATE) // odstraneni '?' buttonku z headeru property sheetu
+    if (uMsg == PSCB_PRECREATE) // remove the '?' button from the property sheet header
     {
         // Remove the DS_CONTEXTHELP style from the dialog box template
         if (((LPDLGTEMPLATEEX)lParam)->signature == 0xFFFF)

--- a/src/plugins/filecomp/dlg_com.cpp
+++ b/src/plugins/filecomp/dlg_com.cpp
@@ -3,12 +3,12 @@
 
 #include "precomp.h"
 
-SALCOLOR Colors[NUMBER_OF_COLORS]; // aktualni barvy
+SALCOLOR Colors[NUMBER_OF_COLORS]; // current colors
 
-// standartni barvy
+// standard colors
 SALCOLOR DefaultColors[NUMBER_OF_COLORS] =
     {
-        // barvy textu ve sloupci s cisly radek
+        // text colors in the column with line numbers
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_FG_NORMAL
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_FG_LEFT_CHANGE
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_FG_RIGHT_CHANGE
@@ -20,11 +20,11 @@ SALCOLOR DefaultColors[NUMBER_OF_COLORS] =
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_BK_LEFT_CHANGE_FOCUSED
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_BK_RIGHT_CHANGE_FOCUSED
 
-        // ramecek kolem aktualni zmeny ve sloupci s cisly radek
+        // frame around the current change in the column with line numbers
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_LEFT_BORDER
         RGBF(0, 0, 0, SCF_DEFAULT), // LINENUM_RIGHT_BORDER
 
-        // barvy zobrazeneho obsahu souboru
+        // colors of the displayed file contents
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_FG_NORMAL
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_FG_LEFT_FOCUSED
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_FG_RIGHT_FOCUSED
@@ -40,11 +40,11 @@ SALCOLOR DefaultColors[NUMBER_OF_COLORS] =
         RGBF(10, 128, 240, 0),      // TEXT_BK_LEFT_CHANGE_FOCUSED
         RGBF(255, 120, 120, 0),     // TEXT_BK_RIGHT_CHANGE_FOCUSED
 
-        // ramecek kolem aktualni zmeny v zobrazenem obsahu souboru
+        // frame around the current change in the displayed file contents
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_LEFT_BORDER
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_RIGHT_BORDER
 
-        // barva vybraneho bloku textu
+        // color of the selected text block
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_FG_SELECTION
         RGBF(0, 0, 0, SCF_DEFAULT), // TEXT_BK_SELECTION
 };
@@ -86,9 +86,9 @@ CCommonDialog::CCommonDialog(int resID, HWND hParent, CObjectOrigin origin)
     {
     case WM_INITDIALOG:
     {
-        // horizontalni i vertikalni vycentrovani dialogu k parentu
+        // horizontal and vertical centering of the dialog over the parent
         CenterWindow(HWindow);
-        break; // chci focus od DefDlgProc
+        break; // I want focus from DefDlgProc
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);
@@ -199,7 +199,7 @@ CreateColorPallete()
 void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
 {
     CALL_STACK_MESSAGE1("UpdateDefaultColors(, )");
-    // barvy textu ve sloupci s cisly radek
+    // text colors in the column with line numbers
     if (GetFValue(colors[LINENUM_FG_NORMAL]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_FG_NORMAL], GetSysColor(COLOR_WINDOWTEXT));
     //if (GetFValue(colors[LINENUM_FG_FOCUSED]) & SCF_DEFAULT)
@@ -214,7 +214,7 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
     if (GetFValue(colors[LINENUM_FG_RIGHT_CHANGE_FOCUSED]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_FG_RIGHT_CHANGE_FOCUSED], GetCOLORREF(colors[LINENUM_FG_RIGHT_CHANGE]));
 
-    // barvy pozadi ve sloupci s cisly radek
+    // background colors in the column with line numbers
     if (GetFValue(colors[LINENUM_BK_NORMAL]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_BK_NORMAL], GetScrollbarColor());
     //if (GetFValue(colors[LINENUM_BK_FOCUSED]) & SCF_DEFAULT)
@@ -232,13 +232,13 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
     //GetAverageColor(GetCOLORREF(colors[LINENUM_BK_RIGHT_CHANGE]), 9,
     //                GetCOLORREF(colors[LINENUM_FG_RIGHT_CHANGE]), 1));
 
-    // barva ramecku kolem vybrane zmeny ve sloupci s cisly radek
+    // frame color around the selected change in the column with line numbers
     if (GetFValue(colors[LINENUM_LEFT_BORDER]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_LEFT_BORDER], GetSysColor(COLOR_BTNSHADOW));
     if (GetFValue(colors[LINENUM_RIGHT_BORDER]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_RIGHT_BORDER], GetSysColor(COLOR_BTNSHADOW));
 
-    // barvy textu zobrazeneho obsahu souboru
+    // text colors of the displayed file contents
     if (GetFValue(colors[TEXT_FG_NORMAL]) & SCF_DEFAULT)
         SetRGBPart(&colors[TEXT_FG_NORMAL], SG->GetCurrentColor(SALCOL_VIEWER_FG_NORMAL));
     if (GetFValue(colors[TEXT_FG_LEFT_FOCUSED]) & SCF_DEFAULT)
@@ -254,7 +254,7 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
     //if (GetFValue(colors[TEXT_FG_RIGHT_CHANGE_FOCUSED]) & SCF_DEFAULT)
     //  SetRGBPart(&colors[TEXT_FG_RIGHT_CHANGE_FOCUSED], GetCOLORREF(colors[TEXT_FG_RIGHT_CHANGE]));
 
-    // barvy pozadi zobrazeneho obsahu souboru
+    // background colors of the displayed file contents
     if (GetFValue(colors[TEXT_BK_NORMAL]) & SCF_DEFAULT)
         SetRGBPart(&colors[TEXT_BK_NORMAL], SG->GetCurrentColor(SALCOL_VIEWER_BK_NORMAL));
     if (GetFValue(colors[TEXT_BK_LEFT_FOCUSED]) & SCF_DEFAULT)
@@ -338,13 +338,13 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
   }
   */
 
-    // barva ramecku kolem vybrane zmeny
+    // frame color around the selected change
     if (GetFValue(colors[TEXT_LEFT_BORDER]) & SCF_DEFAULT)
         SetRGBPart(&colors[TEXT_LEFT_BORDER], GetSysColor(COLOR_BTNSHADOW));
     if (GetFValue(colors[TEXT_RIGHT_BORDER]) & SCF_DEFAULT)
         SetRGBPart(&colors[TEXT_RIGHT_BORDER], GetSysColor(COLOR_BTNSHADOW));
 
-    // barva vybraneho bloku textu
+    // color of the selected text block
     if (GetFValue(colors[TEXT_FG_SELECTION]) & SCF_DEFAULT)
     {
         if (GetFValue(colors[TEXT_FG_NORMAL]) & SCF_DEFAULT)
@@ -404,7 +404,7 @@ BOOL CreateEnvFont()
         return FALSE;
     }
 
-    // zjistime si vysku
+    // determine the height
     HDC dc = GetDC(NULL);
     HFONT oldFont = (HFONT)SelectObject(dc, EnvFont);
     TEXTMETRIC tm;

--- a/src/plugins/filecomp/dlg_com.h
+++ b/src/plugins/filecomp/dlg_com.h
@@ -3,24 +3,24 @@
 
 #pragma once
 
-// pro okno filecompu; WM_USER_WORKERNOTIFIES informuje o ukonceni porovnavani
-// a predava vysledky pokud window proc vrati TRUE je okno zodpovedne za
-// deallokaci predanych bufferu
+// for the filecomp window; WM_USER_WORKERNOTIFIES reports that comparison has finished
+// and passes the results. If the window proc returns TRUE the window is responsible for
+// deallocating the provided buffers
 #define WM_USER_WORKERNOTIFIES (WM_APP + 1)
 
 // wParam:
 enum
 {
-    WN_ERROR,                // (const char *)lParam obsahuje text chyby
-    WN_NO_DIFFERENCE,        // lParam je ignorovan
-    WN_NO_ALL_DIFFS_IGNORED, // lParam je ignorovan
-    WN_BINARY_FILES_DIFFER,  // (CBinaryCompareResults *)lParam obsahuje vysledky diffovani
-    WN_TEXT_FILES_DIFFER,    // (CTextCompareResults<char> *)lParam obsahuje vysledky diffovani
-    WN_UNICODE_FILES_DIFFER, // (CCTextCompareesults<wchar_t> *)lParam obsahuje vysledky diffovani
-    WN_WORKER_CANCELED,      // lParam je ignorovan
-    WN_SETCHANGES,           // (CBinaryChanges *) lParam je pole zmen
-    WN_CBINIT_FINISHED,      // combo box byl upsesne inicializovan
-    WN_CALCULATING_DETAILS,  // pocitaji se podrobne difference
+    WN_ERROR,                // (const char*)lParam contains the error text
+    WN_NO_DIFFERENCE,        // lParam is ignored
+    WN_NO_ALL_DIFFS_IGNORED, // lParam is ignored
+    WN_BINARY_FILES_DIFFER,  // (CBinaryCompareResults*)lParam contains the diff results
+    WN_TEXT_FILES_DIFFER,    // (CTextCompareResults<char>*)lParam contains the diff results
+    WN_UNICODE_FILES_DIFFER, // (CTextCompareResults<wchar_t>*)lParam contains the diff results
+    WN_WORKER_CANCELED,      // lParam is ignored
+    WN_SETCHANGES,           // (CBinaryChanges*)lParam is an array of changes
+    WN_CBINIT_FINISHED,      // the combo box was initialized successfully
+    WN_CALCULATING_DETAILS,  // detailed differences are being computed
     WN_COMPARE_FINISHED,     // comparison finishes
     WN_GET_CHANGESCOMBO,     // queries HWND of the Change combobox
     WN_SET_PROGRESS,         // sets progress MAKELPARAM(percent, changesCnt)
@@ -30,20 +30,20 @@ enum
 #define WM_USER_VSCROLL (WM_APP + 2)
 #define WM_USER_HSCROLL (WM_APP + 3)
 #define WM_USER_SLITPOSCHANGED (WM_APP + 4)
-#define WM_USER_MOUSEWHEEL (WM_APP + 5)     // [wParam, lParam] z WM_MOUSEWHEEL
-#define WM_USER_ACTIVATEWINDOW (WM_APP + 6) // [wParam, lParam] z WM_MOUSEWHEEL
+#define WM_USER_MOUSEWHEEL (WM_APP + 5)     // [wParam, lParam] from WM_MOUSEWHEEL
+#define WM_USER_ACTIVATEWINDOW (WM_APP + 6) // [wParam, lParam] from WM_MOUSEWHEEL
 #define WM_USER_CREATE (WM_APP + 7)
 #define WM_USER_HANDLEFILEERROR (WM_APP + 8)
-#define WM_USER_SETCURSOR (WM_APP + 9) //jako WM_SETCURSOR
+#define WM_USER_SETCURSOR (WM_APP + 9) // same as WM_SETCURSOR
 #define WM_USER_CLEARHISTORY (WM_APP + 10)
 #define WM_USER_GETREBARHEIGHT (WM_APP + 11)
 #define WM_USER_GETHEADERHEIGHT (WM_APP + 12)
 #define WM_USER_AUTOCOPY_CHANGED (WM_APP + 13)
 
-// [wParam, (HWND) lParam] - pro otevrena okna pluginu: konfigurace pluginu se zmenila
+// [wParam, (HWND)lParam] - for open plugin windows: plugin configuration has changed
 #define WM_USER_CFGCHNG (WM_APP + 3246)
 
-// wParam: kombinace nasledujicich hodnot
+// wParam: combination of the following values
 #define CC_FONT 0x01
 #define CC_COLORS 0x02
 #define CC_DEFOPTIONS 0x04
@@ -53,9 +53,9 @@ enum
 #define CC_HAVEHWND 0x40
 #define CC_ALL (CC_FONT | CC_COLORS | CC_DEFOPTIONS | CC_CONTEXT | CC_TABSIZE | CC_CHAR)
 
-// barvy
+// colors
 
-#define LINENUM_FG_NORMAL 0 // barvy textu ve sloupci s cisly radek
+#define LINENUM_FG_NORMAL 0 // text colors in the column with line numbers
 #define LINENUM_FG_LEFT_CHANGE 1
 #define LINENUM_FG_RIGHT_CHANGE 2
 #define LINENUM_FG_LEFT_CHANGE_FOCUSED 3
@@ -66,10 +66,10 @@ enum
 #define LINENUM_BK_LEFT_CHANGE_FOCUSED 8
 #define LINENUM_BK_RIGHT_CHANGE_FOCUSED 9
 
-#define LINENUM_LEFT_BORDER 10 // ramecek kolem aktualni zmeny
+#define LINENUM_LEFT_BORDER 10 // frame around the current change
 #define LINENUM_RIGHT_BORDER 11
 
-#define TEXT_FG_NORMAL 12 // barvy zobrazeneho obsahu souboru
+#define TEXT_FG_NORMAL 12 // colors of the displayed file contents
 #define TEXT_FG_LEFT_FOCUSED 13
 #define TEXT_FG_RIGHT_FOCUSED 14
 #define TEXT_FG_LEFT_CHANGE 15
@@ -84,22 +84,22 @@ enum
 #define TEXT_BK_LEFT_CHANGE_FOCUSED 24
 #define TEXT_BK_RIGHT_CHANGE_FOCUSED 25
 
-#define TEXT_LEFT_BORDER 26 // ramecek kolem aktualni zmeny
+#define TEXT_LEFT_BORDER 26 // frame around the current change
 #define TEXT_RIGHT_BORDER 27
 
-#define TEXT_FG_SELECTION 28 // barva vybraneho bloku textu
+#define TEXT_FG_SELECTION 28 // color of the selected text block
 #define TEXT_BK_SELECTION 29
 
-#define NUMBER_OF_COLORS 30 // pocet barev ve schematu
+#define NUMBER_OF_COLORS 30 // number of colors in the scheme
 
-// interni drzak barvy, ktery navic obsahuje flag
+// internal color holder that additionally carries a flag
 typedef DWORD SALCOLOR;
 
 // SALCOLOR flags
-#define SCF_DEFAULT 0x01 // barevna slozka se ignoruje a pouzije se default hodnota
+#define SCF_DEFAULT 0x01 // ignore the color component and use the default value
 
 #define GetCOLORREF(rgbf) ((COLORREF)rgbf & 0x00ffffff)
-#define GetPALETTERGB(rgbf) (0x02000000 | (COLORREF)rgbf & 0x00ffffff) // viz PALETTERGB ve wingdi.h
+#define GetPALETTERGB(rgbf) (0x02000000 | (COLORREF)rgbf & 0x00ffffff) // see PALETTERGB in wingdi.h
 #define RGBF(r, g, b, f) ((COLORREF)(((BYTE)(r) | ((WORD)((BYTE)(g)) << 8)) | (((DWORD)(BYTE)(b)) << 16) | (((DWORD)(BYTE)(f)) << 24)))
 #define GetFValue(rgbf) ((BYTE)((rgbf) >> 24))
 #define SetFValue(rgbf, f) ((rgbf) |= ((BYTE)f << 24))
@@ -116,9 +116,9 @@ inline void SetRGBPart(SALCOLOR* salColor, COLORREF rgb)
     *salColor = rgb & 0x00ffffff | (((DWORD)(BYTE)((BYTE)((*salColor) >> 24))) << 24);
 }
 
-extern SALCOLOR Colors[NUMBER_OF_COLORS];        // aktualni barvy
-extern SALCOLOR DefaultColors[NUMBER_OF_COLORS]; // standardni barvy
-extern COLORREF CustomColors[16];                // custom colors pro ChooseColor dialog
+extern SALCOLOR Colors[NUMBER_OF_COLORS];        // current colors
+extern SALCOLOR DefaultColors[NUMBER_OF_COLORS]; // standard colors
+extern COLORREF CustomColors[16];                // custom colors for the ChooseColor dialog
 
 #if (WINVER < 0x0600)
 typedef enum _NORM_FORM
@@ -142,7 +142,7 @@ extern TNormalizeString PNormalizeString;
 
 enum CFileViewMode
 {
-    fvmStandard = 0, // nemenit hodnoty
+    fvmStandard = 0, // do not change the values
     fvmOnlyDifferences = 1
 };
 
@@ -196,7 +196,7 @@ extern int CaretWidth;
 //
 // CCommonDialog
 //
-// Dialog centrovany k parentu
+// Dialog centered over the parent
 //
 
 class CCommonDialog : public CDialog

--- a/src/plugins/filecomp/filecomp.h
+++ b/src/plugins/filecomp/filecomp.h
@@ -3,14 +3,14 @@
 
 #pragma once
 
-// definice IDs do menu
+// menu ID definitions
 #define MID_COMPAREFILES 1
 
 #define CURRENT_CONFIG_VERSION_PRESEPARATEOPTIONS 6
 #define CURRENT_CONFIG_VERSION_NORECOMPAREBUTTON 7
 #define CURRENT_CONFIG_VERSION 8
 
-// objekt interfacu pluginu, jeho metody se volaji ze Salamandera
+// plugin interface object whose methods are invoked by Salamander
 class CPluginInterface;
 extern CPluginInterface PluginInterface;
 extern BOOL AlwaysOnTop;
@@ -19,7 +19,7 @@ extern BOOL LoadOnStart;
 
 // ****************************************************************************
 //
-// Interface pluginu
+// Plugin interface
 //
 
 class CPluginInterface : public CPluginInterfaceAbstract
@@ -51,18 +51,19 @@ public:
 class CPluginInterfaceForMenu : public CPluginInterfaceForMenuExtAbstract
 {
 public:
-    // vraci stav polozky menu s identifikacnim cislem 'id'; navratova hodnota je kombinaci
-    // flagu (viz MENU_ITEM_STATE_XXX); 'eventMask' viz CSalamanderConnectAbstract::AddMenuItem
+    // returns the state of the menu item with the identifier 'id'; the return value is a
+    // combination of flags (see MENU_ITEM_STATE_XXX); 'eventMask' corresponds to
+    // CSalamanderConnectAbstract::AddMenuItem
     virtual DWORD WINAPI GetMenuItemState(int id, DWORD eventMask) { return 0; }
 
-    // spousti prikaz menu s identifikacnim cislem 'id', 'eventMask' viz
-    // CSalamanderConnectAbstract::AddMenuItem, 'salamander' je sada pouzitelnych metod
-    // Salamandera pro provadeni operaci, 'parent' je parent messageboxu, vraci TRUE pokud
-    // ma byt v panelu zruseno oznaceni (nebyl pouzit Cancel, mohl byt pouzit Skip), jinak
-    // vraci FALSE (neprovede se odznaceni);
-    // POZOR: Pokud prikaz zpusobi zmeny na nejake ceste (diskove/FS), mel by pouzit
-    //        CSalamanderGeneralAbstract::PostChangeOnPathNotification pro informovani
-    //        panelu bez automatickeho refreshe a otevrene FS (aktivni i odpojene)
+    // executes the menu command identified by 'id'; see
+    // CSalamanderConnectAbstract::AddMenuItem for the meaning of 'eventMask'; 'salamander'
+    // exposes helper methods for performing operations; 'parent' is the owner for message
+    // boxes; returns TRUE if the panel selection should be cleared (Cancel was not used but
+    // Skip might have been), otherwise FALSE (leave the selection as is);
+    // NOTE: If the command modifies any path (disk or FS), it should call
+    //       CSalamanderGeneralAbstract::PostChangeOnPathNotification to notify panels
+    //       without automatic refresh and any open FS windows (both active and detached)
     virtual BOOL WINAPI ExecuteMenuItem(CSalamanderForOperationsAbstract* salamander, HWND parent,
                                         int id, DWORD eventMask);
     virtual BOOL WINAPI HelpForMenuItem(HWND parent, int id);
@@ -94,5 +95,5 @@ public:
     virtual unsigned Body();
 };
 
-extern CWindowQueue MainWindowQueue; // seznam vsech oken filecompu
-extern CThreadQueue ThreadQueue;     // seznam vsech oken+workeru filecompu + remote control
+extern CWindowQueue MainWindowQueue; // list of all FileComp windows
+extern CThreadQueue ThreadQueue;     // list of all FileComp windows, workers, and the remote control

--- a/src/plugins/filecomp/mainwnd.h
+++ b/src/plugins/filecomp/mainwnd.h
@@ -8,8 +8,8 @@
 // CMainWindow
 //
 
-#define BI_TOOLBAR 0  // band s toollbarou
-#define BI_DIFFLIST 1 // band s combacem
+#define BI_TOOLBAR 0  // band with the toolbar
+#define BI_DIFFLIST 1 // band with the combo box
 
 #define IDC_REBAR 100
 #define IDC_TOOLBAR 101
@@ -17,7 +17,7 @@
 #define IDC_LEFTFILEVIEW 103
 #define IDC_RIGHTFILEVIEW 104
 
-// indexy bitmap pro toolbaru
+// bitmap indices for the toolbar
 #define BI_COPY 0
 #define BI_SELECTALL 1
 #define BI_FIRSTDIFF 2
@@ -25,19 +25,19 @@
 #define BI_NEXTDIFF 4
 #define BI_LASTDIFF 5
 
-#define REBAR_BORDER 2 // vyska mezery pod rebarou
+#define REBAR_BORDER 2 // height of the gap below the rebar
 
-// flagy pro CMainWindow::UpdateToolbarButtons()
+// flags for CMainWindow::UpdateToolbarButtons()
 #define UTB_DIFFSSELECTION 0x01
 #define UTB_TEXTSELECTION 0x02
 #define UTB_MENU 0x04
 #define UTB_FORCEDISABLE 0x08
 #define UTB_ALL (UTB_DIFFSSELECTION | UTB_TEXTSELECTION | UTB_MENU)
 
-#define CW_CONTINUE 0 // jedeme dal
-#define CW_CANCEL 1   // storno operace
-#define CW_EXIT 2     // storno a exit file comparatoru
-#define CW_SILENT 3   // ukonceni threadu bez message boxu pro usera
+#define CW_CONTINUE 0 // keep going
+#define CW_CANCEL 1   // cancel the operation
+#define CW_EXIT 2     // cancel and exit the file comparator
+#define CW_SILENT 3   // end the thread without a message box for the user
 
 extern HCURSOR HWaitCursor;
 
@@ -62,7 +62,7 @@ protected:
     int Active;
     CSplitBarWindow* SplitBar;
     CRebar* Rebar;
-    LONG RebarHeight; // vyska rebary + vyska mezery pod rebarou
+    LONG RebarHeight; // height of the rebar plus the gap below it
     CComboBox* ComboBox;
     HWND HToolbar;
     CIntIndexes LinesToChanges;
@@ -92,7 +92,7 @@ protected:
     BOOL Recompare;
     BOOL bOptionsChangedBeingHandled; // Simple semaphore
 
-    // pro binarni compare
+    // for the binary comparator
     CBinaryChanges Changes;
     BOOL OutOfRange;
     UINT ShowCmd;

--- a/src/plugins/filecomp/mtxtout.h
+++ b/src/plugins/filecomp/mtxtout.h
@@ -54,7 +54,7 @@ public:
 
     void FontHasChanged(LOGFONT* plf, HFONT font, int fontWidth, int fontHeight);
 
-    // nahrazuje ExtTextOut: pod Vistou provadi premapovani na "spravne siroke" znaky (viz ViewerFontNeedsMapping)
+    // replacement for ExtTextOut: on Vista performs remapping to characters with the correct width (see ViewerFontNeedsMapping)
     BOOL DoTextOut(HDC hdc, int X, int Y, UINT fuOptions, CONST RECT* lprc,
                    const CChar* lpString, UINT cbCount, CONST INT* lpDx)
     {
@@ -86,18 +86,18 @@ public:
             return ExtTextOutX(hdc, X, Y, fuOptions, lprc, lpString, cbCount, lpDx);
     }
 
-    // true = (jen XP64/Vista) je potreba mapovat znaky pred vykreslenim (nektera pismena jsou "spatne" siroka)
+    // true = only on XP64/Vista it is necessary to map characters before drawing (some glyphs have an incorrect width)
     bool NeedMapping() { return ViewerFontNeedsMapping; }
 
-    // premapuje, mozne volat jen pokud NeedMapping vraci true!!!
+    // remap the character; may be called only when NeedMapping returns true!!!
     CChar MapChar(CChar c) { return ViewerFontMapping[TCharSpecific<CChar>::Unsigned(c)]; }
 
-    // mozne volat jen pokud NeedMapping vraci true!!!
+    // may be called only when NeedMapping returns true!!!
     void CalcMappingIfNeeded(HDC hDC, const CChar* buf, int len);
 
 private:
-    bool ViewerFontNeedsMapping; // TRUE = (jen XP64/Vista) je potreba mapovat znaky pred vykreslenim (nektera pismena jsou "spatne" siroka)
-    CChar* ViewerFontMapping;    // mapovani pro pripad, kdy je ViewerFontNeedsMapping==true
+    bool ViewerFontNeedsMapping; // TRUE = only on XP64/Vista do characters need to be remapped before rendering (some glyphs are wrongly sized)
+    CChar* ViewerFontMapping;    // character map used when ViewerFontNeedsMapping is true
     CChar* Buffer;
     size_t BufferSize;
     LPVOID pMappedFont;

--- a/src/plugins/filecomp/remote.cpp
+++ b/src/plugins/filecomp/remote.cpp
@@ -40,7 +40,7 @@ void CRemoteComparator::CreateRemoteComparator()
         TerminateEvent = NULL;
         return;
     }
-    // TODO nastavit mensi zasobnik
+    // TODO set a smaller stack size
     RemoteComparatorThread = rc->Create(ThreadQueue);
     if (!RemoteComparatorThread)
     {
@@ -134,7 +134,7 @@ void CRemoteComparator::RecieveMessage(const CMessage* message)
 
     if (!ok && *msg->ReleaseEvent)
     {
-        // pustime dal filecomp.exe
+        // allow filecomp.exe to continue
         HANDLE event = OpenEvent(EVENT_MODIFY_STATE, FALSE, msg->ReleaseEvent);
         SetEvent(event);
         CloseHandle(event);

--- a/src/plugins/filecomp/remote.h
+++ b/src/plugins/filecomp/remote.h
@@ -19,7 +19,7 @@ public:
 protected:
     CMessageCenter MessageCenter;
     static BOOL Created;
-    static HANDLE RemoteComparatorThread; // POZOR: handle threadu jen pro pouziti v ThreadQueue
+    static HANDLE RemoteComparatorThread; // NOTE: thread handle intended only for use inside ThreadQueue
     static HANDLE TerminateEvent;
     virtual unsigned Body();
     virtual void RecieveMessage(const CMessage* message);

--- a/src/plugins/filecomp/viewwnd.cpp
+++ b/src/plugins/filecomp/viewwnd.cpp
@@ -50,7 +50,7 @@ CFileViewWindow::CFileViewWindow(CFileViewID id, CFileViewType type)
     LineNumDigits = 0;
     LineNumWidth = (LineNumDigits + 1) * FontWidth + BORDER_WIDTH;
 
-    // nastavime barevna schemata
+    // set up the color schemes
     memset(LineColors, 0, sizeof(LineColors));
 
     Siblink = NULL;
@@ -91,7 +91,7 @@ void CFileViewWindow::ReloadConfiguration(DWORD flags, BOOL updateWindow)
                         updateWindow);
     if (flags & CC_COLORS)
     {
-        // nastavime barevna schemata
+        // set up the color schemes
         int j;
         for (j = 0; j < 3; j++)
         {
@@ -128,7 +128,7 @@ void CFileViewWindow::ReloadConfiguration(DWORD flags, BOOL updateWindow)
 
     if (flags & CC_FONT)
     {
-        // nacteme font
+        // load the font
         HDC hdc = GetDC(NULL);
         if (HFont)
             DeleteObject(HFont);
@@ -163,7 +163,7 @@ void CFileViewWindow::ResetMouseWheelAccumulatorHandler(UINT uMsg, WPARAM wParam
     case WM_SYSKEYDOWN:
     case WM_KEYDOWN:
     {
-        // pokud je SHIFT stisteny, chodi autorepeat, ale nas zajima jen ten prvni stisk
+        // if SHIFT stays pressed, Windows keeps sending repeats, but we only care about the first press
         BOOL firstPress = (lParam & 0x40000000) == 0;
         if (!firstPress)
             break;
@@ -248,7 +248,7 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         switch (wParam)
         {
-        // vertikalni scrollovani
+        // vertical scrolling
         case 'K':
         case VK_UP:
             if (!shiftPressed && !altPressed)
@@ -298,7 +298,7 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 wScrollNotify = SB_BOTTOM;
             break;
 
-        // horizontalni scrollovani
+        // horizontal scrolling
         case 'L':
         case VK_RIGHT:
             if (!ctrlPressed && !shiftPressed && !altPressed)
@@ -350,13 +350,13 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         short zDelta = (short)HIWORD(wParam);
         if ((zDelta < 0 && MouseWheelAccumulator > 0) || (zDelta > 0 && MouseWheelAccumulator < 0))
-            ResetMouseWheelAccumulator(); // pri zmene smeru otaceni kolecka je potreba nulovat akumulator
+            ResetMouseWheelAccumulator(); // reset accumulator when the wheel direction changes
 
         BOOL controlPressed = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
         BOOL altPressed = (GetKeyState(VK_MENU) & 0x8000) != 0;
         BOOL shiftPressed = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
 
-        // ctrl+wheel -- skakani po diferencich
+        // Ctrl + wheel — jump between differences
         if (controlPressed && !altPressed && !shiftPressed)
         {
             MouseWheelAccumulator += 1000 * zDelta;
@@ -369,12 +369,12 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             }
         }
 
-        // wheel bez modifikatoru: standardni scroll
+        // wheel without modifiers: standard scrolling
         if (!controlPressed && !altPressed && !shiftPressed)
         {
-            DWORD wheelScroll = SG->GetMouseWheelScrollLines(); // muze byt az WHEEL_PAGESCROLL(0xffffffff)
+            DWORD wheelScroll = SG->GetMouseWheelScrollLines(); // can be up to WHEEL_PAGESCROLL (0xffffffff)
             DWORD pageHeight = (DWORD)(Height / FontHeight);
-            wheelScroll = max(1, (int)min(wheelScroll, pageHeight - 1)); // omezime maximalne na delku stranky
+            wheelScroll = max(1, (int)min(wheelScroll, pageHeight - 1)); // cap at the page length
 
             MouseWheelAccumulator += 1000 * zDelta;
             int stepsPerLine = max(1, (int)((1000 * WHEEL_DELTA) / wheelScroll));
@@ -396,12 +396,12 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             }
         }
 
-        // shift+wheel: horizontalni scroll
+        // shift+wheel: horizontal scrolling
         if (!controlPressed && !altPressed && shiftPressed)
         {
-            DWORD wheelScroll = SG->GetMouseWheelScrollLines(); // muze byt az WHEEL_PAGESCROLL(0xffffffff)
+            DWORD wheelScroll = SG->GetMouseWheelScrollLines(); // can be up to WHEEL_PAGESCROLL (0xffffffff)
             DWORD pageWidth = max(1, int(Width / FontWidth));
-            wheelScroll = max(1, (int)min((int)wheelScroll, (int)(pageWidth - 1))); // omezime maximalne na delku stranky
+            wheelScroll = max(1, (int)min((int)wheelScroll, (int)(pageWidth - 1))); // cap at the page length
 
             MouseWheelAccumulator += 1000 * zDelta;
             int stepsPerChar = max(1, (int)((1000 * WHEEL_DELTA) / wheelScroll));
@@ -430,11 +430,11 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         short zDelta = (short)HIWORD(wParam);
 
         if ((zDelta < 0 && MouseHWheelAccumulator > 0) || (zDelta > 0 && MouseHWheelAccumulator < 0))
-            ResetMouseWheelAccumulator(); // pri zmene smeru naklapeni kolecka je potreba nulovat akumulator
+            ResetMouseWheelAccumulator(); // reset the accumulator when the wheel tilt direction changes
 
-        DWORD wheelScroll = SG->GetMouseWheelScrollChars(); // muze byt az WHEEL_PAGESCROLL(0xffffffff)
+        DWORD wheelScroll = SG->GetMouseWheelScrollChars(); // can be up to WHEEL_PAGESCROLL (0xffffffff)
         DWORD pageWidth = max(1, int(Width / FontWidth));
-        wheelScroll = max(1, (int)min((int)wheelScroll, (int)(pageWidth - 1))); // omezime maximalne na delku stranky
+        wheelScroll = max(1, (int)min((int)wheelScroll, (int)(pageWidth - 1))); // cap at the page length
 
         MouseHWheelAccumulator += 1000 * zDelta;
         int stepsPerChar = max(1, (int)((1000 * WHEEL_DELTA) / wheelScroll));
@@ -454,7 +454,7 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     SendMessage(HWindow, WM_HSCROLL, charsToScroll < 0 ? SB_LINEUP : SB_LINEDOWN, 0);
             }
         }
-        return TRUE; // udalost jsme zpracovali a nemame zajem o emulaci pomoci klikani na scrollbar (stane se v pripade vraceni FALSE)
+        return TRUE; // the event is handled; do not emulate scrollbar clicking (happens when FALSE is returned)
     }
 
     case WM_RBUTTONUP:
@@ -693,7 +693,7 @@ BOOL CTextFileViewWindowBase::RebuildScript(
 
             if ((GetAsyncKeyState(VK_ESCAPE) & 0x8001) && GetForegroundWindow() == GetParent(HWindow))
             {
-                MSG msg; // vyhodime nabufferovany ESC
+                MSG msg; // discard the queued ESC
                 while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                     ;
                 cancel = TRUE;
@@ -703,8 +703,8 @@ BOOL CTextFileViewWindowBase::RebuildScript(
         }
     }
 
-    // urcime maxWidth
-    int counter = 1000; // testujeme na cancel kazdy tisicy pruchod
+    // determine maxWidth
+    int counter = 1000; // check for cancel every thousand iterations
     for (CLineScript::iterator i = Script[ViewMode].begin(); i < Script[ViewMode].end();
          ++i)
     {
@@ -718,7 +718,7 @@ BOOL CTextFileViewWindowBase::RebuildScript(
         {
             if ((GetAsyncKeyState(VK_ESCAPE) & 0x8001) && GetForegroundWindow() == GetParent(HWindow))
             {
-                MSG msg; // vyhodime nabufferovany ESC
+                MSG msg; // discard the queued ESC
                 while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                     ;
                 cancel = TRUE;
@@ -729,14 +729,14 @@ BOOL CTextFileViewWindowBase::RebuildScript(
         }
     }
 
-    // zjistime velikost mista pro cisla radku
+    // determine the space required for the line numbers
     LineNumDigits = 1;
     int j = max(GetLines(), ((CTextFileViewWindowBase*)Siblink)->GetLines());
     while (j /= 10)
         LineNumDigits++;
     LineNumWidth = (LineNumDigits + 1) * FontWidth + BORDER_WIDTH;
 
-    // nastavime scrollbaru
+    // configure the scrollbars
     SCROLLINFO si;
     si.cbSize = sizeof(SCROLLINFO);
     si.fMask = SIF_DISABLENOSCROLL | SIF_POS | SIF_PAGE | SIF_RANGE;
@@ -775,7 +775,7 @@ BOOL CTextFileViewWindowBase::SetMaxWidth(int maxWidth)
     if (!ReallocLineBuffer())
         return FALSE;
 
-    // nastavime scrollbaru
+    // configure the scrollbars
     SCROLLINFO si;
     si.cbSize = sizeof(SCROLLINFO);
     si.fMask = SIF_DISABLENOSCROLL | SIF_PAGE | SIF_POS | SIF_RANGE;
@@ -932,13 +932,13 @@ void CTextFileViewWindowBase::SelectDifference(int line, int count, BOOL center)
         (count >= page && (line + count - 1 < FirstVisibleLine || line >= FirstVisibleLine + page) ||
          count < page && (line < FirstVisibleLine || line + count - 1 >= FirstVisibleLine + page)))
     {
-        // difference neni viditelna na obrazovce
+        // the difference is not visible on screen
         int pos = FirstVisibleLine;
         if (count > page)
-            pos = line; // zobrazime differenci u hornoho okraje okna
+            pos = line; // show the difference at the top edge of the window
         else
         {
-            pos = line - (page - count) / 2; // vycentrujeme differenci k oknu
+            pos = line - (page - count) / 2; // center the difference within the window
             if (pos < 0)
                 pos = 0;
         }
@@ -960,7 +960,7 @@ void CTextFileViewWindowBase::SelectDifference(int line, int count, BOOL center)
         {
             if (SelectDiffEnd >= FirstVisibleLine && SelectDiffBegin <= FirstVisibleLine + page)
             {
-                // zajistime prekresleni drive vybrane difference
+                // ensure the previously selected difference gets repainted
                 r.top = (SelectDiffBegin - FirstVisibleLine) * FontHeight;
                 if (r.top < 0)
                     r.top = 0;
@@ -969,7 +969,7 @@ void CTextFileViewWindowBase::SelectDifference(int line, int count, BOOL center)
                     r.bottom = Height;
                 InvalidateRect(HWindow, &r, FALSE);
             }
-            // zajistime vykresleni nyni vybrane difference
+            // ensure the currently selected difference gets drawn
             r.top = (line - FirstVisibleLine) * FontHeight;
             if (r.top < 0)
                 r.top = 0;
@@ -999,7 +999,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
 {
     CALL_STACK_MESSAGE3("CTextFileViewWindowBase::UpdateSelection(%d, %d)", x, y);
     if (!DataValid || !Tracking)
-        return; // jen tak pro jistotu
+        return; // just to be safe
     if (x < LineNumWidth)
         x = LineNumWidth;
     if (y < 0)
@@ -1030,7 +1030,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
 
     if (TrackingLineBegin != line || TrackingCharBegin != end)
     {
-        // aby se nam na WM_LBUTTONUP nevyfokusovala difference
+        // prevent the difference from receiving focus on WM_LBUTTONUP
         SelectDifferenceOnButtonUp = FALSE;
     }
 
@@ -1039,7 +1039,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
     int oldCharBegin = SelectionCharBegin;
     int oldCharEnd = SelectionCharEnd;
 
-    // nastavime aktualni vyber
+    // set the current selection
     BOOL reverse;
     if (TrackingLineBegin < line ||
         TrackingLineBegin == line && TrackingCharBegin < end)
@@ -1062,7 +1062,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
     if ((SelectionLineBegin != SelectionLineEnd || SelectionCharBegin != SelectionCharEnd) &&
         (GetKeyState(VK_CONTROL) & 0x8000) != 0) //ctrlPressed
     {
-        // vybirame cele radky
+        // select whole lines
         SelectionCharBegin = 0;
         if (ViewMode != fvmOnlyDifferences || Script[ViewMode][SelectionLineEnd].GetClass() != CLineSpec::lcSeparator)
         {
@@ -1078,7 +1078,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
 
     if (ViewMode == fvmOnlyDifferences)
     {
-        // ohlidame aby slo vybirat jen v ramci jedne difference
+        // ensure the selection stays within a single difference
         if (TrackingLineBegin < line)
         {
             if (Script[ViewMode][SelectionLineBegin].GetClass() == CLineSpec::lcSeparator)
@@ -1112,16 +1112,16 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
         }
     }
 
-    // posuneme kurzor na konec vyberu
+    // move the caret to the end of the selection
     if (reverse)
         SetCaretPos(SelectionCharBegin, SelectionLineBegin);
     else
         SetCaretPos(SelectionCharEnd, SelectionLineEnd);
 
-    // zajistime prekresleni postizenych casti
+    // ensure the affected areas are repainted
     RepaintSelection(oldLineBegin, oldLineEnd, oldCharBegin, oldCharEnd);
 
-    // enablujem/disablujem tlacitko pro COPY v toolbare
+    // enable or disable the COPY button in the toolbar
     //  CMainWindow * parent = (CMainWindow *) WindowsManager.GetWindowPtr(GetParent(HWindow));
     if (MainWindow /*parent*/)
         MainWindow /*parent*/->UpdateToolbarButtons(UTB_TEXTSELECTION);
@@ -1132,7 +1132,7 @@ void CTextFileViewWindowBase::RepaintSelection(int oldLineBegin, int oldLineEnd,
 {
     CALL_STACK_MESSAGE5("CTextFileViewWindowBase::RepaintSelection(%d, %d, %d, %d)",
                         oldLineBegin, oldLineEnd, oldCharBegin, oldCharEnd);
-    // zajistime prekresleni jen postizenych casti
+    // ensure only the affected areas are repainted
     RECT r;
     r.left = LineNumWidth;
     r.right = Width;
@@ -1285,7 +1285,7 @@ void CTextFileViewWindowBase::SetCaretPos(int xPos, int yPos)
             x = LineNumWidth + (MeasureLine(l, CaretXPos) - FirstVisibleChar) * FontWidth;
         }
         if (x < LineNumWidth)
-            x = -1; // mensi finta, aby caret zmizel za roh
+            x = -1; // small trick to hide the caret just past the corner
         ::SetCaretPos(x, y);
     }
 }

--- a/src/plugins/filecomp/viewwnd.h
+++ b/src/plugins/filecomp/viewwnd.h
@@ -16,30 +16,30 @@ class CMainWindow;
 #define BORDER_WIDTH 2
 
 // line color index
-#define LC_NORMAL 0 // shodne text
-#define LC_CHANGE 1 // zmeneny text
-#define LC_FOCUS 2  // zmeneny a fokusovany text
+#define LC_NORMAL 0 // matching text
+#define LC_CHANGE 1 // changed text
+#define LC_FOCUS 2  // changed and focused text
 
 struct CLineColors
 {
     COLORREF LineNumFgColor;
     COLORREF LineNumBkColor;
-    HPEN LineNumBorderPen; // platne jen pro LC_FOCUS (ramecek kolem fokusu) a LC_NORMAL (separator differenci)
+    HPEN LineNumBorderPen; // valid only for LC_FOCUS (focus frame) and LC_NORMAL (difference separator)
     COLORREF FgColor;
     COLORREF BkColor;
-    HPEN BorderPen;    // platne jen pro LC_FOCUS (ramecek kolem fokusu) a LC_NORMAL (separator differenci)
-    COLORREF FgCommon; // barva spolecneho textu pro zobrazeni rozdilu v radce
+    HPEN BorderPen;    // valid only for LC_FOCUS (focus frame) and LC_NORMAL (difference separator)
+    COLORREF FgCommon; // color of the shared text when rendering per-line differences
     COLORREF BkCommon;
 };
 
-// identifikace okna
+// window identification
 enum CFileViewID
 {
     fviLeft,
     fviRight
 };
 
-// identifikace okna
+// window identification
 enum CFileViewType
 {
     fvtText,
@@ -51,7 +51,7 @@ extern HCURSOR HArrowCursor;
 
 extern const char* FILEVIEWWINDOW_CLASSNAME;
 
-// proporcionalne k sirce okna, na okraje kasleme, jde o "odhad"
+// proportional to the window width; edges are ignored, this is just an "estimate"
 #define FAST_LEFTRIGHT __max(1, width / FontWidth / 6)
 
 BOOL TestHScrollWParam(WPARAM wParam);
@@ -76,7 +76,7 @@ protected:
     TMappedTextOut<char> MappedASCII8TextOut;
     BOOL Tracking;
 
-    // slouzi pro akumulaci mikrokroku pri otaceni koleckem mysi, viz
+    // accumulates micro-steps while the mouse wheel turns, see
     // http://msdn.microsoft.com/en-us/library/ms997498.aspx (Best Practices for Supporting Microsoft Mouse and Keyboard Devices)
     int MouseWheelAccumulator;  // vertical
     int MouseHWheelAccumulator; // horizontal
@@ -133,10 +133,10 @@ protected:
 //   return (line & LF_BLANK) == LF_BLANK || (line & LF_BLANK) == LF_SEPARATOR;
 // }
 
-// id timeru pro automaticky scroll pri vyberu textu pomoci mysi
+// timer ID for automatic scrolling when selecting text with the mouse
 #define IDT_SCROLLTEXT 1
 
-// znak, ktery se obevi misto prazdnych znaku
+// character displayed instead of whitespace glyphs
 //#define WHITE_SPACE_CHAR ((char)0xB7)
 
 // update selection flag
@@ -165,13 +165,13 @@ protected:
     int CaretXPos;
     int CaretYPos;
     BOOL ShowWhiteSpace;
-    // prvni prvek LineChanges[cislo_zmeny][cislo_radky_ve_zmene] udava pocet
-    // nasledujicich paru, kazdy par urcuje offset pocatku a konce zmeny v
-    // radce
+    // the first element of LineChanges[change_index][line_index_in_change] stores the count
+    // of following pairs; each pair defines the start and end offsets of the change within
+    // a line
     // unsigned int ***LineChanges;
     // int * ChangesToLinesMap;
     // int * LinesToChangesMap;
-    // CEditScript * EdScript; // potrebne poze pro in-line changes
+    // CEditScript * EdScript; // needed only for in-line changes
     BOOL DetailedDifferences;
     int TabSize;
     CMainWindow* MainWindow;

--- a/src/plugins/filecomp/worker.cpp
+++ b/src/plugins/filecomp/worker.cpp
@@ -212,7 +212,7 @@ CFilecompWorker::Body()
 
 void CFilecompWorker::GuardedBody()
 {
-    // otevreme soubory
+    // open the files
     int i;
     for (i = 0; i <= 1; i++)
     {
@@ -241,7 +241,7 @@ void CFilecompWorker::GuardedBody()
 
     if (Options.ForceBinary)
     {
-        // srovname jako binarni soubory
+        // compare them as binary files
         CompareBinaryFiles();
     }
     else
@@ -263,11 +263,11 @@ void CFilecompWorker::GuardedBody()
         if (files[0].GetType() == CTextFileReader::ftText &&
             files[1].GetType() == CTextFileReader::ftText)
         {
-            // srovnam jako text
+            // compare as text
 
             if (Options.IgnoreLineBreakChanges)
             {
-                Options.IgnoreSpaceChange = 1; // pojiska
+                Options.IgnoreSpaceChange = 1; // safety measure
                 Options.DetailedDifferences = 1;
             }
             Options.IgnoreSomeSpace = Options.IgnoreSpaceChange || Options.IgnoreAllSpace;
@@ -275,7 +275,7 @@ void CFilecompWorker::GuardedBody()
             if (files[0].GetEncoding() == CTextFileReader::encASCII8 &&
                 files[1].GetEncoding() == CTextFileReader::encASCII8)
             {
-                // srovname jako ASCII8 text
+                // compare as ASCII8 text
                 CompareTextFiles<char>(files);
                 //TRACE_I("Total time spent by comparing files " << TotalRuntime.Read());
                 //TRACE_I("Total time spent by shifting boundaries " << ShiftBoundaries.Read());
@@ -287,29 +287,29 @@ void CFilecompWorker::GuardedBody()
             }
             else
             {
-                // srovname jako UNICODE text
+                // compare as Unicode text
                 if (files[0].HasSurrogates() || files[1].HasSurrogates())
                 {
-                    // srovname jako UCS-4/UTF-32 text
-                    // TODO nekdy to treba budem podporovat, zatim umime jen BMP
-                    // tento kod se nikdy nespusti, HasSurrogates vraci vzdy false
+                    // compare as UCS-4/UTF-32 text
+                    // TODO maybe support this in the future; currently we handle only BMP
+                    // this code path never runs, HasSurrogates always returns false
                     throw CFilecompWorker::CException("Only BMP character set is supported.");
                     //CompareTextFiles<DWORD>(files);
                 }
                 else
                 {
-                    // srovname jako UCS-2 text (UTF-16 without surrogates)
-                    // TODO pritomne surrogates ingorujeme, uzivatel dostane warning
+                    // compare as UCS-2 text (UTF-16 without surrogates)
+                    // TODO present surrogates are ignored and the user receives a warning
                     CompareTextFiles<wchar_t>(files);
                 }
             }
         }
         else
         {
-            // uvolnime pamet
+            // release allocated memory
             files[0].Reset();
             files[1].Reset();
-            // srovname jako binarni soubory
+            // compare them as binary files
             CompareBinaryFiles();
         }
     }

--- a/src/plugins/filecomp/worker.h
+++ b/src/plugins/filecomp/worker.h
@@ -22,7 +22,7 @@ struct CCompareOptions
     // Ignore all horizontal white space.
     int IgnoreAllSpace;
 
-    // zahrnuto do ingnore space change
+    // included in ignore-space-change processing
     // Ignore changes that affect only blank lines.
     //int IgnoreBlankLines;
 
@@ -275,26 +275,26 @@ struct CWorkerFileData
 class CFilecompWorker : public CThread
 {
 public:
-    // obecna chyba
+    // generic failure
     class CException : public std::exception
     {
     public:
         CException(const char* s = "Unspecified Error.") : exception(s) {}
         static void Raise(int error, int lastError, ...);
     };
-    // ukonceno uzivatelem
+    // aborted by the user
     class CAbortByUserException : public std::exception
     {
     public:
         CAbortByUserException() : exception("") {}
     };
-    // soubory jsou stejny
+    // files are identical
     class CFilesDontDifferException : public std::exception
     {
     public:
         CFilesDontDifferException() : exception("") {}
     };
-    // soubory jsou stejny
+    // files are identical
     class CAllDiffsIgnoredException : public std::exception
     {
     public:
@@ -308,7 +308,7 @@ protected:
     HWND Parent;
     HWND MainWindow; // The window receiving WM_USER_WORKERNOTIFIES
     CCompareOptions Options;
-    const int& CancelFlag; // 0 ... jedeme dal, jinak konec
+    const int& CancelFlag; // 0 ... keep going, any other value terminates the worker
     HANDLE Event;
 
     CWorkerFileData Files[2];

--- a/src/plugins/filecomp/worker2.cpp
+++ b/src/plugins/filecomp/worker2.cpp
@@ -217,8 +217,8 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
 
     for (;;)
     {
-        // zjistime delku difference
-        // offset ukazuje na zacatek difference
+        // determine the length of the difference
+        // offset points to the start of the difference
 
         offsetSave = offset;
         remain = totalSize - offset;
@@ -283,7 +283,7 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
         {
             changes.push_back(CBinaryChange(offsetSave, lenghtSave));
             if (changes.size() == MaxBinChanges)
-                break; // dale uz nehledame, je jich az az
+                break; // stop searching; we already have plenty
             HWND hComboWnd = (HWND)SendMessage(MainWindow, WM_USER_WORKERNOTIFIES, WN_GET_CHANGESCOMBO, NULL);
             if (hComboWnd)
             {
@@ -310,10 +310,10 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
         else
             break;
 
-        // hledame zacatek dalsi difference
-        offset = changes.back().Offset + changes.back().Length; // zacne za posledni differenci
+        // look for the start of the next difference
+        offset = changes.back().Offset + changes.back().Length; // starts after the last difference
         if (offset >= totalSize)
-            break; // uz jsme na konci souboru
+            break; // already at the end of the file
         remain = totalSize - offset;
 
         while (remain)
@@ -331,7 +331,7 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
                 }
             }
 
-            // porovnavame po blokach o velikosti size
+            // compare data in chunks of the requested size
             DWORD size = (DWORD)__min(blokSize, remain);
 
             ptr0 = cf[0].ReadBuffer(offset, size, CancelFlag);
@@ -367,7 +367,7 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
 
         if (remain)
         {
-            offset = ptr0 - start + offset; // offset nyni ukazuje na zacatek nasledujici difference
+            offset = ptr0 - start + offset; // offset now points to the start of the next difference
         }
     }
 


### PR DESCRIPTION
## Summary
- Convert Czech comments in the FileComp core sources and headers to English, including plugin metadata, configuration handling, and worker routines.
- Translate remaining documentation in the mapped text output and remote comparator modules to describe font mapping, stack usage, and event signalling in English.
- Localize selection, scrolling, and repaint comments in the text and view windows to clarify mouse, keyboard, and repaint handling.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_e_68e25751c6448322ac49111e6b1d4315