### PR TITLE
automation: translate remaining Czech script comments

### DIFF
--- a/src/plugins/automation/abortpalette.cpp
+++ b/src/plugins/automation/abortpalette.cpp
@@ -126,7 +126,7 @@ void CScriptAbortPaletteWindow::OnCreate()
     rc.top = 0;
     rc.right = cx;
     rc.bottom = cy;
-    AdjustWindowRectEx(&rc, GetWindowLong(HWindow, GWL_STYLE), FALSE, // FIXME_X64 - nahradit GetWindowLong -> GetWindowLongPtr (napric celym balikem Salamandera); tento warinig odstrani Honza Rysavy, prosim zachovat
+    AdjustWindowRectEx(&rc, GetWindowLong(HWindow, GWL_STYLE), FALSE, // FIXME_X64 - replace GetWindowLong -> GetWindowLongPtr (across the entire Salamander package); this warning will be removed by Honza Rysavy, please keep it
                        GetWindowLong(HWindow, GWL_EXSTYLE));
 
     SetWindowPos(m_pToolBar->GetHWND(), NULL, 0, 0, cx, cy,

--- a/src/plugins/automation/automationplug.cpp
+++ b/src/plugins/automation/automationplug.cpp
@@ -138,13 +138,13 @@ int CAutomationMenuExtInterface::ExecuteScriptMenu()
 
     SalamanderGeneral->GetFocusedItemMenuPos(&pt);
 
-    /* slouzi pro skript export_mnu.py, ktery generuje salmenu.mnu pro Translator
-   udrzovat synchronizovane s volanim InsertItem() dole...
+    /* used for the export_mnu.py script, which generates salmenu.mnu for Translator
+   keep synchronized with the InsertItem() call below...
 MENU_TEMPLATE_ITEM ExecuteScriptMenu[] =
 {
-	{MNTT_PB, 0
-	{MNTT_IT, IDS_RUNFOCUSED
-	{MNTT_PE, 0
+        {MNTT_PB, 0
+        {MNTT_IT, IDS_RUNFOCUSED
+        {MNTT_PE, 0
 };
 */
     // run focused script menu item
@@ -263,13 +263,13 @@ void WINAPI CAutomationMenuExtInterface::BuildMenu(
     // refresh script list
     g_oScriptLookup.Refresh();
 
-    /* slouzi pro skript export_mnu.py, ktery generuje salmenu.mnu pro Translator
-   udrzovat synchronizovane s volani salamander->AddMenuItem() dole...
-MENU_TEMPLATE_ITEM PluginMenu[] = 
+    /* used for the export_mnu.py script, which generates salmenu.mnu for Translator
+   keep synchronized with the salamander->AddMenuItem() call below...
+MENU_TEMPLATE_ITEM PluginMenu[] =
 {
-	{MNTT_PB, 0
-	{MNTT_IT, IDS_RUNFOCUSED
-	{MNTT_IT, IDS_SCRIPTPOPUPMENU
+        {MNTT_PB, 0
+        {MNTT_IT, IDS_RUNFOCUSED
+        {MNTT_IT, IDS_SCRIPTPOPUPMENU
 	{MNTT_PE, 0
 };
 */
@@ -406,7 +406,7 @@ bool CAutomationMenuExtInterface::CanExecuteFocusedItem()
 {
     // check if we have script engine for the file extension
     const CFileData* pFocusedFile = SalamanderGeneral->GetPanelFocusedItem(PANEL_SOURCE, NULL);
-    // _ASSERTE(pFocusedFile);  // Petr: je-li panel prazdny (napr. kdyz jsme v rootu prazdneho disku)
+    // _ASSERTE(pFocusedFile);  // Petr: if the panel is empty (e.g. when we are in the root of an empty disk)
     if (pFocusedFile == NULL || pFocusedFile->Ext == NULL || *pFocusedFile->Ext == _T('\0'))
     {
         return false;

--- a/src/plugins/automation/entry.cpp
+++ b/src/plugins/automation/entry.cpp
@@ -112,7 +112,7 @@ CPluginInterfaceAbstract*
     // setup help file name
     SalamanderGeneral->SetHelpFileName("automation.chm");
 
-    // nastavime zakladni informace o pluginu
+    // set the basic information about the plugin
     salamander->SetBasicPluginData(
         SalamanderGeneral->LoadStr(g_hLangInst, IDS_PLUGINNAME),
         FUNCTION_CONFIGURATION |

--- a/src/plugins/automation/scripts/ScopeWS.rb
+++ b/src/plugins/automation/scripts/ScopeWS.rb
@@ -1,4 +1,4 @@
-# viz https://forum.altap.cz/viewtopic.php?f=6&t=31928
+# see https://forum.altap.cz/viewtopic.php?f=6&t=31928
 
 class TestScope
   attr_reader :wscript_obj
@@ -6,10 +6,10 @@ class TestScope
     @wscript_obj=wscript_obj
   end
   def do
-    # Objekt WScript neni zde ve tride k dispozici...
+    # The WScript object is not available here in the class...
     #WScript.Echo("In Class")
-    # ALE máme na nìj odkaz wscript_obj
-    wscript_obj.Echo("In Class") # již v pohodì funguje
+    # But we have a reference to it through wscript_obj
+    wscript_obj.Echo("In Class") # and this works just fine
   end
 end
 

--- a/src/plugins/automation/scripts/Sleep.pys
+++ b/src/plugins/automation/scripts/Sleep.pys
@@ -1,3 +1,3 @@
-# Skript pro overeni, ze Automation ve spojeni s Pythonem pada na volani funkci,
-# ktere nemaji navratovou hodnotu.
+# Script to verify that Automation combined with Python crashes on function calls
+# that do not have a return value.
 Salamander.Sleep(1)

--- a/src/plugins/automation/scripts/bug001.rb
+++ b/src/plugins/automation/scripts/bug001.rb
@@ -1,5 +1,5 @@
-# Testovaci skript ze zaslaneho bugreportu.
-# Puvodni nazev souboru: 38621A4D913D1E3B-AS30B3PB103X86-130701-161739.INF
+# Test script from the submitted bug report.
+# Original file name: 38621A4D913D1E3B-AS30B3PB103X86-130701-161739.INF
 
 def fileRename( item )
   if ( !( item.Name =~ /^\[/ ) and ( item.Name =~ /\.(avi|mkv|mp4)$/ ) )

--- a/src/plugins/automation/scripts/gui02.js
+++ b/src/plugins/automation/scripts/gui02.js
@@ -1,4 +1,4 @@
-// testuje automaticky vypocet exit kodu pokud na formu neni zadny exit button
+// Tests automatic exit code calculation when the form has no exit button
 var fm = Salamander.Forms.Form();
 fm.lb = Salamander.Forms.Label();
 fm.lb.Text = "I'm the only label on this form.";

--- a/src/plugins/automation/scripts/gui23.js
+++ b/src/plugins/automation/scripts/gui23.js
@@ -1,4 +1,4 @@
-// testuje osetreni chybneho vstupu do konstrukcni metody GUI komponenty
-// (white box test osetreni vyjimky vyhozene z C++ konstruktoru komponenty)
+// Tests handling of invalid input passed to a GUI component constructor
+// (white-box test for an exception thrown from the component C++ constructor)
 var fm = Salamander.Forms.Form();
 fm.cancelbtn = Salamander.Forms.Button("Cancel", "a");

--- a/src/plugins/automation/scripts/gui24.js
+++ b/src/plugins/automation/scripts/gui24.js
@@ -1,4 +1,4 @@
-// testuje vicenasobne prirazeni controlu (tiket #24)
+// Tests assigning controls multiple times (ticket #24)
 var fm = Salamander.Forms.Form();
 fm.dst = Salamander.Forms.TextBox("aaa");
 fm.dst = Salamander.Forms.TextBox("bbb");

--- a/src/plugins/automation/scripts/gui25.js
+++ b/src/plugins/automation/scripts/gui25.js
@@ -1,4 +1,4 @@
-// test case pro tiket #25 - pozdni nastaveni textu
+// Test case for ticket #25 - setting the text late
 var fm = Salamander.Forms.Form();
 fm.dst = Salamander.Forms.TextBox();
 fm.Text = "aaa"; // put_Text

--- a/src/plugins/automation/scripts/infinite.js
+++ b/src/plugins/automation/scripts/infinite.js
@@ -1,5 +1,5 @@
-// Skript pro testovani moznosti prerusit kdykoliv vykonavani skriptu pomoci
-// plovouciho toolbaru.
+// Script for testing the ability to interrupt script execution at any time using
+// the floating toolbar.
 for (;;)
 {
 }

--- a/src/plugins/automation/scriptsite.cpp
+++ b/src/plugins/automation/scriptsite.cpp
@@ -271,7 +271,7 @@ HRESULT STDMETHODCALLTYPE CScriptSite::GetDocumentContextFromPosition(
     {
         ULONG ulStartPos = 0;
 
-        pdi->pDbgDocHelper->GetScriptBlockInfo((DWORD)dwSourceContext, // FIXME_X64 potlacen warning C4244: 'argument' : conversion from 'DWORDLONG' to 'DWORD', possible loss of data
+        pdi->pDbgDocHelper->GetScriptBlockInfo((DWORD)dwSourceContext, // FIXME_X64 suppressed warning C4244: 'argument' : conversion from 'DWORDLONG' to 'DWORD', possible loss of data
                                                NULL, &ulStartPos, NULL);
         hr = pdi->pDbgDocHelper->CreateDebugDocumentContext(
             ulStartPos + uCharacterOffset, uNumChars, ppsc);


### PR DESCRIPTION
## Summary
- translate the remaining Czech warning comment in the abort palette window
- rewrite automation menu guidance and sample script comments into English
- update ancillary script files to use English descriptions
- translate outstanding Czech comments in automation sample scripts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3427f6f2c832281ccdb25d3339eba