### PR TITLE
demomenu: refine general interface comment wording

### DIFF
--- a/src/plugins/demomenu/demomenu.cpp
+++ b/src/plugins/demomenu/demomenu.cpp
@@ -11,28 +11,28 @@
 
 #include "precomp.h"
 
-// plugin interface object, its methods are called by Salamander
+// Plugin interface object whose methods are called by Salamander
 CPluginInterface PluginInterface;
-// additional parts of the CPluginInterface interface
+// Additional interfaces exposed by CPluginInterface
 CPluginInterfaceForMenuExt InterfaceForMenuExt;
 
-// global data
-const char* PluginNameEN = "DemoMenu";    // non-translated plugin name, used before loading the language module + for debugging
-const char* PluginNameShort = "DEMOMENU"; // plugin name (short, without spaces)
+// Global data
+const char* PluginNameEN = "DemoMenu";    // Non-translated plugin name, used before loading the language module + for debugging
+const char* PluginNameShort = "DEMOMENU"; // Plugin name (short, without spaces)
 
-HINSTANCE DLLInstance = NULL; // handle to SPL - language-independent resources
-HINSTANCE HLanguage = NULL;   // handle to SLG - language-dependent resources
+HINSTANCE DLLInstance = NULL; // Handle to SPL - language-independent resources
+HINSTANCE HLanguage = NULL;   // Handle to SLG - language-dependent resources
 
-// Salamander general interface - valid from Salamander launch until the plugin terminates
+// Salamander general interface - available from Salamander launch until the plugin shuts down
 CSalamanderGeneralAbstract* SalamanderGeneral = NULL;
 
-// variable definition for "dbg.h"
+// Variable required by "dbg.h"
 CSalamanderDebugAbstract* SalamanderDebug = NULL;
 
-// variable definition for "spl_com.h"
+// Variable required by "spl_com.h"
 int SalamanderVersion = 0;
 
-// interface providing customized Windows controls used in Salamander
+// Interface providing customized Windows controls used in Salamander
 //CSalamanderGUIAbstract *SalamanderGUI = NULL;
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
@@ -97,41 +97,41 @@ int WINAPI SalamanderPluginGetReqVer()
 
 CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbstract* salamander)
 {
-    // set SalamanderDebug for "dbg.h"
+    // Set SalamanderDebug for "dbg.h"
     SalamanderDebug = salamander->GetSalamanderDebug();
-    // set SalamanderVersion for "spl_com.h"
+    // Set SalamanderVersion for "spl_com.h"
     SalamanderVersion = salamander->GetVersion();
     HANDLES_CAN_USE_TRACE();
     CALL_STACK_MESSAGE1("SalamanderPluginEntry()");
 
-    // this plugin is made for the current version of Salamander and higher - perform a check
+    // Verify Salamander is at the minimum supported version before continuing
     if (SalamanderVersion < LAST_VERSION_OF_SALAMANDER)
-    { // reject older versions
+    { // Reject older versions
         MessageBox(salamander->GetParentWindow(),
                    REQUIRE_LAST_VERSION_OF_SALAMANDER,
                    PluginNameEN, MB_OK | MB_ICONERROR);
         return NULL;
     }
 
-    // let it load the language module (.slg)
+    // Load the language module (.slg)
     HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), PluginNameEN);
     if (HLanguage == NULL)
         return NULL;
 
-    // obtain Salamander's general interface
+    // Acquire Salamander's general interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
-    // obtain the interface providing customized Windows controls used in Salamander
+    // Acquire the interface providing customized Windows controls used in Salamander
     //  SalamanderGUI = salamander->GetSalamanderGUI();
 
-    // set the name of the help file
+    // Register the name of the help file
     SalamanderGeneral->SetHelpFileName("demomenu.chm");
 
-    // set the basic information about the plugin
+    // Provide the basic plugin metadata
     salamander->SetBasicPluginData(LoadStr(IDS_PLUGINNAME), 0, VERSINFO_VERSION_NO_PLATFORM, VERSINFO_COPYRIGHT,
                                    LoadStr(IDS_PLUGIN_DESCRIPTION), PluginNameShort,
                                    NULL, NULL);
 
