### PR TITLE
demomenu: clarify english wording for translated comments

### DIFF
--- a/src/plugins/demomenu/demomenu.cpp
+++ b/src/plugins/demomenu/demomenu.cpp
@@ -11,28 +11,28 @@
 
 #include "precomp.h"
 
-// objekt interfacu pluginu, jeho metody se volaji ze Salamandera
+// plugin interface object whose methods Salamander calls
 CPluginInterface PluginInterface;
-// dalsi casti interfacu CPluginInterface
+// additional parts of the CPluginInterface implementation
 CPluginInterfaceForMenuExt InterfaceForMenuExt;
 
-// globalni data
-const char* PluginNameEN = "DemoMenu";    // neprekladane jmeno pluginu, pouziti pred loadem jazykoveho modulu + pro debug veci
-const char* PluginNameShort = "DEMOMENU"; // jmeno pluginu (kratce, bez mezer)
+// global data
+const char* PluginNameEN = "DemoMenu";    // non-localized plugin name, used before loading the language module + for debugging
+const char* PluginNameShort = "DEMOMENU"; // plugin name (short, without spaces)
 
-HINSTANCE DLLInstance = NULL; // handle k SPL-ku - jazykove nezavisle resourcy
-HINSTANCE HLanguage = NULL;   // handle k SLG-cku - jazykove zavisle resourcy
+HINSTANCE DLLInstance = NULL; // handle to SPL - language-independent resources
+HINSTANCE HLanguage = NULL;   // handle to SLG - language-dependent resources
 
-// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+// Salamander general interface - valid from plugin start until plugin shutdown
 CSalamanderGeneralAbstract* SalamanderGeneral = NULL;
 
-// definice promenne pro "dbg.h"
+// variable definition for "dbg.h"
 CSalamanderDebugAbstract* SalamanderDebug = NULL;
 
-// definice promenne pro "spl_com.h"
+// variable definition for "spl_com.h"
 int SalamanderVersion = 0;
 
-// rozhrani poskytujici upravene Windows controly pouzivane v Salamanderovi
+// interface that provides Salamander's customized Windows controls
 //CSalamanderGUIAbstract *SalamanderGUI = NULL;
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
@@ -97,41 +97,41 @@ int WINAPI SalamanderPluginGetReqVer()
 
 CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbstract* salamander)
 {
-    // nastavime SalamanderDebug pro "dbg.h"
+    // set SalamanderDebug for "dbg.h"
     SalamanderDebug = salamander->GetSalamanderDebug();
-    // nastavime SalamanderVersion pro "spl_com.h"
+    // set SalamanderVersion for "spl_com.h"
     SalamanderVersion = salamander->GetVersion();
     HANDLES_CAN_USE_TRACE();
     CALL_STACK_MESSAGE1("SalamanderPluginEntry()");
 
-    // tento plugin je delany pro aktualni verzi Salamandera a vyssi - provedeme kontrolu
+    // verify that the plugin targets the current Salamander version or newer
     if (SalamanderVersion < LAST_VERSION_OF_SALAMANDER)
-    { // starsi verze odmitneme
+    { // reject older versions
         MessageBox(salamander->GetParentWindow(),
                    REQUIRE_LAST_VERSION_OF_SALAMANDER,
                    PluginNameEN, MB_OK | MB_ICONERROR);
         return NULL;
     }
 
-    // nechame nacist jazykovy modul (.slg)
+    // load the language module (.slg)
     HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), PluginNameEN);
     if (HLanguage == NULL)
         return NULL;
 
-    // ziskame obecne rozhrani Salamandera
+    // obtain Salamander's general interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
-    // ziskame rozhrani poskytujici upravene Windows controly pouzivane v Salamanderovi
+    // obtain the interface that provides Salamander's customized Windows controls
     //  SalamanderGUI = salamander->GetSalamanderGUI();
 
-    // nastavime jmeno souboru s helpem
+    // set the help file name
     SalamanderGeneral->SetHelpFileName("demomenu.chm");
 
-    // nastavime zakladni informace o pluginu
+    // set basic plugin information
     salamander->SetBasicPluginData(LoadStr(IDS_PLUGINNAME), 0, VERSINFO_VERSION_NO_PLATFORM, VERSINFO_COPYRIGHT,
                                    LoadStr(IDS_PLUGIN_DESCRIPTION), PluginNameShort,
                                    NULL, NULL);
 
-    // nastavime URL home-page pluginu
+    // set the plugin home page URL
     salamander->SetPluginHomePageURL(LoadStr(IDS_PLUGIN_HOME));
 
     return &PluginInterface;
@@ -153,7 +153,7 @@ CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* salamander)
 {
     CALL_STACK_MESSAGE1("CPluginInterface::Connect(,)");
 
-    // zakladni cast:
+    // basic part:
     salamander->AddMenuItem(-1, LoadStr(IDS_TESTCMD), SALHOTKEY('M', HOTKEYF_CONTROL | HOTKEYF_SHIFT),
                             MENUCMD_TESTCMD, FALSE, MENU_EVENT_TRUE, MENU_EVENT_TRUE, MENU_SKILLLEVEL_ALL);
 
@@ -163,7 +163,7 @@ CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* salamander)
   HICON hIcon = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_PLUGINICON), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
   iconList->ReplaceIcon(0, hIcon);
   DestroyIcon(hIcon);