-    // set the plugin home-page URL
+    // Register the plugin home page URL
     salamander->SetPluginHomePageURL(LoadStr(IDS_PLUGIN_HOME));
 
     return &PluginInterface;
@@ -153,7 +153,7 @@ CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* salamander)
 {
     CALL_STACK_MESSAGE1("CPluginInterface::Connect(,)");
 
-    // basic part:
+    // Register the basic menu item:
     salamander->AddMenuItem(-1, LoadStr(IDS_TESTCMD), SALHOTKEY('M', HOTKEYF_CONTROL | HOTKEYF_SHIFT),
                             MENUCMD_TESTCMD, FALSE, MENU_EVENT_TRUE, MENU_EVENT_TRUE, MENU_SKILLLEVEL_ALL);
 

--- a/src/plugins/demomenu/demomenu.h
+++ b/src/plugins/demomenu/demomenu.h
@@ -11,16 +11,16 @@
 
 #pragma once
 
-// global data
-extern HINSTANCE DLLInstance; // handle to SPL - language-independent resources
-extern HINSTANCE HLanguage;   // handle to SLG - language-dependent resources
+// Global data
+extern HINSTANCE DLLInstance; // Handle to SPL - language-independent resources
+extern HINSTANCE HLanguage;   // Handle to SLG - language-dependent resources
 
-// Salamander general interface - valid from Salamander launch until the plugin terminates
+// Salamander general interface - available from Salamander launch until the plugin shuts down
 extern CSalamanderGeneralAbstract* SalamanderGeneral;
 
 char* LoadStr(int resID);
 
-// plugin menu commands
+// Plugin menu commands
 #define MENUCMD_TESTCMD 1
 
 //
@@ -66,8 +66,8 @@ public:
     virtual void WINAPI PasswordManagerEvent(HWND parent, int event) {}
 };
 
-// plugin interface provided to Salamander
+// Plugin interface provided to Salamander
 extern CPluginInterface PluginInterface;
 
-// opens the About window
+// Opens the About window
 void OnAbout(HWND hParent);

--- a/src/plugins/demomenu/menu.cpp
+++ b/src/plugins/demomenu/menu.cpp
@@ -24,7 +24,7 @@ CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstract* sa
     case MENUCMD_TESTCMD:
     {
         SalamanderGeneral->ShowMessageBox("You are trying Test Command.", LoadStr(IDS_PLUGINNAME), MSGBOX_INFO);
-        //      SalamanderGeneral->SetUserWorkedOnPanelPath(PANEL_SOURCE);  // we consider this command to work with the path (it appears in Alt+F12)
+        //      SalamanderGeneral->SetUserWorkedOnPanelPath(PANEL_SOURCE);  // Treat this command as operating on the path (it appears in Alt+F12)
         break;
     }
 

--- a/src/plugins/demomenu/precomp.cpp
+++ b/src/plugins/demomenu/precomp.cpp
@@ -11,9 +11,9 @@
 
 #include "precomp.h"
 
-// the DemoMenu project contains three groups of modules
+// The DemoMenu project contains three groups of modules:
 //
-// 1) the precomp.cpp module, which builds demomenu.pch (/Yc"precomp.h")
-// 2) modules using demomenu.pch (/Yu"precomp.h")
-// 3) commons have their own automatically generated WINDOWS.PCH
+// 1) The precomp.cpp module, which builds demomenu.pch (/Yc"precomp.h")
+// 2) Modules using demomenu.pch (/Yu"precomp.h")
+// 3) Shared code with its own automatically generated WINDOWS.PCH
 //    (/YX"windows.h" /Fp"$(OutDir)\WINDOWS.PCH")


### PR DESCRIPTION
## Summary
- adjust the Salamander general interface lifetime comment to avoid remaining Czech keywords
- mirror the wording in the header for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2d1150f408322b1fe2e9514aa1e24