-  salamander->SetIconListForGUI(iconList); // o destrukci iconlistu se postara Salamander
+  salamander->SetIconListForGUI(iconList); // Salamander takes care of destroying the icon list
 
   salamander->SetPluginIcon(0);
   salamander->SetPluginMenuAndToolbarIcon(0);

--- a/src/plugins/demomenu/demomenu.h
+++ b/src/plugins/demomenu/demomenu.h
@@ -11,16 +11,16 @@
 
 #pragma once
 
-// globalni data
-extern HINSTANCE DLLInstance; // handle k SPL-ku - jazykove nezavisle resourcy
-extern HINSTANCE HLanguage;   // handle k SLG-cku - jazykove zavisle resourcy
+// global data
+extern HINSTANCE DLLInstance; // handle to SPL - language-independent resources
+extern HINSTANCE HLanguage;   // handle to SLG - language-dependent resources
 
-// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+// Salamander general interface - valid from plugin start until plugin shutdown
 extern CSalamanderGeneralAbstract* SalamanderGeneral;
 
 char* LoadStr(int resID);
 
-// prikazy pluginoveho menu
+// plugin menu commands
 #define MENUCMD_TESTCMD 1
 
 //
@@ -66,8 +66,8 @@ public:
     virtual void WINAPI PasswordManagerEvent(HWND parent, int event) {}
 };
 
-// rozhrani pluginu poskytnute Salamanderovi
+// plugin interface provided to Salamander
 extern CPluginInterface PluginInterface;
 
-// otevre About okno
+// opens the About window
 void OnAbout(HWND hParent);

--- a/src/plugins/demomenu/help/hh/salamander_help_shared.css
+++ b/src/plugins/demomenu/help/hh/salamander_help_shared.css
@@ -206,14 +206,14 @@
 
 #help_page td.hdr
 {
-  /* tmavsi seda na leve strane */
+  /* darker gray on the left side */
   margin: .25em;
   background: #dddddd;
   vertical-align: top;
   padding: 2px 4px;
   font-weight: bold;
-  width: 10%;           /* zuzime levou stranu tabulky na minimum */
-  padding-right :10px;  /* ale nechame tam alespon 10 bodu, at to trochu vypada */
+  width: 10%;           /* narrow the left side of the table to the minimum */
+  padding-right :10px;  /* but keep at least 10 pixels so it looks a little better */
   white-space: nowrap;
 }
 

--- a/src/plugins/demomenu/menu.cpp
+++ b/src/plugins/demomenu/menu.cpp
@@ -12,7 +12,7 @@
 #include "precomp.h"
 
 // ****************************************************************************
-// SEKCE MENU
+// MENU SECTION
 // ****************************************************************************
 
 BOOL WINAPI
@@ -24,7 +24,7 @@ CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstract* sa
     case MENUCMD_TESTCMD:
     {
         SalamanderGeneral->ShowMessageBox("You are trying Test Command.", LoadStr(IDS_PLUGINNAME), MSGBOX_INFO);
-        //      SalamanderGeneral->SetUserWorkedOnPanelPath(PANEL_SOURCE);  // tento prikaz povazujeme za praci s cestou (objevi se v Alt+F12)
+        //      SalamanderGeneral->SetUserWorkedOnPanelPath(PANEL_SOURCE);  // treat this command as working with the path (appears in Alt+F12)
         break;
     }
 
@@ -32,7 +32,7 @@ CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstract* sa
         SalamanderGeneral->ShowMessageBox("Unknown command.", LoadStr(IDS_PLUGINNAME), MSGBOX_ERROR);
         break;
     }
-    return FALSE; // neodznacovat polozky v panelu
+    return FALSE; // do not clear panel selections
 }
 
 BOOL WINAPI

--- a/src/plugins/demomenu/precomp.cpp
+++ b/src/plugins/demomenu/precomp.cpp
@@ -11,9 +11,9 @@
 
 #include "precomp.h"
 
-// projekt DemoMenu obsahuje tri skupiny modulu
+// the DemoMenu project contains three groups of modules
 //
-// 1) modul precomp.cpp, ktery postavi demomenu.pch (/Yc"precomp.h")
-// 2) moduly vyuzivajici demomenu.pch (/Yu"precomp.h")
-// 3) commony maji vlastni, automaticky generovany WINDOWS.PCH
+// 1) the precomp.cpp module, which builds demomenu.pch (/Yc"precomp.h")
+// 2) modules using demomenu.pch (/Yu"precomp.h")
+// 3) shared modules generate their own WINDOWS.PCH automatically
 //    (/YX"windows.h" /Fp"$(OutDir)\WINDOWS.PCH")

--- a/src/plugins/demomenu/versinfo.rh2
+++ b/src/plugins/demomenu/versinfo.rh2
@@ -21,7 +21,7 @@
 #define VERSINFO_MINORA      0
 #define VERSINFO_MINORB      2
 
-#include "spl_vers.h" // vytahneme cisla verzi + buildu
+#include "spl_vers.h" // pull version and build numbers
 
 #define VERSINFO_COPYRIGHT   "Copyright © 2009-2023 Open Salamander Authors"
 #define VERSINFO_COMPANY     "Open Salamander"


### PR DESCRIPTION
## Summary
- refine the DemoMenu interface comments to better describe lifecycle details and GUI dependencies in English
- clarify the precompiled-header grouping note and CSS table padding hint for the help content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2c9ae679c83229a91c39455e38c86