### PR TITLE
translator: translate remaining Czech comments

### DIFF
--- a/src/translator/bitmap.cpp
+++ b/src/translator/bitmap.cpp
@@ -91,7 +91,7 @@ BOOL CBitmap::CreateBmpBW(int width, int height)
     return TRUE;
 }
 
-// vytvori bitmapu kompatibilni s DC
+// Creates a bitmap compatible with the DC
 BOOL CBitmap::CreateBmp(HDC hDC, int width, int height)
 {
     if (HBmp != NULL)
@@ -128,7 +128,7 @@ BOOL CBitmap::CreateBmp(HDC hDC, int width, int height)
     if (releaseDC)
         HANDLES(ReleaseDC(NULL, hDC));
 
-    // vytahnu informace pro pozdejsi upravy
+    // Grab information for later adjustments
     BITMAP bmp;
     GetObject(HBmp, sizeof(bmp), &bmp);
     Planes = bmp.bmPlanes;
@@ -149,7 +149,7 @@ BOOL CBitmap::CreateBmp(HDC hDC, int width, int height)
     return TRUE;
 }
 
-// vytvori bitmapu kompatibilni s DC
+// Creates a bitmap compatible with the DC
 BOOL CBitmap::CreateBmpFrom(HINSTANCE hInstance, int resID)
 {
     if (HBmp != NULL)
@@ -164,7 +164,7 @@ BOOL CBitmap::CreateBmpFrom(HINSTANCE hInstance, int resID)
         return FALSE;
     }
 
-    // vytahnu informace pro pozdejsi upravy
+    // Grab information for later adjustments
     BITMAP bmp;
     GetObject(HBmp, sizeof(bmp), &bmp);
     Planes = bmp.bmPlanes;
@@ -208,7 +208,7 @@ BOOL CBitmap::ReCreateForScreenDC()
     HANDLES(DeleteObject(HBmp));
     HBmp = hTmpBmp;
 
-    // vytahnu informace pro pozdejsi upravy
+    // Grab information for later adjustments
     BITMAP bmp;
     GetObject(HBmp, sizeof(bmp), &bmp);
     Planes = bmp.bmPlanes;
@@ -246,10 +246,10 @@ BOOL CBitmap::Enlarge(int width, int height)
             width = Width;
         if (Height > height)
             height = Height;
-        // pousim se vytvorit vetsi bitmapu
-        // !POZOR! Sal 2.5b6 byla pomala pri paintu do Vieweru (PgDn) proti 2.0
-        // Bylo to tim, ze jsme vytvareli cache pres CreateBitmap() misto pres CreateCompatibleBitmap()
-        // Podle MSDN se ma pouzivat CreateBitmap() pouze pro vyvareni B&W bitmap.
+        // Trying to create a larger bitmap
+        // WARNING! Sal 2.5b6 was slower when painting into the Viewer (PgDn) compared to 2.0
+        // That was because we created the cache with CreateBitmap() instead of CreateCompatibleBitmap()
+        // According to MSDN, CreateBitmap() should only be used for creating B&W bitmaps.
         HBITMAP hTmpBmp;
         if (HMemDC == NULL || BlackAndWhite)
         {

--- a/src/translator/bitmap.h
+++ b/src/translator/bitmap.h
@@ -30,23 +30,23 @@ public:
     CBitmap();
     ~CBitmap();
 
-    // destukce bitmapy i DC
+    // Destroy the bitmap and the DC
     void Destroy();
 
-    // vytvori bitmapu kompatibilni s DC (pokud je hDC==NULL, bude kompatibili s obrazovkou)
+    // Create a bitmap compatible with the DC (if hDC == NULL, it will be compatible with the screen)
     BOOL CreateBmp(HDC hDC, int width, int height);
-    // vytvori bitmapu
+    // Create a bitmap
     BOOL CreateBmpBW(int width, int height);
-    // nacte bitmapu z resource (pujde o DDB kompatibilni s obrazovkou)
+    // Load a bitmap from a resource (it will be a DDB compatible with the screen)
     BOOL CreateBmpFrom(HINSTANCE hInstance, int resID);
-    // pokud doslo k zemene barevne hloubky obrazovky, je treba znovu vytvorit bitmapu
-    // rozmery a vybrane handly zustanou zachovany; bitmapa bude kompatibilni s obrazovkou
+    // If the screen color depth changed, the bitmap has to be recreated
+    // The size and selected handles remain intact; the bitmap will be compatible with the screen
     BOOL ReCreateForScreenDC();
 
-    // zvetsi bitampu na pozadovanou velikost; pokud je uz bitmapa dostatecne
-    // velika, nezmensuje ji - pouze vrati TRUE
+    // Enlarge the bitmap to the requested size; if it is already large enough,
+    // it does not shrink it—just returns TRUE
     BOOL Enlarge(int width, int height);
-    // vrati TRUE, pokud je treba bitmapu zvetsit
+    // Return TRUE if the bitmap needs to be enlarged
     BOOL NeedEnlarge(int width, int height);
 
     DWORD GetWidth() { return Width; }

--- a/src/translator/checklst.cpp
+++ b/src/translator/checklst.cpp
@@ -11,24 +11,24 @@
 #include "wndout.h"
 #include "datarh.h"
 
-/* popis formatu check.lst
-Same Size of Property Pages: 300 1105 2645  --seznam IDcek dialogu se oddeluje mezerou, delka seznamu libovolna, ale musi byt v jednom radku
+/* Description of the check.lst format
+Same Size of Property Pages: 300 1105 2645  --list of dialog IDs separated by spaces; the list can be any length, but it must be on one line
 
-Multi-Text Control: 150: 151: 13712 10149 10151 10153 10154 12087 10155       --1. cislo je dialog ID, 2. je ID controlu u nejz mame zkusit nastavit text na vsechny IDcka v nasledujicim seznamu (jde o test, jestli je control dost velky pro vsechny texty, ktere se v nem muzou objevit)
-Multi-Text Control Bold: 150: 151: 13712 10149 10151 10153 10154 12087 10155  --1. cislo je dialog ID, 2. je ID controlu u nejz mame zkusit nastavit text na vsechny IDcka v nasledujicim seznamu (jde o test, jestli je control dost velky pro vsechny texty, ktere se v nem muzou objevit) - text omerovat BOLDem
-Text Control Bold: 150: 151 --1. cislo je dialog ID, 2. je ID controlu u nejz mame zkusit, jestli je control dost velky pro obsazeny text - text omerovat BOLDem
+Multi-Text Control: 150: 151: 13712 10149 10151 10153 10154 12087 10155       --the first number is the dialog ID, the second is the control ID; we try to set the control text to every ID in the following list (this checks whether the control is large enough for all texts that might appear in it)
+Multi-Text Control Bold: 150: 151: 13712 10149 10151 10153 10154 12087 10155  --same as above, but the text is measured in bold
+Text Control Bold: 150: 151 --the first number is the dialog ID, the second is the control ID that we test to ensure the control is large enough for the text it contains—the text is measured in bold
 
-Drop-Down Button: 190: 147  --1. cislo je dialog ID, 2. je ID controlu: jde o tlacitko, mame zkontrolovat, jestli se do nej vejde drop-down sipka (vpravo na tlacitku je symbol sipky dolu)
+Drop-Down Button: 190: 147  --the first number is the dialog ID, the second is the control ID; the control is a button and we verify that a drop-down arrow fits into it (there is an arrow symbol on the right side of the button)
 
-More Button: 190: 147       --1. cislo je dialog ID, 2. je ID controlu: jde o tlacitko, mame zkontrolovat, jestli se do nej vejde more sipka (vpravo na tlacitku je symbol dvou sipek dolu)
+More Button: 190: 147       --the first number is the dialog ID, the second is the control ID; the control is a button and we verify that the "more" arrow fits (there is a double-arrow symbol on the right side of the button)
 
-Combo Box: 205: 227: 13990 13991 13992 13993  --1. cislo je dialog ID, 2. je ID controlu: jde o combo box, mame zkontrolovat, jestli se do nej vejdou vsechny texty v seznamu
+Combo Box: 205: 227: 13990 13991 13992 13993  --the first number is the dialog ID, the second is the control ID; the control is a combo box and we verify that all texts from the list fit inside it
 
-About Dialog Title: 10500: 10501      --specialitka pro About dialogy: 1. cislo je dialog ID, 2. je ID controlu u nejz mame zkusit do jeho textu pres sprintf vlozit verzi: "99.99 beta 10 (PB999 x86)" a text omerovat BOLDem
+About Dialog Title: 10500: 10501      --special case for About dialogs: the first number is the dialog ID, the second is the control ID whose text we try to fill with the version string "99.99 beta 10 (PB999 x86)" via sprintf, measuring the text in bold
 
-Progress Dialog Status: 150: 159  --specialitka pro Progress dialog: 1. cislo je dialog ID, 2. je ID controlu u nejz mame zkusit vytvorit text odpovidajici rutine v CProgressDialog::DialogProc(): WM_TIMER: IDT_UPDATESTATUS
+Progress Dialog Status: 150: 159  --special case for the Progress dialog: the first number is the dialog ID, the second is the control ID whose text we try to create according to the routine in CProgressDialog::DialogProc(): WM_TIMER: IDT_UPDATESTATUS
 
-Strings With CSV: 10400 10401 10402 10403 10404 10405 10406 10407 10408 --kontrola, ze sedi pocet carek v originalnim a prelozenem textu (jde o CSV=Comma Separated Values, pouziva se pro texty pro bottom baru): kontroluji se postupne stringy v seznamu (vzajemne nemusi mit stejny pocet carek)
+Strings With CSV: 10400 10401 10402 10403 10404 10405 10406 10407 10408 --verify that the number of commas matches in the original and translated texts (CSV = Comma Separated Values, used for bottom bar texts); the strings in the list are checked sequentially (they do not need to contain the same number of commas)
 */
 
 BOOL ProcessCheckLstLineAux(const char* overlapHeader, BOOL readDlgAndCtrlID, BOOL readList, int listMinCount,
@@ -126,16 +126,16 @@ BOOL CData::ProcessCheckLstLine(const char* line, const char* lineEnd, int row)
 {
     const char* p = line;
 
-    // preskocim uvodni whitespacy
+    // Skip leading whitespace
     while (p < lineEnd && (*p == ' ' || *p == '\t'))
         p++;
 
-    // orizneme whitespacy na konci radku
+    // Trim whitespace at the end of the line
     while ((lineEnd - 1) > line && (*(lineEnd - 1) == ' ' || *(lineEnd - 1) == '\t'))
         lineEnd--;
 
     BOOL ret = TRUE;
-    if (p < lineEnd) // zajimaji nas jen neprazdne radky
+    if (p < lineEnd) // we only care about non-empty lines
     {
         CCheckLstItem* item = new CCheckLstItem;
         if (item != NULL)
@@ -236,7 +236,7 @@ BOOL CData::LoadCheckLst(const char* fileName)
         HANDLES(CloseHandle(hFile));
         return FALSE;
     }
-    checkLstData[checkLstDataSize] = 0; // vlozime terminator
+    checkLstData[checkLstDataSize] = 0; // insert the terminator
 
     const char* lineStart = checkLstData;
     const char* lineEnd = checkLstData;

--- a/src/translator/config.cpp
+++ b/src/translator/config.cpp
@@ -80,7 +80,7 @@ CConfiguration Config;
 
 BOOL CreateKey(HKEY hKey, const char* name, HKEY& createdKey)
 {
-    DWORD createType; // info jestli byl klic vytvoren nebo jen otevren
+    DWORD createType; // Information whether the key was created or just opened
     LONG res = HANDLES(RegCreateKeyEx(hKey, name, 0, NULL, REG_OPTION_NON_VOLATILE,
                                       KEY_READ | KEY_WRITE, NULL, &createdKey,
                                       &createType));

--- a/src/translator/config.h
+++ b/src/translator/config.h
@@ -85,7 +85,7 @@ public:
     void RemoveRecentProject(int index);
     int FindRecentProject(const char* fileName);
 
-    // 1 = vse TRUE, 2 = layout TRUE, zbytek FALSE
+    // 1 = everything TRUE, 2 = layout TRUE, the rest FALSE
     void SetValidateAll(int mode = 1);
 };
 

--- a/src/translator/consts.h
+++ b/src/translator/consts.h
@@ -16,10 +16,10 @@ extern const char* MDICHILD_CLASSNAME;
 #define TREE_TYPE_NONE_DIALOGS 0x00000002
 #define TREE_TYPE_NONE_MENUS 0x00000003
 
-// vrati hande okna,ktery se pouzije jako parent pro messagebox
+// Return the window handle that is used as the parent for a message box
 HWND GetMsgParent();
 
-// nakopiruje retezec na clipboard; textLen muze byt -1 pro omereni delky retezce
+// Copy a string to the clipboard; textLen can be -1 to measure the string length
 BOOL CopyTextToClipboard(const char* text, int textLen);
 
 #define WM_AUTORELOAD WM_APP + 100

--- a/src/translator/databook.cpp
+++ b/src/translator/databook.cpp
@@ -16,7 +16,7 @@ int CData::FindBookmark(DWORD treeItem, WORD textItem)
 
 void CData::ToggleBookmark(DWORD treeItem, WORD textItem)
 {
-    // pokud bookmark existuje, budeme prepinat jeho stav
+    // If the bookmark exists, toggle its state
     int index = FindBookmark(treeItem, textItem);
     if (index != -1)
         Bookmarks.Delete(index);

--- a/src/translator/datacnfl.cpp
+++ b/src/translator/datacnfl.cpp
@@ -50,14 +50,14 @@ CButtonType GetButtonType(DWORD style)
     return btOther;
 }
 
-// detektor kolizi horkych klaves
+// Hotkey collision detector
 
 struct CKey
 {
     wchar_t Key;
     WORD Index;
     WORD LVIndex;
-    WORD ControlID; // je-li 0, pouziva se LVIndex, jinak se pouziva ControlID a LVIndex je 0
+    WORD ControlID; // If it is 0, LVIndex is used; otherwise ControlID is used and LVIndex is 0
     DWORD Param1;
     DWORD Param2;
     DWORD Param3;
@@ -74,25 +74,25 @@ protected:
 public:
     CKeyConflict();
 
-    // odstrani vsechny pridane klavesty z pole
+    // Remove all added keys from the array
     void Cleanup();
 
-    // prida klavesu do pole; vrati TRUE v pripade uspesneho zarazeni
-    // FALSE v pripade nedostatku pameti
+    // Add a key to the array; returns TRUE if the insertion succeeds
+    // FALSE if memory is insufficient
     BOOL AddKey(wchar_t key, WORD index, WORD lvIndex, WORD controlID, DWORD param1 = 0, DWORD param2 = 0,
                 DWORD param3 = 0, DWORD param4 = 0);
     BOOL AddString(const wchar_t* string, WORD index, WORD lvIndex, WORD controlID, DWORD param1 = 0,
                    DWORD param2 = 0, DWORD param3 = 0, DWORD param4 = 0);
 
-    // je treba zavolat pred prvnim volanim GetNextConflict
+    // Must be called before the first GetNextConflict invocation
     void PrepareConflictIteration(CDialogData* dialog = NULL);
 
-    // vraci TRUE, pokud byl nalezen konflikt; naplni ukazatele
-    // pokud jiz neni zadny dalsi konflikt, vrati FALSE
+    // Returns TRUE if a conflict was found and fills the pointers
+    // Returns FALSE when there are no more conflicts
     BOOL GetNextConflict(WORD* index, WORD* lvIndex, WORD* controlID, DWORD* param1 = NULL,
                          DWORD* param2 = NULL, DWORD* param3 = NULL, DWORD* param4 = NULL);
 
-    // projede 'string', vyhazi z nej obsazene klavesy, zbytek vrati v 'availableKeys'
+    // Walk through 'string', remove the hotkeys already used, and return the rest in 'availableKeys'
     void GetAvailableKeys(const wchar_t* string, wchar_t* availableKeys, int availableKeysSize);
 
 protected:
@@ -254,13 +254,13 @@ void CKeyConflict::GetAvailableKeys(const wchar_t* string, wchar_t* availableKey
 {
     int index = 0;
     const wchar_t* p = string;
-    BOOL allowAllHotkeys = FALSE; // TRUE = hledame hotkeys mezi vsemi pismeny a cisly, FALSE = jen mezi a-z a cisly
+    BOOL allowAllHotkeys = FALSE; // TRUE = search for hotkeys among all letters and digits, FALSE = only among a-z and digits
 
     for (int x = 0; x < 2; x++)
     {
         while (*p != 0 && index < availableKeysSize - 1)
         {
-            if (*p == L'\\' && *(p + 1) == L't') // horke klavesy nechceme do hintu
+            if (*p == L'\\' && *(p + 1) == L't') // do not include hotkeys in the hint
                 break;
             wchar_t ch = (wchar_t)(UINT_PTR)CharLowerW((LPWSTR)*p);
             if (allowAllHotkeys && IsAlphaW(ch) || ch >= L'a' && ch <= L'z')
@@ -294,7 +294,7 @@ void CKeyConflict::GetAvailableKeys(const wchar_t* string, wchar_t* availableKey
     availableKeys[index] = 0;
 }
 
-// vrati TRUE, pokud text ukazuje na jeden z ridicich znaku \n, \r, \t
+// Return TRUE if the text points to one of the control characters \n, \r, \t
 
 BOOL IsControlCharacter(const wchar_t* text)
 {
@@ -307,32 +307,32 @@ BOOL IsControlCharacter(const wchar_t* text)
     return FALSE;
 }
 
-// stringy v TRANSLATOR jsou ulozene ve zdrojakove podobe, tedy napr. CR jako dva znaky: '\\' a 'r'
-// proto delame escape sekvence vlastne dvojnasobne
+// Strings in TRANSLATOR are stored in source form, e.g. CR as two characters: '\\' and 'r'
+// therefore we effectively handle escape sequences twice
 BOOL SkipEscapeSeqInPlurStr(const wchar_t*& s, BOOL* error)
 {
     if (*s == L'\\')
     {
         if (*(s + 1) == L'r' || *(s + 1) == L'n' || *(s + 1) == L't')
-        { // v .res je jediny znak CR, LF nebo TAB
+        { // in the .res there is a single character CR, LF, or TAB
             s += 2;
         }
         else
         {
             if (*(s + 1) == L'\\' && (*(s + 2) == L'|' || *(s + 2) == L'{' || *(s + 2) == L'}' || *(s + 2) == L':'))
-            { // v .res jsou dva znaky: \|, \{, \: nebo \} (escape sekvence pro |, { a } v plural stringu)
+            { // in the .res there are two characters: \|, \{, \: or \} (escape sequences for |, {, and } in a plural string)
                 s += 3;
             }
             else
             {
                 if (*(s + 1) == L'\\' && *(s + 2) == L'\\' && *(s + 3) == L'\\')
-                { // v .res jsou dva znaky: \\ (escape sekvence pro \ v plural stringu)
+                { // in the .res there are two characters: \\ (escape sequence for \ in a plural string)
                     s += 4;
                 }
                 else
                 {
                     if (*(s + 1) == L'\\')
-                    { // v .res je jediny znak backslash
+                    { // in the .res there is a single backslash character
                         s += 2;
                     }
                     else
@@ -356,16 +356,16 @@ const wchar_t* FindPluralStrPar(const wchar_t* s, BOOL* error)
         if (SkipEscapeSeqInPlurStr(s, error))
         {
             if (*error)
-                return s; // chybna escape sekvence
+                return s; // invalid escape sequence
         }
         else
         {
             if (*s == L'{')
-                return s; // nasli jsme zacatek parametru
+                return s; // found the start of a parameter
             s++;
         }
     }
-    return s; // nenalezeno, vracime konec retezce
+    return s; // not found, return the end of the string
 }
 
 BOOL IsPrintfCharacter(const wchar_t* text, int* length);
@@ -376,13 +376,13 @@ const wchar_t* FindPluralStrParEnd(const wchar_t* s, BOOL* error, BOOL calcNumOf
 {
     wchar_t buff[300];
 
-    s++; // preskok L'{'
+    s++; // skip L'{'
 
     const wchar_t* parInd = s;
     int parIndVal = 0;
     while (*parInd >= L'0' && *parInd <= L'9')
         parIndVal = 10 * parIndVal + *parInd++ - L'0';
-    if (*parInd == L':' && parInd > s) // mame prirazeny index, pouzijeme ho
+    if (*parInd == L':' && parInd > s) // an explicit index is present, use it
     {
         if (parIndVal >= 1 && (calcNumOfParams || parIndVal <= *numOfParams))
         {
@@ -397,7 +397,7 @@ const wchar_t* FindPluralStrParEnd(const wchar_t* s, BOOL* error, BOOL calcNumOf
                     swprintf_s(buff, L"Unexpected number of parameters used in plural string (over %d).", parUsedArrCount);
                     OutWindow.AddLine(buff, mteError);
                     *error = TRUE;
-                    return s; // chyba, index je od jedne
+                    return s; // error, indexes start from one
                 }
             }
             s = parInd + 1;
@@ -413,7 +413,7 @@ const wchar_t* FindPluralStrParEnd(const wchar_t* s, BOOL* error, BOOL calcNumOf
                 OutWindow.AddLine(buff, mteError);
             }
             *error = TRUE;
-            return s; // chyba, index je od jedne
+            return s; // error, indexes start from one
         }
     }
     else
@@ -428,7 +428,7 @@ const wchar_t* FindPluralStrParEnd(const wchar_t* s, BOOL* error, BOOL calcNumOf
                        *numOfParams);
             OutWindow.AddLine(buff, mteError);
             *error = TRUE;
-            return s; // chyba, automaticky index vyjel mimo pocet parametru v originale
+            return s; // error, the implicit index exceeded the number of parameters in the original
         }
         if (!calcNumOfParams)
         {
@@ -439,26 +439,26 @@ const wchar_t* FindPluralStrParEnd(const wchar_t* s, BOOL* error, BOOL calcNumOf
                 swprintf_s(buff, L"Unexpected number of parameters used in plural string (over %d).", parUsedArrCount);
                 OutWindow.AddLine(buff, mteError);
                 *error = TRUE;
-                return s; // chyba, index je od jedne
+                return s; // error, indexes start from one
             }
         }
     }
 
     while (*s != 0 && *s != L'}')
     {
-        // preskok textu
+        // Skip text
         while (*s != L'}' && *s != 0 && *s != '|')
         {
             if (IsControlCharacter(s))
             {
                 OutWindow.AddLine(L"Plural string cannot contain control chars in its variable part.", mteError);
                 *error = TRUE;
-                return s; // tyto sekvence se daji kontrolovat jedina nad expandovanym stringem, doufejme ze to nikde nebude nutny pouzit, byl by to trochu ojeb ovalidovat vsechny varianty expandovaneho textu
+                return s; // these sequences can only be verified on the expanded string; hopefully we never need to do that, because validating every variant would be painful
             }
             if (SkipEscapeSeqInPlurStr(s, error))
             {
                 if (*error)
-                    return s; // chybna escape sekvence
+                    return s; // invalid escape sequence
             }
             else
             {
@@ -467,7 +467,7 @@ const wchar_t* FindPluralStrParEnd(const wchar_t* s, BOOL* error, BOOL calcNumOf
                 {
                     OutWindow.AddLine(L"Plural string cannot contain format specifiers in its variable part.", mteError);
                     *error = TRUE;
-                    return s; // tyto sekvence se daji kontrolovat jedina nad expandovanym stringem, doufejme ze to nikde nebude nutny pouzit, byl by to trochu ojeb ovalidovat vsechny varianty expandovaneho textu
+                    return s; // these sequences can only be verified on the expanded string; hopefully we never need to do that, because validating every variant would be painful
                 }
                 s++;
             }
@@ -476,7 +476,7 @@ const wchar_t* FindPluralStrParEnd(const wchar_t* s, BOOL* error, BOOL calcNumOf
         {
             s++;
 
-            // preskok ciselne meze
+            // Skip the numeric bound
             const wchar_t* numBeg = s;
             while (*s != L'}' && *s != 0 && *s != L'|')
             {
@@ -484,12 +484,12 @@ const wchar_t* FindPluralStrParEnd(const wchar_t* s, BOOL* error, BOOL calcNumOf
                 {
                     OutWindow.AddLine(L"Plural string contains interval bound which is not a decimal number.", mteError);
                     *error = TRUE;
-                    return s; // chyba, tady se ocekava jen dekadicke cislo
+                      return s; // error, only a decimal number is expected here
                 }
                 s++;
             }
             if (s > numBeg && *s == L'|')
-                s++; // mez nesmi byt prazdna + musi koncit L'|'
+                s++; // the bound must not be empty and has to end with L'|'
             else
             {
                 if (s == numBeg)
@@ -497,16 +497,16 @@ const wchar_t* FindPluralStrParEnd(const wchar_t* s, BOOL* error, BOOL calcNumOf
                 else
                     OutWindow.AddLine(L"Plural string's variable part cannot end with interval bound (text variant must follow).", mteError);
                 *error = TRUE;
-                return s; // chyba, bud chybi cislo meze nebo chybi dalsi text za L'|'
+                return s; // error: either the bound number is missing or there is no text after L'|'
             }
         }
     }
     return s;
 }
 
-// zkontroluje proti sobe retezce a vrati TRUE, pokud oba nejsou plural stringy
-// nebo oba jsou plural stringy a zaroven maji stejny pocet parametru a jsou
-// syntakticky v poradku
+// Compare the strings and return TRUE if neither is a plural string
+// or if both are plural strings with the same number of parameters
+// and are syntactically correct
 BOOL ValidatePluralStrings(const wchar_t* original, const wchar_t* translated)
 {
     wchar_t buff[300];
@@ -514,7 +514,7 @@ BOOL ValidatePluralStrings(const wchar_t* original, const wchar_t* translated)
     BOOL isOrigPlural = *original == L'{' && *(original + 1) == L'!' && *(original + 2) == L'}';
     BOOL isTranPlural = *translated == L'{' && *(translated + 1) == L'!' && *(translated + 2) == L'}';
     if (isOrigPlural != isTranPlural)
-        return FALSE; // jeden je, druhy neni plural, to je urcite spatne
+        return FALSE; // one is plural and the other is not—that is definitely wrong
     if (isOrigPlural)
     {
         // skip signature
@@ -528,15 +528,15 @@ BOOL ValidatePluralStrings(const wchar_t* original, const wchar_t* translated)
         {
             original = FindPluralStrPar(original, &error);
             if (error)
-                return FALSE; // chybna escape sekvence
+                return FALSE; // invalid escape sequence
             if (*original == 0)
-                break; // hotovo
+                break; // done
             original = FindPluralStrParEnd(original, &error, TRUE, &actParIndex, &numOfParams, NULL, 0);
             if (error || *original != L'}')
             {
                 if (!error)
                     OutWindow.AddLine(L"Original plural string contains variable part which is not closed by '}'.", mteError);
-                return FALSE; // chybna escape sekvence nebo parametry nejsou ukoncene '}'
+                return FALSE; // invalid escape sequence or parameters are not closed by '}'
             }
             original++;
         }
@@ -547,15 +547,15 @@ BOOL ValidatePluralStrings(const wchar_t* original, const wchar_t* translated)
         {
             translated = FindPluralStrPar(translated, &error);
             if (error)
-                return FALSE; // chybna escape sekvence
+                return FALSE; // invalid escape sequence
             if (*translated == 0)
-                break; // hotovo
+                break; // done
             translated = FindPluralStrParEnd(translated, &error, FALSE, &actParIndex, &numOfParams, parUsedArr, 100);
             if (error || *translated != L'}')
             {
                 if (!error)
                     OutWindow.AddLine(L"Plural string contains variable part which is not closed by '}'.", mteError);
-                return FALSE; // chybna escape sekvence nebo parametry nejsou ukoncene '}'
+                return FALSE; // invalid escape sequence or parameters are not closed by '}'
             }
             translated++;
         }
@@ -565,15 +565,15 @@ BOOL ValidatePluralStrings(const wchar_t* original, const wchar_t* translated)
             {
                 swprintf_s(buff, L"Plural string does not use all parameters, first unused parameter index is %d.", i + 1);
                 OutWindow.AddLine(buff, mteError);
-                return FALSE; // nepouzity parametr, nejspis chyba
+                return FALSE; // unused parameter—most likely an error
             }
         }
     }
     return TRUE;
 }
 
-// zkontroluje proti sobe retezce a vrati TRUE, pokud obsahuji stejny pocet a poradi
-// ridicich znaku \r \n \t
+// Compare the strings and return TRUE if they contain the same number and order
+// of control characters \r \n \t
 BOOL ValidateControlCharacters(const wchar_t* original, const wchar_t* translated)
 {
     const wchar_t* oIter = original;
@@ -608,7 +608,7 @@ BOOL ValidateControlCharacters(const wchar_t* original, const wchar_t* translate
     return TRUE;
 }
 
-// zkontroluje, jestli se shoduje pocet carek v originale a prekladu (jde o pocet hodnot ve stringu s CSV)
+// Check whether the number of commas matches in the original and translation (the number of values in a CSV string)
 BOOL ValidateStringWithCSV(const wchar_t* original, const wchar_t* translated)
 {
     const wchar_t* oIter = original;
@@ -624,8 +624,8 @@ BOOL ValidateStringWithCSV(const wchar_t* original, const wchar_t* translated)
     return oCount == tCount;
 }
 
-// vrati TRUE, pokud ukazatel text ukazuje na ridici znak pro printf
-// zaroven naplni promennou length
+// Return TRUE if the text pointer references a printf control specifier
+// and fill the length variable
 
 BOOL IsPrintfCharacter(const wchar_t* text, int* length)
 {
@@ -633,7 +633,7 @@ BOOL IsPrintfCharacter(const wchar_t* text, int* length)
     if (*p == L'%')
     {
         p++;
-        if (*p == L'%') // escape sekvence pro '%'
+        if (*p == L'%') // escape sequence for '%'
         {
             *length = p - text + 1;
             return TRUE;
@@ -680,8 +680,8 @@ BOOL IsPrintfCharacter(const wchar_t* text, int* length)
     return FALSE;
 }
 
-// zkontroluje proti sobe retezce a vrati TRUE, pokud obsahuji stejny pocet a poradi
-// ridicich retezcu pro printf
+// Compare the strings and return TRUE if they contain the same number and order
+// of printf format specifiers
 BOOL ValidatePrintfSpecifier(const wchar_t* original, const wchar_t* translated)
 {
     const wchar_t* oIter = original;
@@ -719,14 +719,14 @@ BOOL ValidatePrintfSpecifier(const wchar_t* original, const wchar_t* translated)
     return TRUE;
 }
 
-// pokud jeden retezec obsahuje horkou klavesu a druhy ne, vrati FALSE
-// jinak vrati TRUE
+// Return FALSE if exactly one string contains a hotkey
+// otherwise return TRUE
 BOOL ValidateHotKeys(const wchar_t* original, const wchar_t* translated)
 {
     const wchar_t* oIter = original;
     const wchar_t* tIter = translated;
 
-    // pocet horkych klaves
+    // Number of hotkeys
     int oCount = 0;
     int tCount = 0;
 
@@ -760,8 +760,8 @@ BOOL ValidateHotKeys(const wchar_t* original, const wchar_t* translated)
     return TRUE;
 }
 
-// vraci FALSE, pokud maji retezce na zacatku ruzny pocet mezer
-// jinak vraci TRUE
+// Return FALSE if the strings start with a different number of spaces
+// otherwise return TRUE
 BOOL ValidateTextBeginning(const wchar_t* original, const wchar_t* translated)
 {
     const wchar_t* oIter = original;
@@ -782,14 +782,14 @@ BOOL ValidateTextBeginning(const wchar_t* original, const wchar_t* translated)
     return oCount == tCount;
 }
 
-#define IDEOGRAPHIC_PERIOD L'\x3002' // tecka za vetou v simplified chinese (a zrejme i v dalsich obrazkovych pismech)
+#define IDEOGRAPHIC_PERIOD L'\x3002' // sentence period in Simplified Chinese (and likely other logographic scripts)
 
-// otestuje konce retezcu, zda oba maji stejne zaviraci sekvence (mezery, tecky, dvojtecky)
-// pokud jsou konce retezcu shodne, vraci TRUE, jinak vraci FALSE
+// Check whether both string endings use the same trailing sequence (spaces, dots, colons)
+// Return TRUE if the endings match; otherwise return FALSE
 BOOL ValidateTextEnding(const wchar_t* original, const wchar_t* translated, WORD strID)
 {
-    // Petr: pridame sem i test na to, jestli neni jeden text prazdny a druhy ne, to
-    // by byla tez chyba a da se rict, ze to spada pod ruzne zacatky/konce textu
+    // Petr: also add a test that one text is not empty while the other is not;
+    // that would also be an error and falls under mismatching beginnings/endings
     const wchar_t* oWS = original;
     while (*oWS != 0 && (*oWS == ' ' || *oWS == '\t'))
         oWS++;
@@ -816,7 +816,7 @@ BOOL ValidateTextEnding(const wchar_t* original, const wchar_t* translated, WORD
         tCont = (tIter >= translated && (*tIter == L'.' || *tIter == L':' || *tIter == L' ' || *tIter == IDEOGRAPHIC_PERIOD));
         if (ignoreMissingColonAtEnd && oCont && *oIter == L':' && (!tCont || *tIter != L':'))
         {
-            ignoreMissingColonAtEnd = FALSE; // ignorujeme jen jednu chybejici dvojtecku
+            ignoreMissingColonAtEnd = FALSE; // ignore only a single missing colon
             oIter--;
             oCont = (oIter >= original && (*oIter == L'.' || *oIter == L':' || *oIter == L' ' || *oIter == IDEOGRAPHIC_PERIOD));
         }
@@ -825,7 +825,7 @@ BOOL ValidateTextEnding(const wchar_t* original, const wchar_t* translated, WORD
             wchar_t oCh = *oIter;
             wchar_t tCh = *tIter;
             if (oCh == IDEOGRAPHIC_PERIOD)
-                oCh = L'.'; // IDEOGRAPHIC_PERIOD a L'.' jsou pro nase ucely ekvivalentni znaky
+                oCh = L'.'; // IDEOGRAPHIC_PERIOD and L'.' are equivalent for our purposes
             if (tCh == IDEOGRAPHIC_PERIOD)
                 tCh = L'.';
             if (oCh != tCh)
@@ -864,7 +864,7 @@ BOOL DoesControlsOverlap(WORD dialogID, const CControl* ctrl1, const CControl* c
 {
     RECT r1;
     int r1Height = ctrl1->TCY;
-    if (ctrl1->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+    if (ctrl1->IsComboBox()) // For combo boxes we want their "collapsed" size
         r1Height = COMBOBOX_BASE_HEIGHT;
     r1.left = ctrl1->TX;
     r1.top = ctrl1->TY;
@@ -874,7 +874,7 @@ BOOL DoesControlsOverlap(WORD dialogID, const CControl* ctrl1, const CControl* c
 
     RECT r2;
     int r2Height = ctrl2->TCY;
-    if (ctrl2->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+    if (ctrl2->IsComboBox()) // For combo boxes we want their "collapsed" size
         r2Height = COMBOBOX_BASE_HEIGHT;
     r2.left = ctrl2->TX;
     r2.top = ctrl2->TY;
@@ -888,19 +888,19 @@ BOOL DoesControlsOverlap(WORD dialogID, const CControl* ctrl1, const CControl* c
 
 BOOL DoesGroupBoxLabelOverlap(BOOL control1IsCheckOrRadioBox, const CControl* control1, const CControl* control2)
 {
-    return control1IsCheckOrRadioBox && control2->IsGroupBox() &&                                  // poresime, jestli nepresahuje label z checkboxu/radioboxu groupbox
-           control1->TY <= control2->TY + 4 && control1->TY + control1->TCY >= control2->TY + 5 && // +4 a +5 experimentalne zjisteno (checkbox/radiobox vertikalne prekryva horni caru groupboxu)
-           control1->TX > control2->TX && control1->TX < control2->TX + control2->TCX &&           // checkbox/radiobox horizontalne prekryva groupbox
-           control1->TX + control1->TCX > control2->TX + control2->TCX - 3;                        // checkbox/radiobox konci moc daleko, nici horni pravy roh groupboxu
+    return control1IsCheckOrRadioBox && control2->IsGroupBox() &&                                  // solve whether the checkbox/radio label overlaps the group box
+           control1->TY <= control2->TY + 4 && control1->TY + control1->TCY >= control2->TY + 5 && // +4 and +5 determined experimentally (checkbox/radio overlaps the top edge vertically)
+           control1->TX > control2->TX && control1->TX < control2->TX + control2->TCX &&           // checkbox/radio overlaps the group box horizontally
+           control1->TX + control1->TCX > control2->TX + control2->TCX - 3;                        // checkbox/radio ends too far and damages the upper-right corner of the group box
 }
 
 BOOL ShouldValidateLayoutFor(const CControl* control)
 {
-    // groupboxy ignorujeme
+    // Ignore group boxes
     if (control->IsGroupBox())
         return FALSE;
 
-    // nizky static bez texty bude horizontalni separator
+    // A short static control without text represents a horizontal separator
     if ((DWORD)control->ClassName == 0x0082ffff && (control->TCY < 2) && (control->TWindowName[0] == 0))
         return FALSE;
 
@@ -947,14 +947,14 @@ BOOL ShouldValidateAlignment(CDialogData* dialog, const CControl* control1,
 
     if ((DWORD)control1->ClassName == 0x0082ffff &&
         (DWORD)control2->ClassName == 0x0082ffff &&
-        control1->TCY == 1 && control2->TCY == 1) // vodorovne cary zkontrolujeme na obou stranach
+        control1->TCY == 1 && control2->TCY == 1) // check horizontal lines on both sides
     {
-        *checkLeft = control1->TY < 20 && control2->TY < 20; // jen pokud jdou od kraje dialogu, jinak nejspis pokracuji od konec static textu pred nima a to nema smysl validovat
+        *checkLeft = control1->TY < 20 && control2->TY < 20; // only if they start at the dialog edge; otherwise they likely continue after a static text and validating makes no sense
         *checkRight = TRUE;
         return TRUE;
     }
 
-    // statiky "levy text" a radiaky s checkboxama budeme vsechny rovnat na levou stranu
+    // Align "left text" statics and radio/check boxes to the left edge
     if (((DWORD)control1->ClassName == 0x0080ffff && IsRadioOrCheckBox(control1->Style) ||
          (DWORD)control1->ClassName == 0x0082ffff && IsStaticLeftText(control1->Style) &&
              control1->TCY > 1 && !Data.IgnoreStaticItIsProgressBar(dialog->ID, control1->ID)) &&
@@ -975,41 +975,41 @@ BOOL ShouldValidateAlignment(CDialogData* dialog, const CControl* control1,
     {
         CButtonType b1 = GetButtonType(control1->Style);
         CButtonType b2 = GetButtonType(control2->Style);
-        *checkLeft = TRUE; // u tlacitek testujeme vzdy levou stranu (snad nemame checkboxy/radiaky s right align?)
+        *checkLeft = TRUE; // always test the left side for buttons (hopefully no right-aligned checkboxes/radios)
         *checkRight = b1 == btPush && b2 == btPush ||
-                      b1 == btGroup && b2 == btGroup; // pokud jde o "push" tlacitko nebo groupbox, overime i pravou hranu
+                      b1 == btGroup && b2 == btGroup; // if it is a push button or group box, verify the right edge as well
         *checkVertical = *checkRight;
         return *checkRight || (control1->Style & BS_TYPEMASK) == (control2->Style & BS_TYPEMASK);
     }
 
-    if ((DWORD)control1->ClassName == 0x0082ffff) // STATIC nebo progress bar
+    if ((DWORD)control1->ClassName == 0x0082ffff) // STATIC or progress bar
     {
         if (Data.IgnoreStaticItIsProgressBar(dialog->ID, control1->ID)) // progress bar
         {
             *checkLeft = TRUE;
             *checkRight = TRUE;
             *checkVertical = TRUE;
-            return Data.IgnoreStaticItIsProgressBar(dialog->ID, control2->ID); // jen je-li druhy tez progress bar
+            return Data.IgnoreStaticItIsProgressBar(dialog->ID, control2->ID); // only if the other one is also a progress bar
         }
         DWORD ssStyle = (control1->Style & SS_TYPEMASK);
-        *checkLeft = IsStaticLeftText(control1->Style); // levou hranu chceme testovat pouze pokud je zarovnan vlevo
-        *checkRight = (ssStyle == SS_RIGHT);            // pravou hranu chceme testovat pouze pokud je zarovnan vpravo
+        *checkLeft = IsStaticLeftText(control1->Style); // test the left edge only if it is left-aligned
+        *checkRight = (ssStyle == SS_RIGHT);            // test the right edge only if it is right-aligned
         return ((control1->Style & SS_TYPEMASK) == (control2->Style & SS_TYPEMASK) ||
                 IsStaticLeftText(control1->Style) && IsStaticLeftText(control2->Style)) &&
-               control1->TCY > 1 && control2->TCY > 1 &&                    // vylouceni vodorovnych car
-               !Data.IgnoreStaticItIsProgressBar(dialog->ID, control2->ID); // vylouceni progress baru
+               control1->TCY > 1 && control2->TCY > 1 &&                    // exclude horizontal lines
+               !Data.IgnoreStaticItIsProgressBar(dialog->ID, control2->ID); // exclude progress bars
     }
 
     if ((DWORD)control1->ClassName == 0x0081ffff) // EDIT
     {
         if ((control1->Style & WS_BORDER) != (control2->Style & WS_BORDER))
-            return FALSE; // editbox s a bez ramecku nezarovnavame, to nema smysl
+            return FALSE; // aligning edits with and without borders makes no sense
         *checkLeft = TRUE;
-        *checkRight = (control1->Style & WS_BORDER) != 0; // pravou hranu chceme testovat pouze pokud ma ramecek (jinak prava hrana neni patrna)
+        *checkRight = (control1->Style & WS_BORDER) != 0; // test the right edge only if it has a border (otherwise the edge is not visible)
         return TRUE;
     }
 
-    // vsechny ostatni prvky nechame validovat "tvrde", postupne muzeme pridavat vyjimky, viz dva bloky BUTTON a STATIC
+    // Validate all remaining controls strictly; we can add exceptions later, see the BUTTON and STATIC blocks
     *checkLeft = TRUE;
     *checkRight = TRUE;
     return TRUE;
@@ -1025,13 +1025,13 @@ BOOL ShouldValidateSize(const CControl* control1, const CControl* control2)
         CButtonType b1 = GetButtonType(control1->Style);
         CButtonType b2 = GetButtonType(control2->Style);
         return b1 == btPush && b2 == btPush ||
-               b1 == btGroup && b2 == btGroup; // pokud jde o "push" tlacitko nebo groupbox
+               b1 == btGroup && b2 == btGroup; // if it is a push button or group box
     }
 
     if ((DWORD)control1->ClassName == 0x0081ffff) // EDIT
     {
         if ((control1->Style & WS_BORDER) != (control2->Style & WS_BORDER))
-            return FALSE; // editbox s a bez ramecku nezarovnavame, to nema smysl
+            return FALSE; // Do not align edit boxes with and without borders—it makes no sense
         return TRUE;
     }
 
@@ -1048,7 +1048,7 @@ enum EnumSpacingControlType
     esctPushButton,
     esctCheckBox,
     esctRadioButton,
-    //  esctStatic, kdybysme chteli uchylacit
+    //  esctStatic, if we ever wanted to go overboard
     esctEditBox,
     esctComboBox,
     esctNone
@@ -1090,18 +1090,18 @@ EnumSpacingControlType GetSpacingControlType(const CControl* control)
 BOOL HasDifferentSpacing(CDialogData* dialogData, int controlIndex)
 {
     const CControl* control = dialogData->Controls[controlIndex];
-    // zjistime, zda jde o control, ktery mame na mezery testovat
+    // Determine whether this control should be checked for spacing
     EnumSpacingControlType ctrlType = GetSpacingControlType(control);
     if (ctrlType != esctNone)
     {
-        BOOL checkHoriz = ctrlType != esctRadioButton && ctrlType != esctCheckBox; // co nema ram okolo nema smysl rovnat ve vodorovnem smeru
+        BOOL checkHoriz = ctrlType != esctRadioButton && ctrlType != esctCheckBox; // elements without a frame should not be aligned horizontally
 
         RECT outline;
         outline.left = control->TX;
         outline.top = control->TY;
         outline.right = control->TX + control->TCX;
         int ctrlH = control->TCY;
-        if (control->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+        if (control->IsComboBox()) // for combo boxes we want their "collapsed" size
             ctrlH = COMBOBOX_BASE_HEIGHT;
         outline.bottom = control->TY + ctrlH;
 
@@ -1112,27 +1112,27 @@ BOOL HasDifferentSpacing(CDialogData* dialogData, int controlIndex)
         outerSpace.right = OUTERSPACEMAX;
         outerSpace.bottom = OUTERSPACEMAX;
 
-        // budeme hledat vzdalenost ke stejnym prvkum (ve 4 smerech)
+        // Look for distances to the same control types (in four directions)
 
-        // v druhe fazi od controlu v kazdem ze smeru
-        for (int i = 1; i < dialogData->Controls.Count; i++) // 0 - title dialogu
+        // Second phase: from the control in each direction
+        for (int i = 1; i < dialogData->Controls.Count; i++) // 0 = dialog title
         {
             const CControl* control2 = dialogData->Controls[i];
-            if (control != control2 && ctrlType == GetSpacingControlType(control2)) // hledame stejny typ + nechceme sami sebe
+            if (control != control2 && ctrlType == GetSpacingControlType(control2)) // find the same type and avoid ourselves
             {
                 int ctrlX = control2->TX;
                 int ctrlW = control2->TCX;
                 int ctrlY = control2->TY;
                 ctrlH = control2->TCY;
-                if (control2->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+                if (control2->IsComboBox()) // for combo boxes we want their "collapsed" size
                     ctrlH = COMBOBOX_BASE_HEIGHT;
 
-                // POZOR, obdobny kod je jeste v GetOuterSpace() a GetMutualControlsPosition()
+                // WARNING: similar code lives in GetOuterSpace() and GetMutualControlsPosition()
 
-                // control lezi vejskove v pasmu nasi skupiny
-                if ((ctrlY >= outline.top && ctrlY < outline.bottom) ||                  // horni hrana controly lezi uprostred skupiny
-                    (ctrlY + ctrlH >= outline.top && ctrlY + ctrlH <= outline.bottom) || // dolni hrana controlu lezi uprostred skupiny
-                    (ctrlY < outline.top && ctrlY + ctrlH > outline.bottom))             // horni hrana lezi nad skupinou, dolni pod skupinou (control je vyssi nez cela skupina)
+                // The control is vertically within the band's range
+                if ((ctrlY >= outline.top && ctrlY < outline.bottom) ||                  // top edge lies inside the group
+                    (ctrlY + ctrlH >= outline.top && ctrlY + ctrlH <= outline.bottom) || // bottom edge lies inside the group
+                    (ctrlY < outline.top && ctrlY + ctrlH > outline.bottom))             // spans above and below the group (taller than the band)
                 {
                     if ((ctrlX + ctrlW <= outline.left) && (outline.left - (ctrlX + ctrlW) < outerSpace.left))
                     {
@@ -1143,7 +1143,7 @@ BOOL HasDifferentSpacing(CDialogData* dialogData, int controlIndex)
                         outerSpace.right = ctrlX - outline.right;
                     }
                 }
-                // control lezi sirkove v pasmu nasi skupiny
+                // The control is horizontally within the band's range
                 if ((ctrlX >= outline.left && ctrlX < outline.right) ||
                     (ctrlX + ctrlW >= outline.left && ctrlX + ctrlW <= outline.right) ||
                     (ctrlX < outline.left && ctrlX + ctrlW > outline.right))
@@ -1175,21 +1175,21 @@ void GetMutualControlsPosition(const CControl* control1, const CControl* control
     int ctrl1W = control1->TCX;
     int ctrl1Y = control1->TY;
     int ctrl1H = control1->TCY;
-    if (control1->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+    if (control1->IsComboBox()) // for combo boxes we want their "collapsed" size
         ctrl1H = COMBOBOX_BASE_HEIGHT;
 
     int ctrl2X = control2->TX;
     int ctrl2W = control2->TCX;
     int ctrl2Y = control2->TY;
     int ctrl2H = control2->TCY;
-    if (control2->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+    if (control2->IsComboBox()) // for combo boxes we want their "collapsed" size
         ctrl2H = COMBOBOX_BASE_HEIGHT;
 
-    // control lezi vejskove v pasmu nasi outline
-    *inRow = ((ctrl2Y >= ctrl1Y && ctrl2Y < ctrl1Y + ctrl1H) ||                   // horni hrana druheho lezi uprostred prvniho
-              (ctrl2Y + ctrl2H > ctrl1Y && ctrl2Y + ctrl2H <= ctrl1Y + ctrl1H) || // dolni hrana druheho lezi uprostred prvniho
-              (ctrl1Y < ctrl2Y && ctrl1Y + ctrl1H > ctrl2Y + ctrl2H) ||           // horni hrana prvniho lezi nad druhym, dolni hrana prvniho pod druhym (druhy lezi vyskove v prvnim)
-              (ctrl2Y < ctrl1Y && ctrl2Y + ctrl2H > ctrl1Y + ctrl1H));            // horni hrana druheho lezi nad prvnim, dolni hrana druheho pod prvnim (prvni lezi vyskove v druhem)
+    // The control is vertically within the outline band
+    *inRow = ((ctrl2Y >= ctrl1Y && ctrl2Y < ctrl1Y + ctrl1H) ||                   // second control's top edge lies inside the first
+              (ctrl2Y + ctrl2H > ctrl1Y && ctrl2Y + ctrl2H <= ctrl1Y + ctrl1H) || // second control's bottom edge lies inside the first
+              (ctrl1Y < ctrl2Y && ctrl1Y + ctrl1H > ctrl2Y + ctrl2H) ||           // first control spans above and below the second
+              (ctrl2Y < ctrl1Y && ctrl2Y + ctrl2H > ctrl1Y + ctrl1H));            // second control spans above and below the first
     *inCol = ((ctrl2X >= ctrl1X && ctrl2X < ctrl1X + ctrl1W) ||
               (ctrl2X + ctrl2W > ctrl1X && ctrl2X + ctrl2W <= ctrl1X + ctrl1W) ||
               (ctrl1X < ctrl2X && ctrl1X + ctrl1W > ctrl2X + ctrl2W) ||
@@ -1209,7 +1209,7 @@ BOOL IsControlForLabelPlacingTest(const CDialogData* dialog, const CControl* con
                 if ((DWORD)firstControl->ClassName == 0x0080ffff) // BUTTON
                 {
                     CButtonType b = GetButtonType(firstControl->Style);
-                    if (b == btCheck || b == btRadio) // checkbox nebo radiobutton pred tlacitkem
+                    if (b == btCheck || b == btRadio) // Checkbox or radio button before the button
                     {
                         *deltaY = (control->TCY - 12) / 2;
                         return TRUE;
@@ -1220,23 +1220,23 @@ BOOL IsControlForLabelPlacingTest(const CDialogData* dialog, const CControl* con
                 {
                     DWORD ss = (firstControl->Style & SS_TYPEMASK);
                     if (ss == SS_LEFT || ss == SS_RIGHT || ss == SS_CENTER || ss == SS_SIMPLE || ss == SS_LEFTNOWORDWRAP)
-                    { // static pred tlacitkem
+                    { // Static before the button
                         *deltaY = (control->TCY - 12) / 2;
                         return TRUE;
                     }
                 }
 
                 if ((DWORD)firstControl->ClassName == 0x0081ffff && // EDIT
-                    (firstControl->Style & WS_BORDER) != 0)         // s rameckem
+                    (firstControl->Style & WS_BORDER) != 0)         // With a border
                 {
-                    *deltaY = (control->TCY - firstControl->TCY) / 2; // button za editboxem (nejspis Browse tlacitko) - srovname vrsky (edit ma vzdy *deltaY == 0)
+                    *deltaY = (control->TCY - firstControl->TCY) / 2; // Button after an edit box (likely a Browse button) — align the tops (edits always have *deltaY == 0)
                     return TRUE;
                 }
 
                 *deltaY = 2;
                 return TRUE;
             }
-            return FALSE; // jako label button nekontrolujeme (je treba u zmeny fontu, ale kasleme na to)
+            return FALSE; // We do not check buttons used as labels (needed for font changes, but we'll ignore it)
         }
 
         case btCheck:
@@ -1301,7 +1301,7 @@ BOOL IsControlForLabelPlacingTest(const CDialogData* dialog, const CControl* con
 
 BOOL IsNotLeftStaticFollowedByLine(const CControl* control, CDialogData* dialogData, int controlIndex)
 {
-    if (control->IsStaticText(TRUE) && control->TCY < 16) // label musi byt static zarovnany vlevo, bereme jen jednoradkove labely
+    if (control->IsStaticText(TRUE) && control->TCY < 16) // Labels must be left-aligned statics; only single-line labels are considered
     {
         for (int i = 0; i < 2; i++)
         {
@@ -1311,11 +1311,11 @@ BOOL IsNotLeftStaticFollowedByLine(const CControl* control, CDialogData* dialogD
             if (i == 1 && controlIndex > 0)
                 control2 = dialogData->Controls[controlIndex - 1];
             if (control2 != NULL && control2->TCY == 1 &&
-                control2->ClassName == (wchar_t*)0x0082FFFF &&                                   // STATIC: vodorovna cara
-                control2->TY >= control->TY && control2->TY < control->TY + control->TCY &&      // cara je vyskove v controlu
-                control2->TX >= control->TX && control2->TX - (control->TX + control->TCX) < 20) // cara zacina za controlem a to nejvyse 20 dlg-units
+                control2->ClassName == (wchar_t*)0x0082FFFF &&                                   // STATIC: horizontal line
+                control2->TY >= control->TY && control2->TY < control->TY + control->TCY &&      // The line sits vertically within the control
+                control2->TX >= control->TX && control2->TX - (control->TX + control->TCX) < 20) // The line starts after the control, at most 20 dialog units away
             {
-                return FALSE; // tohle je levy static nasledovany carou
+                return FALSE; // This is a left static followed by a line
             }
         }
     }
@@ -1331,11 +1331,11 @@ BOOL IsLabelCorrectlyPlaced(CDialogData* dialogData, int controlIndex, int* cont
 
     int ctrl1YOffset;
     if (IsControlForLabelPlacingTest(dialogData, control1, NULL, &ctrl1YOffset) &&
-        IsNotLeftStaticFollowedByLine(control1, dialogData, controlIndex)) // levy static s nalepenou carou vpravo nemuze byt label
+        IsNotLeftStaticFollowedByLine(control1, dialogData, controlIndex)) // A left static with a bar glued to its right cannot be a label
     {
         const CControl* control2 = NULL;
         BOOL tryingNextCtrl = FALSE;
-        if (controlIndex < dialogData->Controls.Count - 1) // jako prvni control k labelu zkusime ten nasledujici po labelu
+        if (controlIndex < dialogData->Controls.Count - 1) // Try the control immediately after the label first
         {
             control2 = dialogData->Controls[controlIndex + 1];
             *controlIndexOut = controlIndex + 1;
@@ -1349,14 +1349,14 @@ BOOL IsLabelCorrectlyPlaced(CDialogData* dialogData, int controlIndex, int* cont
         int ctrl1W = control1->TCX;
         int ctrl1Y = control1->TY;
         int ctrl1H = control1->TCY;
-        if (control1->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+        if (control1->IsComboBox()) // For combo boxes we want their "collapsed" size
             ctrl1H = COMBOBOX_BASE_HEIGHT;
         if (control1->IsIcon() && Data.IgnoreIconSizeIconIsSmall(dialogData->ID, control1->ID))
             ctrl1W = ctrl1H = 10;
 
         while (1)
         {
-            if (control2 == NULL) // pokusime se najit control k labelu jen podle souradnic
+            if (control2 == NULL) // Try to find the control for the label solely by coordinates
             {
                 if (tryNeighborAtRight)
                 {
@@ -1365,21 +1365,21 @@ BOOL IsLabelCorrectlyPlaced(CDialogData* dialogData, int controlIndex, int* cont
                     int found = -1;
                     for (int i = 0; i < dialogData->Controls.Count; i++)
                     {
-                        if (i != controlIndex) // sami sobe byt control za labelem nemuzeme
+                        if (i != controlIndex) // The control itself cannot be behind the label
                         {
                             const CControl* c = dialogData->Controls[i];
                             int x = c->TX;
                             int w = c->TCX;
                             int y = c->TY;
                             int h = c->TCY;
-                            if (c->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+                            if (c->IsComboBox()) // For combo boxes we want their "collapsed" size
                                 h = COMBOBOX_BASE_HEIGHT;
                             if (c->IsIcon() && Data.IgnoreIconSizeIconIsSmall(dialogData->ID, c->ID))
                                 w = h = 10;
 
-                            if (x >= ctrl1X + ctrl1W && y + h > ctrl1Y && y < ctrl1Y + ctrl1H) // je vpravo a ma prunik s vyskou labelu
+                            if (x >= ctrl1X + ctrl1W && y + h > ctrl1Y && y < ctrl1Y + ctrl1H) // It is to the right and overlaps the label height
                             {
-                                if (minDist == -1 || minDist > x - (ctrl1X + ctrl1W)) // prvni nalezeny nebo je k labelu blize
+                                if (minDist == -1 || minDist > x - (ctrl1X + ctrl1W)) // Use the first found control or the one closer to the label
                                 {
                                     found = i;
                                     minDist = x - (ctrl1X + ctrl1W);
@@ -1401,21 +1401,21 @@ BOOL IsLabelCorrectlyPlaced(CDialogData* dialogData, int controlIndex, int* cont
                     int found = -1;
                     for (int i = 0; i < dialogData->Controls.Count; i++)
                     {
-                        if (i != controlIndex) // sami sobe byt control za labelem nemuzeme
+                        if (i != controlIndex) // The control itself cannot be behind the label
                         {
                             const CControl* c = dialogData->Controls[i];
                             int x = c->TX;
                             int w = c->TCX;
                             int y = c->TY;
                             int h = c->TCY;
-                            if (c->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+                            if (c->IsComboBox()) // For combo boxes we want their "collapsed" size
                                 h = COMBOBOX_BASE_HEIGHT;
                             if (c->IsIcon() && Data.IgnoreIconSizeIconIsSmall(dialogData->ID, c->ID))
                                 w = h = 10;
 
-                            if (y >= ctrl1Y + ctrl1H && x + w > ctrl1X && x < ctrl1X + ctrl1W) // je dole a ma prunik s sirkou labelu
+                            if (y >= ctrl1Y + ctrl1H && x + w > ctrl1X && x < ctrl1X + ctrl1W) // It is below and overlaps the label width
                             {
-                                if (minDist == -1 || minDist > y - (ctrl1Y + ctrl1H)) // prvni nalezeny nebo je k labelu blize
+                                if (minDist == -1 || minDist > y - (ctrl1Y + ctrl1H)) // Use the first found control or the one closer to the label
                                 {
                                     found = i;
                                     minDist = y - (ctrl1Y + ctrl1H);
@@ -1444,9 +1444,9 @@ BOOL IsLabelCorrectlyPlaced(CDialogData* dialogData, int controlIndex, int* cont
 #define TOPLABELDISTANCE_MAX_X2 20
 #define TOPLABELDISTANCE_MAX_Y 10
             if (!inRow && inCol && deltaY < 0 &&
-                control1->IsStaticText(TRUE) && control1->TCY < 16 &&                                // label musi byt static zarovnany vlevo, bereme jen jednoradkove labely
-                control2->TY - (control1->TY + 8) <= TOPLABELDISTANCE_MAX_Y &&                       // control nesmi mit prilis velky Y-ovy odstup od labelu
-                abs(deltaX) <= (tryingNextCtrl ? TOPLABELDISTANCE_MAX_X2 : TOPLABELDISTANCE_MAX_X1)) // control nesmi mit prilis velky X-ovy odstup od labelu
+                control1->IsStaticText(TRUE) && control1->TCY < 16 &&                                // Labels must be left-aligned statics; only single-line labels are considered
+                control2->TY - (control1->TY + 8) <= TOPLABELDISTANCE_MAX_Y &&                       // The control must not be too far in Y from the label
+                abs(deltaX) <= (tryingNextCtrl ? TOPLABELDISTANCE_MAX_X2 : TOPLABELDISTANCE_MAX_X1)) // The control must not be too far in X from the label
             {
                 CButtonType bt;
                 if ((DWORD)control2->ClassName == 0x0081ffff ||                                                    // EDIT
@@ -1456,12 +1456,12 @@ BOOL IsLabelCorrectlyPlaced(CDialogData* dialogData, int controlIndex, int* cont
                     (DWORD)control2->ClassName == 0x0080ffff &&                                                    // BUTTON: push-button + checkbox + radiobutton
                         ((bt = GetButtonType(control2->Style)) == btPush || bt == btCheck || bt == btRadio))
                 {
-                    // label lezi nad controlem
+                    // Label is above the control
 #define LABEL2CONTROL_SPACING_V -2 // 2 pro space
                     int labelDY = LABEL2CONTROL_SPACING_V - 8 * (control1->TCY / 8);
                     BOOL control2IsCheckOrRadio = (DWORD)control2->ClassName == 0x0080ffff && (bt == btCheck || bt == btRadio);
                     if (control2IsCheckOrRadio)
-                        labelDY += (control2->TCY - 10) / 2; // BUTTON: checkbox + radiobutton: Y-ovy odstup se lisi podle vysky buttonu (bezne jsou 10 a 12)
+                        labelDY += (control2->TCY - 10) / 2; // BUTTON: checkbox + radiobutton: the Y offset depends on button height (typically 10 or 12)
                     if (deltaY != labelDY &&
                         !Data.IgnoreProblem(iltIncorPlLbl, dialogData->ID, control1->ID, control2->ID))
                     {
@@ -1469,14 +1469,14 @@ BOOL IsLabelCorrectlyPlaced(CDialogData* dialogData, int controlIndex, int* cont
                         *deltaAxis = "vertically";
                         return FALSE;
                     }
-#define LABEL2CHECKBOX_H_ALIGN -7 // labelum sloupce pushbuttonu/checkboxu/radiaku dovolime odsazeni o presne 7 dlg-units (pouziva PictView a bez odsazeni je to hnusny)
+#define LABEL2CHECKBOX_H_ALIGN -7 // Allow labels of push-button/checkbox/radio columns to be offset by exactly 7 dialog units (used by PictView; without the offset it looks ugly)
                     BOOL control2IsPushOrCheckOrRadio = (DWORD)control2->ClassName == 0x0080ffff && (bt == btPush || bt == btCheck || bt == btRadio);
                     BOOL control2IsEditWithoutBorder = (DWORD)control2->ClassName == 0x0081ffff && (control2->Style & WS_BORDER) == 0;
                     if (deltaX != (control2IsEditWithoutBorder ? 2 : 0) &&
                         (!control2IsPushOrCheckOrRadio || deltaX != LABEL2CHECKBOX_H_ALIGN) &&
                         !Data.IgnoreProblem(iltIncorPlLbl, dialogData->ID, control1->ID, control2->ID))
                     {
-                        if (control2IsEditWithoutBorder) // edit bez ramecku ma byt proste -2 dlg. unity vlevo od labelu, jinak je spatne
+                        if (control2IsEditWithoutBorder) // An edit without a border should simply be -2 dialog units to the left of the label; otherwise it is wrong
                             *delta = deltaX - 2;
                         else
                         {
@@ -1510,7 +1510,7 @@ BOOL IsLabelCorrectlyPlaced(CDialogData* dialogData, int controlIndex, int* cont
                     if (tryingNextCtrl && !control2->IsStaticText(TRUE) && offsetY == 0 &&
                         distanceX >= 0 && distanceX <= LABELDISTANCE_CLOSE)
                     {
-                        return TRUE; // zjevna kombinace label+control, nema smysl hledat, jestli to neni label pro dole umisteny control (nachazi to akorat nesmysly)
+                        return TRUE; // Obvious label+control combination; no point searching for a label of a lower control (would only find nonsense)
                     }
                 }
             }
@@ -1538,7 +1538,7 @@ BOOL ControlHasStandardSize(const CDialogData* dialog, const CControl* control)
         {
         case btPush:
             return control->TCY == PUSHBUTTON_STANDARD_H && control->TCX >= PUSHBUTTON_STANDARD_W ||
-                   wcscmp(control->OWindowName, L"") == 0 || wcscmp(control->OWindowName, L"...") == 0 // specialni "kratka" browse tlacitka budeme ignorovat
+                   wcscmp(control->OWindowName, L"") == 0 || wcscmp(control->OWindowName, L"...") == 0 // Ignore special "short" browse buttons
                    || wcscmp(control->OWindowName, L"&...") == 0;
 
         case btCheck:
@@ -1555,11 +1555,11 @@ BOOL ControlHasStandardSize(const CDialogData* dialog, const CControl* control)
             return control->TCY == PROGRESSBAR_STANDARD_H;
 
         DWORD ss = (control->Style & SS_TYPEMASK);
-        if (ss == SS_ETCHEDHORZ && control->TCY != ETCHEDHORZ_STANDARD_H) // etched-horizontal musi mit vysku 1
+        if (ss == SS_ETCHEDHORZ && control->TCY != ETCHEDHORZ_STANDARD_H) // An etched horizontal line must have height 1
             return FALSE;
 
         if (ss == SS_LEFT || ss == SS_RIGHT || ss == SS_CENTER || ss == SS_SIMPLE || ss == SS_LEFTNOWORDWRAP)
-            return control->TCY == 1 /* vodorovne cary */ || control->TCY % STATIC_STANDARD_H == 0;
+            return control->TCY == 1 /* horizontal lines */ || control->TCY % STATIC_STANDARD_H == 0;
         else
             return TRUE;
     }
@@ -1618,12 +1618,12 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
     if (dlgFont == NULL)
     {
         TRACE_E("IsControlClippedAux(): unable to create dialog font, height: " << fontHeight);
-        return TRUE; // chyba = radsi ohlasime, ze je orizly
+        return TRUE; // Treat as an error—report it as clipped
     }
 
     HFONT hOldFont = (HFONT)SelectObject(hDC, dlgFont);
 
-    // vypocet "dialog box units based on the current font" prevzaty od MS:
+    // Calculation of "dialog box units based on the current font" taken from Microsoft:
     // http://support.microsoft.com/kb/145994
     TEXTMETRIC tm;
     GetTextMetrics(hDC, &tm);
@@ -1639,7 +1639,7 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
     RECT wndRBackup = wndR;
 
     BOOL ret = FALSE;
-    BOOL progressDlgCheckRound = 1; // 1 = Copy + hr+min, 2 = Move + hr+min, 3 = Copy + min+secs, 4 = Move + min+secs, 5 uz neni potreba
+    BOOL progressDlgCheckRound = 1; // 1 = Copy + hr+min, 2 = Move + hr+min, 3 = Copy + min+secs, 4 = Move + min+secs, 5 is no longer needed
     BOOL setBoldFont = FALSE;
     while (1)
     {
@@ -1667,7 +1667,7 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
                                  L"dialog %hs, control %hs",
                            DataRH.GetIdentifier(dialog->ID), DataRH.GetIdentifier(control->ID));
                 OutWindow.AddLine(buff, mteError);
-                ret = TRUE; // chyba = radsi ohlasime, ze je orizly
+                ret = TRUE; // Treat as an error—report it as clipped
                 break;
             }
         }
@@ -1681,7 +1681,7 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
                 swprintf_s(buff, L"IsControlClippedAux(): string ID for progress-dlg-status-check was not found: string ID %hs, dialog %hs, control %hs",
                            DataRH.GetIdentifier(txtID), DataRH.GetIdentifier(dialog->ID), DataRH.GetIdentifier(control->ID));
                 OutWindow.AddLine(buff, mteError);
-                ret = TRUE; // chyba = radsi ohlasime, ze je orizly
+                ret = TRUE; // Treat as an error—report it as clipped
                 break;
             }
             const wchar_t* formatTxt = L"%s%s";
@@ -1707,7 +1707,7 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
                         goto STRING_NOT_FOUND;
                     if (!ValidatePrintfSpecifier(buff, formatTxt))
                         goto STRING_FORMAT_ERROR;
-                    swprintf_s(buff2, buff, 8); // u 9 hodin uz se zaokrouhluje na hodiny (minuty se neukazou)
+                    swprintf_s(buff2, buff, 8); // At 9 hours we round to hours (minutes are not shown)
                     wcscat_s(buff2, L" ");
                 }
                 else
@@ -1718,7 +1718,7 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
                 if (!ValidatePrintfSpecifier(buff, formatTxt))
                     goto STRING_FORMAT_ERROR;
                 swprintf_s(buff2 + wcslen(buff2), _countof(buff2) - wcslen(buff2), buff,
-                           progressDlgCheckRound < 3 ? 59 : 8); // u spojeni s hodinama merime dve cifry, u spojeni se sekundama jen 8 minut (9 minut uz se zaokrouhluje na minuty, sekundy se neukazou, tedy mista dost)
+                           progressDlgCheckRound < 3 ? 59 : 8); // When hours are shown we measure two digits; with seconds we measure only 8 minutes (9 minutes already round to minutes, so seconds are hidden and space is sufficient)
                 if (progressDlgCheckRound >= 3)
                 {
                     wcscat_s(buff2, L" ");
@@ -1746,7 +1746,7 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
                                  L"dialog %hs, control %hs",
                            formatTxt, DataRH.GetIdentifier(dialog->ID), DataRH.GetIdentifier(control->ID));
                 OutWindow.AddLine(buff, mteError);
-                ret = TRUE; // chyba = radsi ohlasime, ze je orizly
+                ret = TRUE; // Treat as an error—report it as clipped
                 break;
             }
             controlText = changedControlText;
@@ -1763,45 +1763,45 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
                 if (dlgFontBold == NULL)
                 {
                     TRACE_E("IsControlClippedAux(): unable to create BOLD dialog font, height: " << fontHeight);
-                    ret = TRUE; // chyba = radsi ohlasime, ze je orizly
+                    ret = TRUE; // Treat as an error—report it as clipped
                     break;
                 }
             }
             SelectObject(hDC, dlgFontBold);
         }
         DrawTextW(hDC, controlText, -1, &txtR, dtFlags);
-        int cxReserveUsed = controlType != ectStatic || control->TCY < 16 ? cxReserve : 0; // viceradkove statiky nebudeme zbytecne zvetsovat
+        int cxReserveUsed = controlType != ectStatic || control->TCY < 16 ? cxReserve : 0; // Do not enlarge multi-line statics unnecessarily
         txtR.right += cxReserveUsed;
         if (controlType == ectPushButton)
         {
             int len = wcslen(controlText);
             bool isAlpha = len > 0 && (IsCharAlphaNumericW(controlText[0] == L'&' && len > 1 ? controlText[1] : controlText[0]) || IsCharAlphaNumericW(controlText[len - 1]));
-            wndR.right -= isAlpha ? buttonMarginsAlphaCX : buttonMarginsSymbolCX; // okraje tlacitka -- nevim jak to programove zjistit, takze hardcoded (Petr: u tlacitek s texty zvetseno z 6 na 12, abysme nasli osklive mala tlacitka)
-            wndR.bottom -= buttonMarginsCY;                                       // okraje tlacitka -- nevim jak to programove zjistit, takze hardcoded
+            wndR.right -= isAlpha ? buttonMarginsAlphaCX : buttonMarginsSymbolCX; // Button margins—no idea how to get them programmatically, so they are hard-coded (Petr: increased from 6 to 12 for text buttons to catch ugly small buttons)
+            wndR.bottom -= buttonMarginsCY;                                       // Button margins—no idea how to get them programmatically, so they are hard-coded
             if (checkLstItem != NULL)
                 wndR.right -= checkLstItem->Type == cltDropDownButton ? buttonDropDownSymbolCX : buttonMoreSymbolCX;
-            // idealSizeXAdd = 6; // okraje tlacitka -- nevim jak to programove zjistit, takze hardcoded
+            // idealSizeXAdd = 6; // Button margins—no idea how to get them programmatically, so they are hard-coded
         }
         if (controlType == ectCheckBox)
         {
-            // Petr: u radiaku bylo potreba 16, tady to ocekavam tez, maximalne budou zbytecne o bod sirsi, no problem
-            wndR.right -= boxWidth;   // checkbox ctverecek
-            idealSizeXAdd = boxWidth; // checkbox ctverecek
+            // Petr: radios needed 16, expect the same here; at worst they end up one unit wider, which is fine
+            wndR.right -= boxWidth;   // Checkbox square
+            idealSizeXAdd = boxWidth; // Checkbox square
         }
         if (controlType == ectRadioButton)
         {
-            // jry: v protech vetvi jsem zjistil, ze pri hodnote 15 jeste prolezly clipnute texty
-            wndR.right -= boxWidth;   // radiobutton kolecko
-            idealSizeXAdd = boxWidth; // radiobutton kolecko
+            // jry: in other branches I found that value 15 still let clipped texts slip through
+            wndR.right -= boxWidth;   // Radio button circle
+            idealSizeXAdd = boxWidth; // Radio button circle
         }
         if (idealSizeX != NULL && idealSizeY != NULL &&
-            !IsEmptyString(controlText) &&                   // controly (mozna jen statiky) s prazdnymi texty nebudeme zmensovat, predpoklada se dynamicke plneni za behu softu
-            controlType != ectPushButton &&                  // zmensovani tlacitek je spis jen na obtiz (predpoklad je: Ctrl+A a S v Layout Editoru, coz ovsem tlacitka rozhodi)
-            controlType != ectGroupBox &&                    // zmensovani groupboxu je spis jen na obtiz (predpoklad je: Ctrl+A a S v Layout Editoru, coz ovsem groupboxy rozhodi)
-            controlType != ectComboBox &&                    // zmensovani comboboxu je spis jen na obtiz (predpoklad je: Ctrl+A a S v Layout Editoru, coz ovsem comboboxy rozhodi)
-            (controlType != ectStatic || control->TCY < 16)) // viceradkove statiky nepodporujeme
+            !IsEmptyString(controlText) &&                   // Controls (likely statics) with empty text are not shrunk—the software is expected to fill them dynamically at runtime
+            controlType != ectPushButton &&                  // Shrinking buttons is more trouble than it is worth (assumption: Ctrl+A and S in the Layout Editor, which would break buttons)
+            controlType != ectGroupBox &&                    // Shrinking group boxes is more trouble than it is worth (assumption: Ctrl+A and S in the Layout Editor, which would break group boxes)
+            controlType != ectComboBox &&                    // Shrinking combo boxes is more trouble than it is worth (assumption: Ctrl+A and S in the Layout Editor, which would break combos)
+            (controlType != ectStatic || control->TCY < 16)) // Multi-line statics are not supported
         {
-            // tady budeme pocitat presne, bez cxReserve, rezervu pridava volajici, tak at nejsou rezervy dve
+            // Perform exact calculations here without cxReserve; the caller adds reserve so we avoid duplicating it
             if (controlType == ectStatic)
                 DrawTextW(hDC, controlText, -1, &txtR2, DT_CALCRECT | DT_LEFT | DT_SINGLELINE | ((control->Style & SS_NOPREFIX) ? DT_NOPREFIX : 0));
             else
@@ -1839,10 +1839,10 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
                 *idealSizeY = curIdealSizeY;
         }
         if (controlType == ectComboBox)
-            wndR.right -= (control->Style & CBS_DROPDOWNLIST) == CBS_DROPDOWNLIST ? comboBoxListMarginsCX : comboBoxMarginsCX; // okraje comboboxu
+            wndR.right -= (control->Style & CBS_DROPDOWNLIST) == CBS_DROPDOWNLIST ? comboBoxListMarginsCX : comboBoxMarginsCX; // Combo-box margins
 
-        // pro static s nulovou sirkou DrawTextW vrati TRUE a zaroven nezvetsi obdelnik
-        // pro prazdny text DrawTextW zvetsi txtR na vysku
+        // For a static with zero width DrawTextW returns TRUE without enlarging the rectangle
+        // For empty text DrawTextW grows txtR vertically
         ret |= txtR.right > wndR.right ||
                txtR.bottom > wndR.bottom && controlText[0] != 0 ||
                wndR.left == wndR.right && controlText[0] != 0;
@@ -1850,8 +1850,8 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
         if (checkLstItem != NULL && checkLstItem->Type == cltProgressDialogStatus)
         {
             if (progressDlgCheckRound >= 4)
-                break;               // 5. kolo neni potreba
-            progressDlgCheckRound++; // jdeme do dalsiho kola
+                break;               // The fifth round is unnecessary
+            progressDlgCheckRound++; // Move on to the next round
         }
         else
             break;
@@ -1866,7 +1866,7 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
     return ret;
 }
 /*
-// Zobrazi mereny text do hlavniho okna -- pro ladeni problemu
+// Show the measured text in the main window—used for debugging issues
     static int iii = 0;
     if (iii == 0)
     {
@@ -1883,56 +1883,56 @@ BOOL IsControlClippedAux(const CDialogData* dialog, const CControl* control, HDC
     }
 */
 
-// rezerva ve smeru osy X, i kdyz v jine situaci text bude o toto cislo delsi (v bodech),
-// jeste nedojde k jeho orezu
+// X-axis reserve; even if the text grows by this many points in another situation,
+// Still does not cause clipping
 #define CX_RESERVE_DPI_100 2
 #define CX_RESERVE_DPI_125 2
 #define CX_RESERVE_DPI_150 3
 #define CX_RESERVE_DPI_200 4
 
-// natvrdo namerene "nutne" X-ove okraje tlacitka s textem
+// Hard-measured required button X margins for text buttons
 #define CX_BUTTON_MARGINS_ALPHA_DPI_100 12
 #define CX_BUTTON_MARGINS_ALPHA_DPI_125 15
 #define CX_BUTTON_MARGINS_ALPHA_DPI_150 18
 #define CX_BUTTON_MARGINS_ALPHA_DPI_200 24
 
-// natvrdo namerene "nutne" X-ove okraje tlacitka se symbolem (napr. "...")
+// Hard-measured required button X margins for symbol buttons (e.g., "...")
 #define CX_BUTTON_MARGINS_SYMBOL_DPI_100 6
 #define CX_BUTTON_MARGINS_SYMBOL_DPI_125 7
 #define CX_BUTTON_MARGINS_SYMBOL_DPI_150 9
 #define CX_BUTTON_MARGINS_SYMBOL_DPI_200 12
 
-// natvrdo namerene "nutne" X-ove rozsireni drop-down tlacitka (aby se vesel symbol "drop-down" vpravo na tlacitko)
+// Hard-measured required drop-down button X extension (to fit the drop-down symbol on the right)
 #define CX_BUTTON_DROP_DOWN_DPI_100 8
 #define CX_BUTTON_DROP_DOWN_DPI_125 10
 #define CX_BUTTON_DROP_DOWN_DPI_150 12
 #define CX_BUTTON_DROP_DOWN_DPI_200 16
 
-// natvrdo namerene "nutne" X-ove rozsireni more tlacitka (aby se vesel symbol "more" vpravo na tlacitko)
+// Hard-measured required More-button X extension (to fit the "more" symbol on the right)
 #define CX_BUTTON_MORE_DPI_100 14
 #define CX_BUTTON_MORE_DPI_125 17
 #define CX_BUTTON_MORE_DPI_150 21
 #define CX_BUTTON_MORE_DPI_200 28
 
-// natvrdo namerene "nutne" Y-ove okraje tlacitka
+// Hard-measured required button Y margins
 #define CY_BUTTON_MARGINS_DPI_100 4
 #define CY_BUTTON_MARGINS_DPI_125 6
 #define CY_BUTTON_MARGINS_DPI_150 7
 #define CY_BUTTON_MARGINS_DPI_200 11
 
-// natvrdo namerena sirka boxu u radioboxu a checkboxu
+// Hard-measured required width of radio/checkbox boxes
 #define CX_BOX_WIDTH_DPI_100 16
 #define CX_BOX_WIDTH_DPI_125 20
 #define CX_BOX_WIDTH_DPI_150 25
 #define CX_BOX_WIDTH_DPI_200 27
 
-// natvrdo namerene "nutne" X-ove okraje combo boxu, ve kterem se da editovat (editline + drop down list)
+// Hard-measured required combo-box X margins for editable combos (edit line + drop-down list)
 #define CX_COMBOBOX_MARGINS_DPI_100 25
 #define CX_COMBOBOX_MARGINS_DPI_125 30
 #define CX_COMBOBOX_MARGINS_DPI_150 36
 #define CX_COMBOBOX_MARGINS_DPI_200 46
 
-// natvrdo namerene "nutne" X-ove okraje combo boxu, ve kterem se neda editovat (static + drop down list)
+// Hard-measured required combo-box X margins for non-editable combos (static + drop-down list)
 #define CX_COMBOBOX_LIST_MARGINS_DPI_100 24
 #define CX_COMBOBOX_LIST_MARGINS_DPI_125 28
 #define CX_COMBOBOX_LIST_MARGINS_DPI_150 33
@@ -1943,13 +1943,13 @@ BOOL IsControlClipped(const CDialogData* dialog, const CControl* control, HWND h
                       CCheckLstItem* checkLstItem)
 {
     if (idealSizeX != NULL)
-        *idealSizeX = -1; // pokud idealni velikost nevime, vratime -1
+        *idealSizeX = -1; // If we do not know the ideal size, return -1
     if (idealSizeY != NULL)
-        *idealSizeY = -1; // pokud idealni velikost nevime, vratime -1
+        *idealSizeY = -1; // If we do not know the ideal size, return -1
     HWND hControl = GetDlgItem(hDlg, control->ID);
 
-    // control->TWindowName je zakodovany pomoci __GetCharacterString
-    // pouzijeme primo text vytazeny z controlu
+    // control->TWindowName is encoded via __GetCharacterString
+    // Use the text extracted directly from the control
     wchar_t controlText[100000];
     GetWindowTextW(hControl, controlText, 100000);
     controlText[99999] = 0;
@@ -2050,10 +2050,10 @@ BOOL IsControlClipped(const CDialogData* dialog, const CControl* control, HWND h
                 continue;
         }
 
-        // na Win7 jsem zjistil, ze velikosti symbolu (napr. radio/check box) se meni
-        // jen pro 100%, 125%, 150% a 200% DPI, mezilehla DPI pouzivaji vzdy symboly
-        // z nizsiho "celeho" DPI, pro ne omerime vsechny mezilehle velikosti fontu,
-        // tim bysme meli postihnout vsechna mozna DPI
+        // On Win7 I noticed symbol sizes (e.g., radio/check boxes) change
+        // Only for 100%, 125%, 150%, and 200% DPI; intermediate DPIs reuse symbols from the lower whole DPI
+        // For lower "whole" DPIs we measure all intermediate font sizes for them,
+        // That should cover every possible DPI
         for (int i = 0; i < 2; i++)
             ret |= IsControlClippedAux(dialog, control, hDC, &lf, -11 - i, controlType, controlText,
                                        multiTextIsBold, checkLstItem, idealSizeX, idealSizeY, CX_RESERVE_DPI_100,
@@ -2061,7 +2061,7 @@ BOOL IsControlClipped(const CDialogData* dialog, const CControl* control, HWND h
                                        CX_BUTTON_DROP_DOWN_DPI_100, CX_BUTTON_MORE_DPI_100,
                                        CY_BUTTON_MARGINS_DPI_100, CX_BOX_WIDTH_DPI_100,
                                        CX_COMBOBOX_MARGINS_DPI_100, CX_COMBOBOX_LIST_MARGINS_DPI_100);
-        // if (ret) break; // kvuli size-to-content prochazime vsechny varianty, aby se omerila maximalni sire multi-textu
+        // if (ret) break; // Because of size-to-content we traverse all variants to measure the maximum multi-text width
         for (int i = 0; i < 3; i++)
             ret |= IsControlClippedAux(dialog, control, hDC, &lf, -13 - i, controlType, controlText,
                                        multiTextIsBold, checkLstItem, idealSizeX, idealSizeY, CX_RESERVE_DPI_125,
@@ -2069,7 +2069,7 @@ BOOL IsControlClipped(const CDialogData* dialog, const CControl* control, HWND h
                                        CX_BUTTON_DROP_DOWN_DPI_125, CX_BUTTON_MORE_DPI_125,
                                        CY_BUTTON_MARGINS_DPI_125, CX_BOX_WIDTH_DPI_125,
                                        CX_COMBOBOX_MARGINS_DPI_125, CX_COMBOBOX_LIST_MARGINS_DPI_125);
-        // if (ret) break; // kvuli size-to-content prochazime vsechny varianty, aby se omerila maximalni sire multi-textu
+        // if (ret) break; // Because of size-to-content we traverse all variants to measure the maximum multi-text width
         for (int i = 0; i < 5; i++)
             ret |= IsControlClippedAux(dialog, control, hDC, &lf, -16 - i, controlType, controlText,
                                        multiTextIsBold, checkLstItem, idealSizeX, idealSizeY, CX_RESERVE_DPI_150,
@@ -2077,14 +2077,14 @@ BOOL IsControlClipped(const CDialogData* dialog, const CControl* control, HWND h
                                        CX_BUTTON_DROP_DOWN_DPI_150, CX_BUTTON_MORE_DPI_150,
                                        CY_BUTTON_MARGINS_DPI_150, CX_BOX_WIDTH_DPI_150,
                                        CX_COMBOBOX_MARGINS_DPI_150, CX_COMBOBOX_LIST_MARGINS_DPI_150);
-        // if (ret) break; // kvuli size-to-content prochazime vsechny varianty, aby se omerila maximalni sire multi-textu
+        // if (ret) break; // Because of size-to-content we traverse all variants to measure the maximum multi-text width
         ret |= IsControlClippedAux(dialog, control, hDC, &lf, -21, controlType, controlText,
                                    multiTextIsBold, checkLstItem, idealSizeX, idealSizeY, CX_RESERVE_DPI_200,
                                    CX_BUTTON_MARGINS_ALPHA_DPI_200, CX_BUTTON_MARGINS_SYMBOL_DPI_200,
                                    CX_BUTTON_DROP_DOWN_DPI_200, CX_BUTTON_MORE_DPI_200,
                                    CY_BUTTON_MARGINS_DPI_200, CX_BOX_WIDTH_DPI_200,
                                    CX_COMBOBOX_MARGINS_DPI_200, CX_COMBOBOX_LIST_MARGINS_DPI_200);
-        // if (ret) break; // kvuli size-to-content prochazime vsechny varianty, aby se omerila maximalni sire multi-textu
+        // if (ret) break; // Because of size-to-content we traverse all variants to measure the maximum multi-text width
     }
 
     HANDLES(ReleaseDC(hControl, hDC));
@@ -2108,7 +2108,7 @@ void CData::MarkChangedTextsAsTranslated()
     swprintf_s(buff, L"Searching for changed texts marked as Untranslated to mark them as Translated...");
     OutWindow.AddLine(buff, mteInfo);
 
-    // prohledame dialogy
+    // Scan dialogs
     for (i = 0; i < DlgData.Count; i++)
     {
         CDialogData* dialog = DlgData[i];
@@ -2127,7 +2127,7 @@ void CData::MarkChangedTextsAsTranslated()
         }
     }
 
-    // prohledame strings
+    // Scan strings
     for (i = 0; i < StrData.Count; i++)
     {
         CStrData* strData = StrData[i];
@@ -2147,7 +2147,7 @@ void CData::MarkChangedTextsAsTranslated()
         }
     }
 
-    // prohledame windows MENU
+    // Scan Windows menus
     for (i = 0; i < MenuData.Count; i++)
     {
         CMenuData* menu = MenuData[i];
@@ -2169,13 +2169,13 @@ void CData::MarkChangedTextsAsTranslated()
     // display outro
     swprintf_s(buff, L"%d text(s) have been marked as Translated.", changes);
     OutWindow.AddLine(buff, mteSummary);
-    PostMessage(FrameWindow.HWindow, WM_FOCLASTINOUTPUTWND, 0, 0); // Output okno jeste nemusi existovat
+    PostMessage(FrameWindow.HWindow, WM_FOCLASTINOUTPUTWND, 0, 0); // The Output window might not exist yet
 
     if (changes > 0)
     {
         Data.SetDirty();
-        Data.UpdateAllNodes(); // nastavime translated stavy na treeview
-        Data.UpdateTexts();    // update list view v okne Texts
+        Data.UpdateAllNodes(); // Update translated states in the tree view
+        Data.UpdateTexts();    // Update the list view in the Texts window
     }
 
     OutWindow.EnablePaint(TRUE);
@@ -2198,7 +2198,7 @@ void CData::ResetDialogsLayoutsToOriginal()
     swprintf_s(buff, L"Changing all dialogs to original layout...");
     OutWindow.AddLine(buff, mteInfo);
 
-    // prohledame dialogy
+    // Scan dialogs
     for (i = 0; i < DlgData.Count; i++)
     {
         CDialogData* dialog = DlgData[i];
@@ -2219,11 +2219,11 @@ void CData::ResetDialogsLayoutsToOriginal()
     // display outro
     swprintf_s(buff, L"DONE");
     OutWindow.AddLine(buff, mteSummary);
-    PostMessage(FrameWindow.HWindow, WM_FOCLASTINOUTPUTWND, 0, 0); // Output okno jeste nemusi existovat
+    PostMessage(FrameWindow.HWindow, WM_FOCLASTINOUTPUTWND, 0, 0); // The Output window might not exist yet
 
     Data.SetDirty();
-    Data.UpdateAllNodes(); // nastavime translated stavy na treeview
-    Data.UpdateTexts();    // update list view v okne Texts
+    Data.UpdateAllNodes(); // Update translated states in the tree view
+    Data.UpdateTexts();    // Update the list view in the Texts window
 
     OutWindow.EnablePaint(TRUE);
 
@@ -2253,7 +2253,7 @@ BOOL CData::GetItemFromCheckLst(WORD dialogID, WORD controlID, CCheckLstItem** m
                     *multiTextOrComboItem = item;
                 }
             }
-            else // tyto "ostatni" testy se resi jen uvnitr IsControlClippedAux (nejde o seznam textu, ktere se maji postupne omerit)
+            else // These "other" tests are handled only inside IsControlClippedAux (it is not a list of texts to measure sequentially)
             {
                 if (checkLstItem != NULL)
                 {
@@ -2301,12 +2301,12 @@ void CData::ValidateTranslation(HWND hParent)
 
         CKeyConflict conflict;
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
 
-            CCheckLstItem* multiTextOrComboItem; // zkusime, jestli vubec k dialogu nejakou mame
+            CCheckLstItem* multiTextOrComboItem; // Check whether we even have one assigned to the dialog
             BOOL findMultiTextOrComboItems = GetItemFromCheckLst(dialog->ID, 0, &multiTextOrComboItem, NULL, TRUE);
 
             lvIndex = 0;
@@ -2326,7 +2326,7 @@ void CData::ValidateTranslation(HWND hParent)
                 if (multiTextOrComboItem == NULL || control->TWindowName != NULL && control->TWindowName[0] != 0)
                     conflict.AddString(control->TWindowName, j, showInLV ? lvIndex : 0, showInLV ? 0 : control->ID);
                 else
-                { // prozatim udelame kontrolu aspon prvniho textu (pokud control nema svuj vlastni text primo v dialogu)
+                { // For now check at least the first text (if the control has no text directly in the dialog)
                     if (!Data.GetStringWithID(multiTextOrComboItem->IDList[0], buff, _countof(buff)))
                     {
                         swprintf_s(buff, L"ValidateTranslation(): string ID for multi-text control was not found, string ID %hs, dialog %hs, control %hs",
@@ -2356,7 +2356,7 @@ void CData::ValidateTranslation(HWND hParent)
                 if (multiTextOrComboItem == NULL || control->TWindowName != NULL && control->TWindowName[0] != 0)
                     conflict.GetAvailableKeys(control->TWindowName, availableKeys, 100);
                 else
-                { // vytahneme kontrolovany prvni text (pokud control nema svuj vlastni text primo v dialogu)
+                { // Pull the first text to validate (if the control has no text directly in the dialog)
                     if (Data.GetStringWithID(multiTextOrComboItem->IDList[0], buff2, _countof(buff2)) && buff2[0] != 0)
                     {
                         conflict.GetAvailableKeys(buff2, availableKeys, 100);
@@ -2383,7 +2383,7 @@ void CData::ValidateTranslation(HWND hParent)
 
         CKeyConflict conflict;
 
-        // prohledame SalMenu
+        // Scan SalMenu
         for (i = 0; i < SalMenuSections.Count; i++)
         {
             CMenuPreview* menuPreview = new CMenuPreview();
@@ -2392,7 +2392,7 @@ void CData::ValidateTranslation(HWND hParent)
 
             if (section->SectionControlDialogID != 0)
             {
-                // k sekci je pripojen control z dialogu, budeme kontrolovat konflikty vuci nemu
+                // The section is linked to a dialog control; check conflicts against it
                 BOOL found = FALSE;
                 for (int dlgIndex = 0; dlgIndex < DlgData.Count; dlgIndex++)
                 {
@@ -2419,7 +2419,7 @@ void CData::ValidateTranslation(HWND hParent)
                             swprintf_s(buff, L"Control <%d> not found in dialog %hs!", section->SectionControlControlID,
                                        DataRH.GetIdentifier(dialog->ID));
                             OutWindow.AddLine(buff, mteError, rteDialog, dialog->ID);
-                            found = TRUE; // dalsi chybu uz neukazeme
+                            found = TRUE; // Do not show the same error again
                         }
                         break;
                     }
@@ -2454,7 +2454,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
             if (section->SectionDialogID != 0)
             {
-                // k sekci je pripojen dialog, budeme kontrolovat konflikty vuci dialogu
+                // The section is linked to a dialog; check conflicts against the dialog
                 CDialogData* dialog = NULL;
                 for (int dlgIndex = 0; dlgIndex < DlgData.Count; dlgIndex++)
                 {
@@ -2471,7 +2471,7 @@ void CData::ValidateTranslation(HWND hParent)
                 }
                 else
                 {
-                    CCheckLstItem* multiTextOrComboItem; // zkusime, jestli vubec k dialogu nejakou mame
+                    CCheckLstItem* multiTextOrComboItem; // Check whether we even have one assigned to the dialog
                     BOOL findMultiTextOrComboItems = GetItemFromCheckLst(dialog->ID, 0, &multiTextOrComboItem, NULL, TRUE);
 
                     lvIndex = 0;
@@ -2494,7 +2494,7 @@ void CData::ValidateTranslation(HWND hParent)
                             menuPreview->AddText(control->TWindowName);
                         }
                         else
-                        { // prozatim udelame kontrolu aspon prvniho textu (pokud control nema svuj vlastni text primo v dialogu)
+                        { // For now check at least the first text (if the control has no text directly in the dialog)
                             if (!Data.GetStringWithID(multiTextOrComboItem->IDList[0], buff, _countof(buff)))
                             {
                                 swprintf_s(buff, L"ValidateTranslation(): string ID for multi-text control was not found, string ID %hs, dialog %hs, control %hs",
@@ -2554,7 +2554,7 @@ void CData::ValidateTranslation(HWND hParent)
                         if (multiTextOrComboItem == NULL || control->TWindowName != NULL && control->TWindowName[0] != 0)
                             conflict.GetAvailableKeys(control->TWindowName, availableKeys, 100);
                         else
-                        { // vytahneme kontrolovany prvni text (pokud control nema svuj vlastni text primo v dialogu)
+                        { // Pull the first text to validate (if the control has no text directly in the dialog)
                             if (Data.GetStringWithID(multiTextOrComboItem->IDList[0], buff2, _countof(buff2)) && buff2[0] != 0)
                             {
                                 conflict.GetAvailableKeys(buff2, availableKeys, 100);
@@ -2592,7 +2592,7 @@ void CData::ValidateTranslation(HWND hParent)
                 delete menuPreview;
         }
 
-        // prohledame windows MENU
+        // Scan Windows menus
         for (i = 0; i < MenuData.Count; i++)
         {
             CMenuData* menu = MenuData[i];
@@ -2646,7 +2646,7 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for inconsistent format specifier...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
@@ -2667,7 +2667,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
         }
 
-        // prohledame strings
+        // Scan strings
         for (i = 0; i < StrData.Count; i++)
         {
             CStrData* strData = StrData[i];
@@ -2691,7 +2691,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
         }
 
-        // prohledame windows MENU
+        // Scan Windows menus
         for (i = 0; i < MenuData.Count; i++)
         {
             CMenuData* menu = MenuData[i];
@@ -2718,7 +2718,7 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for inconsistent control characters...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
@@ -2738,7 +2738,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
         }
 
-        // prohledame strings
+        // Scan strings
         for (i = 0; i < StrData.Count; i++)
         {
             CStrData* strData = StrData[i];
@@ -2762,7 +2762,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
         }
 
-        // prohledame windows MENU
+        // Scan Windows menus
         for (i = 0; i < MenuData.Count; i++)
         {
             CMenuData* menu = MenuData[i];
@@ -2789,7 +2789,7 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for inconsistent strings with CSV...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame strings
+        // Scan strings
         for (i = 0; i < StrData.Count; i++)
         {
             CStrData* strData = StrData[i];
@@ -2820,7 +2820,7 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for inconsistent plural strings...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
@@ -2840,7 +2840,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
         }
 
-        // prohledame strings
+        // Scan strings
         for (i = 0; i < StrData.Count; i++)
         {
             CStrData* strData = StrData[i];
@@ -2863,7 +2863,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
         }
 
-        // prohledame windows MENU
+        // Scan Windows menus
         for (i = 0; i < MenuData.Count; i++)
         {
             CMenuData* menu = MenuData[i];
@@ -2890,7 +2890,7 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for inconsistent text beginnings and endings...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
@@ -2922,7 +2922,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
         }
 
-        // prohledame strings
+        // Scan strings
         for (i = 0; i < StrData.Count; i++)
         {
             CStrData* strData = StrData[i];
@@ -2948,7 +2948,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
         }
 
-        // prohledame windows MENU
+        // Scan Windows menus
         for (i = 0; i < MenuData.Count; i++)
         {
             CMenuData* menu = MenuData[i];
@@ -2976,7 +2976,7 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for inconsistent hot keys...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
@@ -2987,7 +2987,7 @@ void CData::ValidateTranslation(HWND hParent)
                 if (!control->ShowInLVWithControls(j))
                     continue;
 
-                if (j != 0 && // nulty control je nazev dialogu a v nem hotkeys nejsou, neni co kontrolovat
+                if (j != 0 && // Control 0 is the dialog name and has no hotkeys to check
                     !ValidateHotKeys(control->OWindowName, control->TWindowName))
                 {
                     swprintf_s(buff, L"Dialog %hs: %ls", DataRH.GetIdentifier(dialog->ID), control->TWindowName);
@@ -2997,7 +2997,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
         }
 
-        // prohledame strings
+        // Scan strings
         for (i = 0; i < StrData.Count; i++)
         {
             CStrData* strData = StrData[i];
@@ -3021,7 +3021,7 @@ void CData::ValidateTranslation(HWND hParent)
             }
         }
 
-        // prohledame windows MENU
+        // Scan Windows menus
         for (i = 0; i < MenuData.Count; i++)
         {
             CMenuData* menu = MenuData[i];
@@ -3048,27 +3048,27 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching dialogs for overlapping controls...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
             lvIndex = 1;
-            if (dialog->Controls.Count > 0 && (dialog->Controls[0]->OWindowName == NULL || dialog->Controls[0]->OWindowName[0] == 0)) // prazdny nazev dialogu
+            if (dialog->Controls.Count > 0 && (dialog->Controls[0]->OWindowName == NULL || dialog->Controls[0]->OWindowName[0] == 0)) // Empty dialog title
                 lvIndex = 0;
-            for (j = 1; j < dialog->Controls.Count; j++) // 0 je nazev dialogu, zacneme tedy od 1
+            for (j = 1; j < dialog->Controls.Count; j++) // 0 is the dialog title, so start from 1
             {
                 CControl* control = dialog->Controls[j];
                 if (!control->ShowInLVWithControls(j))
                     continue;
 
-                if (ShouldValidateLayoutFor(control)) // jde o control ktery mame validovat (groupboxy ignorujeme)
+                if (ShouldValidateLayoutFor(control)) // Control we are supposed to validate (ignore group boxes)
                 {
                     BOOL isCheckOrRadioBox = control->IsRadioOrCheckBox();
                     for (int k = 1; k < dialog->Controls.Count; k++)
                     {
                         CControl* control2 = dialog->Controls[k];
-                        if (k > j ||                                     // bereme vsechny controly za 'j'
-                            k < j && !control2->ShowInLVWithControls(k)) // pred 'j' jen pokud uz jsme je netestovali (vypadly z testu protoze se neprekladaji, napr. ikony)
+                        if (k > j ||                                     // Take all controls after 'j'
+                            k < j && !control2->ShowInLVWithControls(k)) // Before 'j' only if we have not tested them yet (skipped because they are not translated, e.g., icons)
                         {
                             BOOL shouldValidate = ShouldValidateLayoutFor(control2);
                             if ((shouldValidate && DoesControlsOverlap(dialog->ID, control, control2) ||
@@ -3100,15 +3100,15 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching dialogs for clipped texts...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
 
-            // budeme omerovat nad realnym dialogem, takze potrebujeme jeho template
+            // We will measure the real dialog, so we need its template
             WORD dialogTemplate[200000];
             DWORD dialogTemplateSize = dialog->PrepareTemplate(dialogTemplate, FALSE, TRUE, FALSE);
-            // dialog nechceme nechat zobrazit
+            // Do not let the dialog be displayed
             dialog->TemplateAddRemoveStyles(dialogTemplate, 0, WS_VISIBLE);
 
             HWND hDlg = CreateDialogIndirectW(HInstance, (LPDLGTEMPLATE)dialogTemplate, hParent, NULL);
@@ -3120,7 +3120,7 @@ void CData::ValidateTranslation(HWND hParent)
                 continue;
             }
 
-            CCheckLstItem *multiTextOrComboItem, *checkLstItem; // zkusime, jestli vubec k dialogu nejakou mame
+            CCheckLstItem *multiTextOrComboItem, *checkLstItem; // Check whether we even have one assigned to the dialog
             BOOL findMulTextAndDropDownItems = GetItemFromCheckLst(dialog->ID, 0, &multiTextOrComboItem, &checkLstItem, TRUE);
 
             lvIndex = 0;
@@ -3142,7 +3142,7 @@ void CData::ValidateTranslation(HWND hParent)
                      checkLstItem != NULL && checkLstItem->Type == cltProgressDialogStatus ||
                      control->TWindowName[0] != 0) &&
                     IsControlClipped(dialog, control, hDlg, NULL, NULL, multiTextOrComboItem, checkLstItem) &&
-                    !IgnoreProblem(iltClip, dialog->ID, control->ID, 0 /* nepouziva se */))
+                    !IgnoreProblem(iltClip, dialog->ID, control->ID, 0 /* not used */))
                 {
                     swprintf_s(buff, L"Dialog %hs: %hs (%ls)", DataRH.GetIdentifier(dialog->ID),
                                DataRH.GetIdentifier(control->ID),
@@ -3165,14 +3165,14 @@ void CData::ValidateTranslation(HWND hParent)
 
 #define CONTROL_TO_DIALOG_MIN_V_SPACING 4    // (vertical) dlg units
 #define CONTROL_TO_DIALOG_MIN_H_SPACING 5    // (horizontal) dlg units
-#define CONTROL_TO_DIALOG_MIN_H_SPACING_RT 3 // (horizontal pro vpravo zarovnane texty) dlg units
+#define CONTROL_TO_DIALOG_MIN_H_SPACING_RT 3 // (horizontal for right-aligned texts) dlg units
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
 
-            for (j = 1; j < dialog->Controls.Count; j++) // 0 je nazev dialogu, zacneme tedy od 1
+            for (j = 1; j < dialog->Controls.Count; j++) // 0 is the dialog title, so start from 1
             {
                 CControl* control = dialog->Controls[j];
 
@@ -3180,16 +3180,16 @@ void CData::ValidateTranslation(HWND hParent)
                 int minHSpacing = 0;
                 if (!Data.IgnoreTooCloseToDlgFrame(dialog->ID, control->ID))
                 {
-                    if ((dialog->Style & (DS_CONTROL | WS_CHILD)) == 0 && // vlozene dialogy at maji controly klidne az ke kraji
-                        control->TCY > 1 && control->TCX > 1)             // vodorovne a svisle cary muzou byt az k okraji dialogu
+                    if ((dialog->Style & (DS_CONTROL | WS_CHILD)) == 0 && // Allow embedded dialogs to have controls right at the edge
+                        control->TCY > 1 && control->TCX > 1)             // Horizontal and vertical lines may extend to the dialog edges
                     {
                         minVSpacing = CONTROL_TO_DIALOG_MIN_V_SPACING;
                         minHSpacing = CONTROL_TO_DIALOG_MIN_H_SPACING;
                     }
 
                     if ((DWORD)control->ClassName == 0x0082ffff &&    // STATIC
-                        (control->Style & SS_TYPEMASK) == SS_RIGHT && // pravy text - muze jit vic k okraji (leva strana se vetsinou nepouziva)
-                        control->TCY > 1 && control->TCX > 1)         // vodorovne a svisle cary muzou byt az k okraji dialogu
+                        (control->Style & SS_TYPEMASK) == SS_RIGHT && // Right-aligned text may go closer to the edge (the left side is rarely used)
+                        control->TCY > 1 && control->TCX > 1)         // Horizontal and vertical lines may extend to the dialog edges
                     {
                         minHSpacing = CONTROL_TO_DIALOG_MIN_H_SPACING_RT;
                     }
@@ -3199,7 +3199,7 @@ void CData::ValidateTranslation(HWND hParent)
                 int y = control->TY;
                 int cx = control->TCX;
                 int cy = control->TCY;
-                if (control->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+                if (control->IsComboBox()) // For combo boxes we want their "collapsed" size
                     cy = COMBOBOX_BASE_HEIGHT;
                 if (control->IsIcon() && Data.IgnoreIconSizeIconIsSmall(dialog->ID, control->ID))
                     cx = cy = 10;
@@ -3207,7 +3207,7 @@ void CData::ValidateTranslation(HWND hParent)
                 if (x < minHSpacing || dialog->TCX - (x + cx) < minHSpacing ||
                     y < minVSpacing || dialog->TCY - (y + cy) < minVSpacing)
                 {
-                    if (x + cx > 0 && x < dialog->TCX && // controly cele mimo dialog neresime
+                    if (x + cx > 0 && x < dialog->TCX && // Ignore controls that are completely outside the dialog
                         y + cy > 0 && y < dialog->TCY)
                     {
                         swprintf_s(buff, L"Dialog %hs: %hs", DataRH.GetIdentifier(dialog->ID),
@@ -3229,12 +3229,12 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for slightly misaligned controls...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
 
-            for (j = 1; j < dialog->Controls.Count; j++) // 0 je nazev dialogu, zacneme tedy od 1
+            for (j = 1; j < dialog->Controls.Count; j++) // 0 is the dialog title, so start from 1
             {
                 CControl* control = dialog->Controls[j];
 
@@ -3256,9 +3256,9 @@ void CData::ValidateTranslation(HWND hParent)
                         int y2 = control2->TY;
                         int cx2 = control2->TCX;
                         int cy2 = control2->TCY;
-                        if (control->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+                        if (control->IsComboBox()) // For combo boxes we want their "collapsed" size
                             cy1 = COMBOBOX_BASE_HEIGHT;
-                        if (control2->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+                        if (control2->IsComboBox()) // For combo boxes we want their "collapsed" size
                             cy2 = COMBOBOX_BASE_HEIGHT;
                         if (control->IsIcon() && Data.IgnoreIconSizeIconIsSmall(dialog->ID, control->ID))
                             cx1 = cy1 = 10;
@@ -3298,12 +3298,12 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for slightly different sized controls...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
 
-            for (j = 1; j < dialog->Controls.Count; j++) // 0 je nazev dialogu, zacneme tedy od 1
+            for (j = 1; j < dialog->Controls.Count; j++) // 0 is the dialog title, so start from 1
             {
                 CControl* control = dialog->Controls[j];
 
@@ -3318,9 +3318,9 @@ void CData::ValidateTranslation(HWND hParent)
                         int cy1 = control->TCY;
                         int cx2 = control2->TCX;
                         int cy2 = control2->TCY;
-                        if (control->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+                        if (control->IsComboBox()) // For combo boxes we want their "collapsed" size
                             cy1 = COMBOBOX_BASE_HEIGHT;
-                        if (control2->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+                        if (control2->IsComboBox()) // For combo boxes we want their "collapsed" size
                             cy2 = COMBOBOX_BASE_HEIGHT;
                         if (control->IsIcon() && Data.IgnoreIconSizeIconIsSmall(dialog->ID, control->ID))
                             cx1 = cy1 = 10;
@@ -3354,12 +3354,12 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for slightly different spacing between controls...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
 
-            for (j = 1; j < dialog->Controls.Count; j++) // 0 je nazev dialogu, zacneme tedy od 1
+            for (j = 1; j < dialog->Controls.Count; j++) // 0 is the dialog title, so start from 1
             {
                 CControl* control = dialog->Controls[j];
                 if (!Data.IgnoreDifferentSpacing(dialog->ID, control->ID) &&
@@ -3380,12 +3380,12 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for controls with nonstandard size...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
 
-            for (j = 1; j < dialog->Controls.Count; j++) // 0 je nazev dialogu, zacneme tedy od 1
+            for (j = 1; j < dialog->Controls.Count; j++) // 0 is the dialog title, so start from 1
             {
                 CControl* control = dialog->Controls[j];
                 if (!Data.IgnoreNotStdSize(dialog->ID, control->ID) &&
@@ -3406,12 +3406,12 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching for labels placed incorrectly to associated controls...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
 
-            for (j = 1; j < dialog->Controls.Count; j++) // 0 je nazev dialogu, zacneme tedy od 1
+            for (j = 1; j < dialog->Controls.Count; j++) // 0 is the dialog title, so start from 1
             {
                 CControl* control = dialog->Controls[j];
                 int foundIndex;
@@ -3444,7 +3444,7 @@ void CData::ValidateTranslation(HWND hParent)
             CCheckLstItem* check = Data.CheckLstItems[j];
             if (check->Type == cltPropPgSameSize)
             {
-                // prohledame dialogy
+                // Scan dialogs
                 int maxCX = 0;
                 int maxCY = 0;
                 for (i = 0; i < DlgData.Count; i++)
@@ -3478,7 +3478,7 @@ void CData::ValidateTranslation(HWND hParent)
         OutWindow.AddLine(buff, mteInfo);
 
         //TRACE_E("TODO: ValidateHButtonSpacing");
-        // prohledame dialogy
+        // Scan dialogs
         //for (i = 0; i < DlgData.Count; i++)
         //{
         //  CDialogData *dialog = DlgData[i];
@@ -3493,12 +3493,12 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"Searching dialog boxes for ID conflicts...");
         OutWindow.AddLine(buff, mteInfo);
 
-        // prohledame dialogy
+        // Scan dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
 
-            for (j = 1; j < dialog->Controls.Count; j++) // 0 je nazev dialogu, zacneme tedy od 1
+            for (j = 1; j < dialog->Controls.Count; j++) // 0 is the dialog title, so start from 1
             {
                 CControl* control = dialog->Controls[j];
                 if (!control->ShowInLVWithControls(j))
@@ -3532,7 +3532,7 @@ void CData::ValidateTranslation(HWND hParent)
         }
     }
 
-    // najdeme IDcka bez textovych identifikatoru (detekce chybejicich symbolu v .inc souboru)
+    // Find IDs without text identifiers (detect missing symbols in the .inc file)
     OutWindow.AddLine(L"Searching for unknown identifiers...", mteInfo);
     CheckIdentifiers(TRUE);
 
@@ -3555,9 +3555,9 @@ void CData::ValidateTranslation(HWND hParent)
         swprintf_s(buff, L"%d problem(s) have been found.", count);
     OutWindow.AddLine(buff, mteSummary);
     if (count == 0)
-        PostMessage(FrameWindow.HWindow, WM_FOCLASTINOUTPUTWND, 0, 0); // Output okno jeste nemusi existovat
+        PostMessage(FrameWindow.HWindow, WM_FOCLASTINOUTPUTWND, 0, 0); // The Output window might not exist yet
     else
-        PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_WND_OUTPUT, 0); // aktivace Output okna
+        PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_WND_OUTPUT, 0); // Activate the Output window
 
     OutWindow.EnablePaint(TRUE);
 
@@ -3577,7 +3577,7 @@ void CData::LookForIdConflicts()
     wchar_t buff[1000];
     OutWindow.EnablePaint(FALSE);
 
-    // prohledame dialogy
+    // Scan dialogs
     for (int i = 0; i < DlgData.Count; i++)
     {
         TDirectArray<DWORD> ids(20, 10);
@@ -3590,7 +3590,7 @@ void CData::LookForIdConflicts()
             if (!control->ShowInLVWithControls(j))
                 continue;
 
-            if (j > 0) // j==0 znamena jmeno a ID dialogu
+            if (j > 0) // j == 0 means the dialog name and ID
             {
                 BOOL displayed = FALSE;
                 for (int k = 0; k < ids.Count; k++)

--- a/src/translator/datacnfl.cpp
+++ b/src/translator/datacnfl.cpp
@@ -484,7 +484,7 @@ const wchar_t* FindPluralStrParEnd(const wchar_t* s, BOOL* error, BOOL calcNumOf
                 {
                     OutWindow.AddLine(L"Plural string contains interval bound which is not a decimal number.", mteError);
                     *error = TRUE;
-                      return s; // error, only a decimal number is expected here
+                    return s; // error, only a decimal number is expected here
                 }
                 s++;
             }

--- a/src/translator/datadlg.cpp
+++ b/src/translator/datadlg.cpp
@@ -162,7 +162,7 @@ void CControl::LoadFrom(CControl* src)
 
 BOOL IsStyleStaticText(DWORD style, BOOL onlyLeft, BOOL onlyRight)
 {
-    return (!onlyRight && (style & SS_TYPEMASK) == SS_LEFT || // neni ikona, frame, atd.
+    return (!onlyRight && (style & SS_TYPEMASK) == SS_LEFT || // not an icon, frame, etc.
             !onlyLeft && !onlyRight && (style & SS_TYPEMASK) == SS_CENTER ||
             !onlyLeft && (style & SS_TYPEMASK) == SS_RIGHT ||
             !onlyRight && (style & SS_TYPEMASK) == SS_SIMPLE ||
@@ -171,21 +171,21 @@ BOOL IsStyleStaticText(DWORD style, BOOL onlyLeft, BOOL onlyRight)
 
 BOOL CControl::IsStaticText(BOOL onlyLeft, BOOL onlyRight) const
 {
-    return ClassName == (wchar_t*)0x0082FFFF &&             // je static
-           IsStyleStaticText(Style, onlyLeft, onlyRight) && // neni ikona, frame, atd.
-           OCY > 1;                                         // eliminace horizontalnich car (jsou vedene jako textove statiky), do nich se texty nepisou
+    return ClassName == (wchar_t*)0x0082FFFF &&             // is a static control
+           IsStyleStaticText(Style, onlyLeft, onlyRight) && // not an icon, frame, etc.
+           OCY > 1;                                         // eliminate horizontal lines (they are handled as text statics); no text is written into them
 }
 
 BOOL CControl::IsIcon() const
 {
-    return ClassName == (wchar_t*)0x0082FFFF && // je static
-           (Style & SS_TYPEMASK) == SS_ICON;    // je ikona
+    return ClassName == (wchar_t*)0x0082FFFF && // is a static control
+           (Style & SS_TYPEMASK) == SS_ICON;    // is an icon
 }
 
 BOOL CControl::IsWhiteFrame() const
 {
-    return ClassName == (wchar_t*)0x0082FFFF &&    // je static
-           (Style & SS_TYPEMASK) == SS_WHITEFRAME; // je white-frame
+    return ClassName == (wchar_t*)0x0082FFFF &&    // is a static control
+           (Style & SS_TYPEMASK) == SS_WHITEFRAME; // is a white frame
 }
 
 BOOL CControl::IsComboBox() const
@@ -206,7 +206,7 @@ BOOL CControl::IsGroupBox() const
 
 BOOL CControl::IsHorizLine() const
 {
-    return ClassName == (wchar_t*)0x0082FFFF &&    // je static
+    return ClassName == (wchar_t*)0x0082FFFF &&    // is a static control
            (Style & SS_TYPEMASK) == SS_ETCHEDHORZ; // etched-horizontal
 }
 
@@ -216,19 +216,19 @@ BOOL IsCheckBox(int bt);
 
 BOOL CControl::IsRadioOrCheckBox() const
 {
-    return ClassName == (wchar_t*)0x0080FFFF && // je button
-           ::IsRadioOrCheckBox(Style);          // je check nebo radio
+    return ClassName == (wchar_t*)0x0080FFFF && // is a button
+           ::IsRadioOrCheckBox(Style);          // is a check or radio button
 }
 
 BOOL CControl::IsRadioBox() const
 {
-    return ClassName == (wchar_t*)0x0080FFFF && // je button
+    return ClassName == (wchar_t*)0x0080FFFF && // is a button
            ::IsRadioBox(Style);
 }
 
 BOOL CControl::IsCheckBox() const
 {
-    return ClassName == (wchar_t*)0x0080FFFF && // je button
+    return ClassName == (wchar_t*)0x0080FFFF && // is a button
            ::IsCheckBox(Style);
 }
 
@@ -236,8 +236,8 @@ BOOL IsPushButton(int bt);
 
 BOOL CControl::IsPushButton() const
 {
-    return ClassName == (wchar_t*)0x0080FFFF && // je button
-           ::IsPushButton(Style);               // je push button
+    return ClassName == (wchar_t*)0x0080FFFF && // is a button
+           ::IsPushButton(Style);               // is a push button
 }
 
 BOOL CControl::IsTContainedIn(CControl const* c) const
@@ -254,22 +254,22 @@ BOOL CControl::IsTVertContainedIn(CControl const* c) const
 BOOL CControl::ShowInLVWithControls(int i)
 {
     return OWindowName != NULL && HIWORD(OWindowName) != 0x0000 &&
-           (IsTranslatableControl(OWindowName) || // vse krome ikon a dalsich neprelozitelnych prvku
-            i > 0 && IsStaticText());             // u staticu s textem delame vyjimku, je mozne prelozit i prazdny text (napr. "" -> "Prelozil (c) 2010 Ferda" v About dialogu PictView)
+           (IsTranslatableControl(OWindowName) || // everything except icons and other non-translatable elements
+            i > 0 && IsStaticText());             // we make an exception for statics with text: it is possible to translate even an empty string (e.g., "" -> "Translated (c) 2010 Ferda" in the PictView About dialog)
 }
 
 void CControl::GetTRect(RECT* r, BOOL adjustZeroSize)
 {
     r->left = TX;
     r->top = TY;
-    // 0 jednotek siroke nebo vysoke controly rozsirime na 1 jednotku
+    // expand controls with 0 width or height to one unit
     int w = TCX;
     if (adjustZeroSize && w == 0)
         w = 1;
     int h = TCY;
     if (adjustZeroSize && h == 0)
         h = 1;
-    if (IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+    if (IsComboBox()) // for combo boxes we use their "collapsed" size
         h = COMBOBOX_BASE_HEIGHT;
     r->right = TX + w;
     r->bottom = TY + h;
@@ -399,17 +399,17 @@ void CDialogData::LoadFrom(CDialogData* src, BOOL keepLangID)
     TCY = src->TCY;
 
     if (HIWORD(src->MenuName) != 0)
-        MenuName = dupstr(src->MenuName); // alokovany retezec
+        MenuName = dupstr(src->MenuName); // allocated string
     else
         MenuName = src->MenuName;
 
     if (HIWORD(src->ClassName) != 0)
-        ClassName = dupstr(src->ClassName); // alokovany retezec
+        ClassName = dupstr(src->ClassName); // allocated string
     else
         ClassName = src->ClassName;
 
     FontSize = src->FontSize;
-    FontName = dupstr(src->FontName); // alokovany retezec
+    FontName = dupstr(src->FontName); // allocated string
 
     IsEX = src->IsEX;
     ExDlgVer = src->ExDlgVer;
@@ -466,7 +466,7 @@ BOOL CDialogData::DoesLayoutChanged(CDialogData* orgDialogData)
 
 BOOL IsFilteredDialogStyleSame(DWORD style1, DWORD style2)
 {
-    DWORD mask = DS_3DLOOK | DS_FIXEDSYS; // do masky pridat styly, u kterych budeme ignorovat jejich rozdilnost
+    DWORD mask = DS_3DLOOK | DS_FIXEDSYS; // add styles to the mask for which we ignore differences
     return (style1 & ~mask) == (style2 & ~mask);
 }
 
@@ -482,12 +482,12 @@ BOOL IsFilteredControlStyleSame(CControl* control, CControl* controlOrg)
         IsEmptyWindowName(controlOrg->OWindowName) &&
         IsEmptyWindowName(controlOrg->TWindowName) &&
         control->Style == (controlOrg->Style & ~(WS_BORDER | SS_WHITEFRAME)))
-    { // Petr: u staticu pro progress-bar ignorujeme ztratu WS_BORDER | SS_WHITEFRAME (prechod na flat variantu progresu)
+    { // Petr: for progress-bar statics ignore losing WS_BORDER | SS_WHITEFRAME (switching to the flat progress variant)
         return TRUE;
     }
 
     DWORD editMask = ES_AUTOHSCROLL;
-    if (control->IsEditBox() && controlOrg->IsEditBox() && // Petr: u editu ignorujeme zmenu ES_AUTOHSCROLL, nema zadny vliv na layout
+    if (control->IsEditBox() && controlOrg->IsEditBox() && // Petr: for edits ignore changes to ES_AUTOHSCROLL; they do not affect the layout
         (control->Style & ~editMask) == (controlOrg->Style & ~editMask))
     {
         return TRUE;
@@ -501,7 +501,7 @@ BOOL CDialogData::DoesLayoutChanged2(CDialogData* orgDialogData)
     CDialogData* dataOrg = orgDialogData;
     BOOL changed = FALSE;
 
-    if (ID != dataOrg->ID) // Petr: tohle snad nemuze nastat, ne? Vzdyt se podle ID ty dialogy sparovaly, tak musi byt shodna.
+    if (ID != dataOrg->ID) // Petr: This should not happen, right? The dialogs were paired by ID, so they must match.
     {
         swprintf_s(buff, L"Dialog %hs: ID changed, original ID:%d, new ID:%d",
                    DataRH.GetIdentifier(ID),
@@ -520,7 +520,7 @@ BOOL CDialogData::DoesLayoutChanged2(CDialogData* orgDialogData)
     else
     {
         if (dataOrg->Style != Style)
-            dataOrg->Style = Style; // Petr: pri importu se kopiruji komplet data z puvodniho dialogu, tedy nakopiroval by se "spatny" styl, tohle je reseni, i kdyz trochu prasarna
+            dataOrg->Style = Style; // Petr: during import we copy the original dialog data completely, so the "wrong" style would be copied; this fixes it, even if it's a bit of a hack
     }
 
     if (OX != dataOrg->OX || OY != dataOrg->OY || OCX != dataOrg->OCX || OCY != dataOrg->OCY)
@@ -608,9 +608,9 @@ BOOL CDialogData::DoesLayoutChanged2(CDialogData* orgDialogData)
                     OutWindow.AddLine(buff, mteInfo, rteDialog, ID);
                     changed = TRUE;
                 }
-                else // lisi se jen Style, ale neni to podstatny pro layout, takze to ignorujeme
+                else // only the Style differs and it is irrelevant for the layout, so we ignore it
                 {
-                    controlOrg->Style = control->Style; // Petr: trochu prasarna: pri importu se kopiruje kompletni puvodni dialog, ale styl potrebujeme z nove verze dialogu, tedy ho prevezmeme do puvodni verze a je to vyresene
+                    controlOrg->Style = control->Style; // Petr: a bit of a hack: import copies the original dialog, but we need the style from the new version, so we take it over into the original and resolve it
                 }
             }
 
@@ -652,14 +652,14 @@ BOOL CDialogData::DoesLayoutChanged2(CDialogData* orgDialogData)
 
 int CDialogData::FindControlIndex(WORD id, BOOL isDlgTitle)
 {
-    if (isDlgTitle) // ID nazvu dialogu srovnavame jen ID nazvu dialogu (ID se muze mezi controly opakovat)
+    if (isDlgTitle) // for the dialog title compare only title IDs (control IDs can repeat)
     {
         if (Controls.Count > 0 && Controls[0]->ID == id)
             return 0;
     }
     else
     {
-        for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+        for (int i = 1; i < Controls.Count; i++) // skip element 0; it contains the dialog title
         {
             if (Controls[i]->ID == id)
                 return i;
@@ -670,11 +670,11 @@ int CDialogData::FindControlIndex(WORD id, BOOL isDlgTitle)
 
 BOOL CDialogData::GetControlIndexInLV(int controlIndex, int* lvIndex)
 {
-    if (Controls.Count > 0 && (Controls[0]->OWindowName == NULL || Controls[0]->OWindowName[0] == 0)) // prazdny nazev dialogu
+    if (Controls.Count > 0 && (Controls[0]->OWindowName == NULL || Controls[0]->OWindowName[0] == 0)) // empty dialog title
         *lvIndex = 0;
     else
         *lvIndex = 1;
-    for (int x = 1; x < Controls.Count; x++) // 0 je nazev dialogu, zacneme tedy od 1
+    for (int x = 1; x < Controls.Count; x++) // index 0 is the dialog title, so start at 1
     {
         CControl* control = Controls[x];
         if (!control->ShowInLVWithControls(x))
@@ -758,8 +758,8 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
     WORD tCount = GET_WORD(tBuff);
     tBuff++;
 
-    if ((oStyle & ~(DS_3DLOOK | (oIsEX != tIsEX ? DS_FIXEDSYS : 0))) !=
-            (tStyle & ~(DS_3DLOOK | (oIsEX != tIsEX ? DS_FIXEDSYS : 0))) || // rozdily v DS_3DLOOK ignorujeme, pokud je jeden dialog DLG a druhy DLG-EX, ignorujeme jeste taky DS_FIXEDSYS
+        if ((oStyle & ~(DS_3DLOOK | (oIsEX != tIsEX ? DS_FIXEDSYS : 0))) !=
+                (tStyle & ~(DS_3DLOOK | (oIsEX != tIsEX ? DS_FIXEDSYS : 0))) || // ignore DS_3DLOOK differences; if one dialog is DLG and the other DLG-EX, also ignore DS_FIXEDSYS
         oExStyle != tExStyle ||
         oCount != tCount)
     {
@@ -902,7 +902,7 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
     }
 
     // window name
-    // nulty control bude nazev dialogu
+    // control 0 holds the dialog title
     CControl* control = new CControl();
     if (control == NULL)
     {
@@ -917,7 +917,7 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
     if (tLen > 0 && !data->MUIMode)
         control->State = data->QueryTranslationState(tteDialogs, 0, ID, (wchar_t*)oBuff, (wchar_t*)tBuff);
     else
-        control->State = PROGRESS_STATE_TRANSLATED; // prazdny retezec je "prelozeny"
+        control->State = PROGRESS_STATE_TRANSLATED; // an empty string counts as "translated"
 
     if (!DecodeString((wchar_t*)oBuff, oLen, &control->OWindowName))
         return FALSE;
@@ -967,10 +967,10 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
         tBuff += tLen + 1;
     }
 
-    // nacteme controls
+    // load the controls
     for (int i = 0; i < oCount; i++)
     {
-        // control je zarovnany na DWORDy
+        // controls are aligned to DWORDs
         oBuff = (WORD*)((((int)oBuff) + 3) & ~3);
         tBuff = (WORD*)((((int)tBuff) + 3) & ~3);
 
@@ -1063,7 +1063,7 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
         }
 
         if (data->MUIMode)
-            oControlID = i + 1 + 1000; // pokud jsem ID sazel od 1, osklive se na nekterych resourcech podelala okna, failnulo vytvoreni dialogu a dochazelo k prepisum pameti; zrejme se jedna o ID vyhrazena tlacitkum OK a spol??
+            oControlID = i + 1 + 1000; // when I numbered IDs from 1, some resources broke badly: dialog creation failed and memory was overwritten; apparently those IDs are reserved for OK buttons and similar controls??
 
         if (tIsEX)
         {
@@ -1087,7 +1087,7 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
         }
 
         if (data->MUIMode)
-            control->ID = i + 1 + 1000; // pokud jsem ID sazel od 1, osklive se na nekterych resourcech podelala okna, failnulo vytvoreni dialogu a dochazelo k prepisum pameti; zrejme se jedna o ID vyhrazena tlacitkum OK a spol??
+            control->ID = i + 1 + 1000; // when I numbered IDs from 1, some resources broke badly: dialog creation failed and memory was overwritten; apparently those IDs are reserved for OK buttons and similar controls??
 
         BOOL sameIDs = oControlID == control->ID;
 
@@ -1175,7 +1175,7 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
         if (!data->MUIMode && (GET_WORD(tBuff) == 0xffff || HIWORD(control->TWindowName) != 0x0000 && wcslen(control->TWindowName) > 0))
             control->State = data->QueryTranslationState(tteDialogs, Controls.Count, ID, oWinName, tWinName);
         else
-            control->State = PROGRESS_STATE_TRANSLATED; // prazdny retezec je "prelozeny"
+            control->State = PROGRESS_STATE_TRANSLATED; // an empty string counts as "translated"
 
         // control data
         WORD oExtraCount = GET_WORD(oBuff);
@@ -1322,7 +1322,7 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
     DWORD oExStyle = GET_DWORD(oBuff); oBuff += 2;
     DWORD tExStyle = GET_DWORD(tBuff); tBuff += 2;
 
-    // prepiseme style
+    // overwrite the style
     oStyle = GET_DWORD(oBuff); oBuff += 2;
     tStyle = GET_DWORD(tBuff); tBuff += 2;
 
@@ -1365,7 +1365,7 @@ CDialogData::PrepareTemplate(WORD* buff, BOOL addProgress, BOOL forPreview, BOOL
         return 0;
     }
 
-    // prvni control je virtualni (nazev dialogu)
+    // the first control is virtual (the dialog title)
 
     WORD* p = buff;
     if (IsEX)
@@ -1402,7 +1402,7 @@ CDialogData::PrepareTemplate(WORD* buff, BOOL addProgress, BOOL forPreview, BOOL
     p++;
 
     // menu name
-    if (MenuName == NULL || forPreview) // pro preview nepropojime s menu, protoze by se nepodarilo dialog vytvorit
+    if (MenuName == NULL || forPreview) // do not attach a menu for preview, otherwise the dialog could not be created
     {
         PUT_WORD(p, 0);
         p++;
@@ -1420,7 +1420,7 @@ CDialogData::PrepareTemplate(WORD* buff, BOOL addProgress, BOOL forPreview, BOOL
     }
 
     // class name
-    if (ClassName == NULL || forPreview) // ve win jsem potkal dialogy, ktere mely nejaky custom class a nebylo mozne je nasledne vytvorit pro preview
+    if (ClassName == NULL || forPreview) // in Windows I encountered dialogs with a custom class that could not be created for preview
     {
         PUT_WORD(p, 0);
         p++;
@@ -1457,14 +1457,14 @@ CDialogData::PrepareTemplate(WORD* buff, BOOL addProgress, BOOL forPreview, BOOL
 
     // controls
 
-    RECT maxControlsRect; // pri preview "nafoukneme" dialog tak, aby byly vydet i prvky mimo (pouzivame to jak my, tak hojne Honza Patera)
+    RECT maxControlsRect; // for preview we "inflate" the dialog so elements outside are visible (used by us and often by Honza Patera)
     ZeroMemory(&maxControlsRect, sizeof(maxControlsRect));
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip element 0; it contains the dialog title
     {
         CControl* control = Controls[i];
         *p = 0;
         *(p + 1) = 0;
-        // zarovnat na DWORDy
+        // align to DWORDs
         p = (WORD*)((((int)p) + 3) & ~3);
 
         if (IsEX)
@@ -1515,7 +1515,7 @@ CDialogData::PrepareTemplate(WORD* buff, BOOL addProgress, BOOL forPreview, BOOL
             int ctrlW = control->TCX;
             int ctrlY = control->TY;
             int ctrlH = control->TCY;
-            if (control->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+            if (control->IsComboBox()) // for combo boxes we use their "collapsed" size
                 ctrlH = COMBOBOX_BASE_HEIGHT;
             if (ctrlX + ctrlW > maxControlsRect.right)
                 maxControlsRect.right = ctrlX + ctrlW;
@@ -1541,9 +1541,9 @@ CDialogData::PrepareTemplate(WORD* buff, BOOL addProgress, BOOL forPreview, BOOL
             wchar_t* className = control->ClassName;
             if (forPreview)
             {
-                // pro ucely preview je potreba, aby vsechny class childu byly registrovany
-                // snadnejsi pro nas je zmenit class v takovem pripade na static nez ho registrovat
-                // pokud se ho casem rozhodneme registrovat, muzeme si do nej posadit treba napis s nazvem tridy
+                // for preview every child class needs to be registered
+                // easier for us to change the class to static instead of registering it
+                // if we decide to register it later, we can put a label with the class name into it
                 WNDCLASSW wc;
                 if (!GetClassInfoW(HInstance, className, &wc))
                 {
@@ -1621,7 +1621,7 @@ int CDialogData::GetNearestControlInDirection(int fromIndex, CSearchDirection di
         TRACE_E("fromIndex == 0");
 
     RECT fR;
-    RECT fRProjected; // obdelnik prodlouzeny do nekonecna ve smeru hledani
+    RECT fRProjected; // rectangle extended to infinity in the search direction
     Controls[fromIndex]->GetTRect(&fR, TRUE);
     fRProjected = fR;
 
@@ -1643,7 +1643,7 @@ int CDialogData::GetNearestControlInDirection(int fromIndex, CSearchDirection di
 
     if (wideScan)
     {
-        // obdelnik rozsirime az k hranicim dialogu
+        // extend the rectangle to the dialog bounds
         if (direction == esdRight || direction == esdLeft)
         {
             fRProjected.top = 0;
@@ -1665,8 +1665,8 @@ int CDialogData::GetNearestControlInDirection(int fromIndex, CSearchDirection di
     }
     else
     {
-        // prodlouzeny obdelnik zuzime na jednu jednotku kvuli dialogum jako IDD_CFGPAGE_GENERAL,
-        // kde mezi checkboxy mame napriklad edit line, ktera nam prerusovala vyber skupiny
+        // narrow the extended rectangle to a single unit for dialogs such as IDD_CFGPAGE_GENERAL,
+        // where an edit line between check boxes interrupted the group selection
         if (direction == esdRight || direction == esdLeft)
         {
             fRProjected.bottom = fRProjected.top + 1;
@@ -1682,7 +1682,7 @@ int CDialogData::GetNearestControlInDirection(int fromIndex, CSearchDirection di
 
     int distance = -1;
     int distanceIndex = -1;
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip element 0; it contains the dialog title
     {
         if (i == fromIndex)
             continue;
@@ -1706,18 +1706,18 @@ int CDialogData::GetNearestControlInDirection(int fromIndex, CSearchDirection di
 BOOL CDialogData::GetFooterSeparatorAndButtons(TDirectArray<DWORD>* footer)
 {
     footer->DetachMembers();
-    // v prvni fazi prohledame vsechny prvky, ktere nejsou push button a urcime jejich nejspodnejsi hranu
-    // pro push buttons dohledame nejspodnejsi Y pozici
+    // first pass: scan all non-push-button controls and determine the lowest edge
+    // for push buttons find the lowest Y position
     int ctrlBottom = -1;
     int buttonsY = -1;
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip element 0; it contains the dialog title
     {
         CControl* ctrl = Controls[i];
         if (!ctrl->IsPushButton())
         {
             int ctrlY = ctrl->TY;
             int ctrlH = ctrl->TCY;
-            if (ctrl->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+            if (ctrl->IsComboBox()) // for combo boxes we use their "collapsed" size
                 ctrlH = COMBOBOX_BASE_HEIGHT;
             if (ctrlY + ctrlH >= ctrlBottom)
                 ctrlBottom = ctrlY + ctrlH;
@@ -1729,26 +1729,26 @@ BOOL CDialogData::GetFooterSeparatorAndButtons(TDirectArray<DWORD>* footer)
         }
     }
 
-    // ve druhe fazi hledame vsechny push button prvky, ktere lezi pod spodni hranou,
-    // jsou umistene na buttonsY souradnici a maji shodne rozestupy
+    // second pass: look for push buttons that lie below the bottom edge,
+    // located on the buttonsY coordinate with equal spacing
     TDirectArray<DWORD> indexes(10, 10);
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip element 0; it contains the dialog title
     {
         CControl* ctrl = Controls[i];
         if (ctrl->IsPushButton() && ctrl->TY > ctrlBottom && ctrl->TY == buttonsY)
             indexes.Add(i);
     }
 
-    // omerime vzdalenosti mezi tlacitky, v nekterych dialozich je spodni rada tlacitek
-    // roztrzena na dve casti (jedna zarovnana vlevo, jedna vpravo) - takovou verzi automaticky
-    // neucesavame
+    // measure the distances between buttons; in some dialogs the bottom row of buttons
+    // is split into two parts (one left aligned, one right aligned) - we do not tidy that automatically
+    // we do not tidy it automatically
     BOOL spacingIsOK = TRUE;
     if (indexes.Count > 2)
     {
-        // prvky seradime zleva doprava
+        // sort the controls from left to right
         SortControlsByEdge(&indexes, TRUE);
         int firstSpace = -1;
-        // zkontrolujeme, ze jsou mezi nimy konstantni mezery
+        // verify that the gaps between them are constant
         for (int i = 1; i < indexes.Count; i++)
         {
             int space = Controls[indexes[i]]->TX - (Controls[indexes[i - 1]]->TX + Controls[indexes[i - 1]]->TCX);
@@ -1758,24 +1758,24 @@ BOOL CDialogData::GetFooterSeparatorAndButtons(TDirectArray<DWORD>* footer)
             }
             else
             {
-                // tolerujeme malou odchylku mezi tlacitky +- 1 dlg unit
+                // allow a small deviation between buttons of +/- 1 dialog unit
                 if (space < firstSpace - 1 || space > firstSpace + 1)
                     spacingIsOK = FALSE;
             }
         }
     }
 
-    // pokud jsme nasli tlacitka, ale nemaji shodne mezery, nechame zobrazit varovani
+    // if we found buttons but their spacing differs, show a warning
     if (indexes.Count > 0 && !spacingIsOK)
         return FALSE;
 
     if (indexes.Count > 0)
     {
-        // podivame se, zda nad tlacitky lezi vodorovny oddelovac a pokud ano, pridame ho na prvni pozici
+        // check whether a horizontal separator lies above the buttons and add it first if so
         int topIndex = GetNearestControlInDirection(indexes[0], esdUp, TRUE);
         if (topIndex != -1 && Controls[topIndex]->IsHorizLine())
         {
-            // nesmi mit vlevo text
+            // it must not have text on the left
             if (GetNearestControlInDirection(topIndex, esdLeft, FALSE) == -1)
                 footer->Add(topIndex);
         }
@@ -1794,7 +1794,7 @@ void CDialogData::AdjustFooter(BOOL wide, TDirectArray<DWORD>* footer)
 
     int marginHeight = wide ? DIALOG_WIDE_MARGIN_HEIGHT : DIALOG_STD_MARGIN_HEIGHT;
 
-    // dohledame posledni prvek nad patickou
+    // find the last control above the footer
     int bottomCtrl = GetNearestControlInDirection(footer->At(0), esdUp, TRUE);
     if (bottomCtrl == -1)
         return;
@@ -1838,7 +1838,7 @@ BOOL CDialogData::BelongsToSameSelectionGroup(int fromIndex, int testIndex)
     CControl* fromCtrl = Controls[fromIndex];
     CControl* testCtrl = Controls[testIndex];
 
-    // pokud se ClassName lisi (retezce nebo IDcka), nepatri prvky do stejne skupiny
+    // if the ClassName differs (string or ID), the controls are not in the same group
     if (LOWORD(fromCtrl->ClassName) != 0xFFFF && LOWORD(testCtrl->ClassName) != 0xFFFF)
     {
         if (wcscmp(fromCtrl->ClassName, testCtrl->ClassName) != 0)
@@ -1850,7 +1850,7 @@ BOOL CDialogData::BelongsToSameSelectionGroup(int fromIndex, int testIndex)
             return FALSE;
     }
 
-    // zde jsou ClassName obou prvku shodne, budeme testovat styly
+    // the ClassName matches for both controls, so compare styles
     if (fromCtrl->IsStaticText(TRUE, FALSE) != testCtrl->IsStaticText(TRUE, FALSE))
         return FALSE;
     if (fromCtrl->IsStaticText(FALSE, TRUE) != testCtrl->IsStaticText(FALSE, TRUE))
@@ -1900,7 +1900,7 @@ BOOL CDialogData::ControlsHasSameGroupEdge(int fromIndex, int testIndex, CSearch
 
 BOOL CDialogData::HasOuterControls()
 {
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip element 0; it contains the dialog title
     {
         CControl* ctrl = Controls[i];
         RECT cr;
@@ -1914,7 +1914,7 @@ BOOL CDialogData::HasOuterControls()
 BOOL CDialogData::GetControlsRect(BOOL ignoreSeparators, BOOL ignoreOuterControls, RECT* r)
 {
     BOOL first = TRUE;
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip element 0; it contains the dialog title
     {
         CControl* ctrl = Controls[i];
 
@@ -1948,12 +1948,12 @@ BOOL CDialogData::GetControlsRect(BOOL ignoreSeparators, BOOL ignoreOuterControl
 
 BOOL CDialogData::CanNormalizeLayout()
 {
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip element 0; it contains the dialog title
     {
         CControl* ctrl = Controls[i];
         RECT cr;
         ctrl->GetTRect(&cr, FALSE);
-        // pokud control spodni hranou presahuje pres TCY, normalizace neni nakodovana
+        // if a control extends past TCY, normalization is not implemented
         if (cr.bottom > TCY)
             return FALSE;
     }
@@ -1963,12 +1963,12 @@ BOOL CDialogData::CanNormalizeLayout()
 void CDialogData::AdjustSeparatorsWidth(CStringList* errors)
 {
     char buff[1000];
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip element 0; it contains the dialog title
     {
         CControl* ctrl = Controls[i];
         if (!ctrl->IsHorizLine())
             continue;
-        // pokud vpravo od separatoru nalezneme element, informujeme
+        // if we find an element to the right of the separator, report it
         int rightIndex = GetNearestControlInDirection(i, esdRight, FALSE);
         if (rightIndex != -1)
         {
@@ -1976,19 +1976,19 @@ void CDialogData::AdjustSeparatorsWidth(CStringList* errors)
             errors->AddString(buff);
             continue;
         }
-        // pokud je pravy konec separatory prilis daleko od prave hrany dialogu, informujeme
+        // if the separator's right edge is too far from the dialog's right edge, report it
         if (ctrl->TX + ctrl->TCX < TCX - DIALOG_MARGIN_WIDTH * 2)
         {
             sprintf_s(buff, "Cannot adjust separator <%d>. It is too far from the right dialog box side.", ctrl->ID);
             errors->AddString(buff);
             continue;
         }
-        // pokud vlevo od separatoru nic neni a separator zacina priblizne na hrane dialogu,
-        // usadime jeho levou pozici presne na margin
+        // if nothing is to the left and the separator starts roughly at the dialog edge,
+        // align its left position exactly to the margin
         int leftIndex = GetNearestControlInDirection(i, esdLeft, FALSE);
         if (leftIndex == -1)
         {
-            // pokud je leva strana separatoru prilis vzdalena od leve hrany dialogu, informujeme
+            // if the separator's left edge is too far from the dialog's left edge, report it
             if (ctrl->TX > DIALOG_MARGIN_WIDTH * 2)
             {
                 sprintf_s(buff, "Cannot adjust separator <%d>. It is too far from the left dialog box side.", ctrl->ID);
@@ -2005,24 +2005,24 @@ void CDialogData::AdjustSeparatorsWidth(CStringList* errors)
 void CDialogData::NormalizeLayout(BOOL wide, CStringList* errors)
 {
     int marginHeight = wide ? DIALOG_WIDE_MARGIN_HEIGHT : DIALOG_STD_MARGIN_HEIGHT;
-    // v prvni fazi najdeme rozmery obdelniku opsaneho kolem prvku dialogu
-    // ignorujeme vodorovne separatory a prvky lezici za hranici dialogu (pouzivame pro ruzne real-time zmeny layoutu)
+    // first find the bounding rectangle around the dialog controls
+    // ignore horizontal separators and controls outside the dialog (used for various real-time layout changes)
     RECT r;
     GetControlsRect(TRUE, TRUE, &r);
     CtrlsMove(FALSE, DIALOG_MARGIN_WIDTH - r.left, marginHeight - r.top);
     SIZE dlgSize;
     dlgSize.cx = r.right - r.left + 2 * DIALOG_MARGIN_WIDTH;
     dlgSize.cy = r.bottom - r.top + (marginHeight + DIALOG_STD_MARGIN_HEIGHT);
-    // property pages nikdy nezmensujeme, protoze je udrzujeme stejne velike kvuli pohodlnesimu
-    // layoutovani (clovek vidi, jaky prostor ma diky nejvetsi strance k dispozici)
+    // never shrink property pages; we keep them the same size for convenience
+    // when laying out, you can see how much space the largest page provides
     if (Style & DS_CONTROL)
     {
         dlgSize.cx = max(TCX, dlgSize.cx);
         dlgSize.cy = max(TCY, dlgSize.cy);
     }
-    // tato funkce je volana pouze pro dialogy bez prvku mimo hranici dialogu, pripadne s prvky za jeho pravou hranici
-    // prvkum lezicim vpravo vnutime jejich puvodni offset od prave hrany dialogu
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    // this function is called only for dialogs without controls outside the bounds or with controls beyond the right edge
+    // controls on the right keep their original offset from the dialog's right edge
+    for (int i = 1; i < Controls.Count; i++) // skip element 0; it contains the dialog title
     {
         CControl* ctrl = Controls[i];
         RECT cr;
@@ -2030,9 +2030,9 @@ void CDialogData::NormalizeLayout(BOOL wide, CStringList* errors)
         if (cr.left >= TCX)
             ctrl->TX = (short)dlgSize.cx + (ctrl->TX - TCX) - (DIALOG_MARGIN_WIDTH - (short)r.left);
     }
-    // nova velikost dialogu
+    // new dialog size
     DialogSetSize(dlgSize.cx, dlgSize.cy);
-    // uceseme paticku dialogu (spodni rada tlacitek, pripadne separator nad nima)
+    // tidy the footer (the bottom row of buttons and any separator above them)
 
     TDirectArray<DWORD> footerIndexes(10, 10);
     if (!GetFooterSeparatorAndButtons(&footerIndexes))
@@ -2040,7 +2040,7 @@ void CDialogData::NormalizeLayout(BOOL wide, CStringList* errors)
     if (footerIndexes.Count > 0)
         AdjustFooter(wide, &footerIndexes);
 
-    // protahneme vodorovne separatory az k prave hrane dialogu (minus margin)
+    // stretch horizontal separators to the dialog's right edge (minus the margin)
     AdjustSeparatorsWidth(errors);
 }
 
@@ -2074,7 +2074,7 @@ BOOL CData::SaveDialogs(HANDLE hUpdateRes)
         CDialogData* dlgData = DlgData[i];
         DWORD size = dlgData->PrepareTemplate((WORD*)buff, TRUE, FALSE, FALSE);
         BOOL result = TRUE;
-        if (dlgData->TLangID != MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL)) // resource neni "neutral", musime ho smaznout, aby ve vyslednem .SLG nebyly dialogy dva
+        if (dlgData->TLangID != MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL)) // resource is not "neutral"; delete it so the resulting .SLG does not contain the dialog twice
         {
             result = UpdateResource(hUpdateRes, RT_DIALOG, MAKEINTRESOURCE(dlgData->ID),
                                     dlgData->TLangID,

--- a/src/translator/datadlg.cpp
+++ b/src/translator/datadlg.cpp
@@ -758,7 +758,7 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
     WORD tCount = GET_WORD(tBuff);
     tBuff++;
 
-        if ((oStyle & ~(DS_3DLOOK | (oIsEX != tIsEX ? DS_FIXEDSYS : 0))) !=
+    if ((oStyle & ~(DS_3DLOOK | (oIsEX != tIsEX ? DS_FIXEDSYS : 0))) !=
             (tStyle & ~(DS_3DLOOK | (oIsEX != tIsEX ? DS_FIXEDSYS : 0))) || // ignore DS_3DLOOK differences; if one dialog is DLG and the other DLG-EX, also ignore DS_FIXEDSYS
         oExStyle != tExStyle ||
         oCount != tCount)

--- a/src/translator/datadlg.cpp
+++ b/src/translator/datadlg.cpp
@@ -759,7 +759,7 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
     tBuff++;
 
         if ((oStyle & ~(DS_3DLOOK | (oIsEX != tIsEX ? DS_FIXEDSYS : 0))) !=
-                (tStyle & ~(DS_3DLOOK | (oIsEX != tIsEX ? DS_FIXEDSYS : 0))) || // ignore DS_3DLOOK differences; if one dialog is DLG and the other DLG-EX, also ignore DS_FIXEDSYS
+            (tStyle & ~(DS_3DLOOK | (oIsEX != tIsEX ? DS_FIXEDSYS : 0))) || // ignore DS_3DLOOK differences; if one dialog is DLG and the other DLG-EX, also ignore DS_FIXEDSYS
         oExStyle != tExStyle ||
         oCount != tCount)
     {

--- a/src/translator/datafind.cpp
+++ b/src/translator/datafind.cpp
@@ -83,7 +83,7 @@ BOOL CData::CompareStrings(const wchar_t* _string, const wchar_t* _pattern)
             {
                 break; // found
             }
-            iterator = str + patternLen; // zkusime dalsi vyskyt
+            iterator = str + patternLen; // try the next occurrence
             str = NULL;
         }
     } while (str == NULL);
@@ -108,11 +108,11 @@ void CData::Find()
     OutWindow.AddLine(buff, mteInfo);
 
     int i, j;
-    WORD lvIndex; // index v ListView
+    WORD lvIndex; // index in the ListView
 
     if (Config.FindTexts || Config.FindOriginal)
     {
-        // prohledame dialogy
+        // scan the dialogs
         for (i = 0; i < DlgData.Count; i++)
         {
             CDialogData* dialog = DlgData[i];
@@ -123,7 +123,7 @@ void CData::Find()
                 if (!control->ShowInLVWithControls(j))
                     continue;
 
-                BOOL found = FALSE; // nechceme duplicity
+                BOOL found = FALSE; // avoid duplicates
                 if (Config.FindTexts)
                 {
                     const wchar_t* text = control->TWindowName;
@@ -147,7 +147,7 @@ void CData::Find()
             }
         }
 
-        // prohledame menu
+        // scan the menus
         for (i = 0; i < MenuData.Count; i++)
         {
             CMenuData* menu = MenuData[i];
@@ -158,7 +158,7 @@ void CData::Find()
                 if (wcslen(item->TString) == 0)
                     continue;
 
-                BOOL found = FALSE; // nechceme duplicity
+                BOOL found = FALSE; // avoid duplicates
                 if (Config.FindTexts)
                 {
                     const wchar_t* text = item->TString;
@@ -183,14 +183,14 @@ void CData::Find()
             }
         }
 
-        // prohledame strings
+        // scan the string resources
         for (i = 0; i < StrData.Count; i++)
         {
             CStrData* strData = StrData[i];
             lvIndex = 0;
             for (j = 0; j < 16; j++)
             {
-                BOOL found = FALSE; // nechceme duplicity
+                BOOL found = FALSE; // avoid duplicates
                 if (Config.FindTexts)
                 {
                     wchar_t* str = strData->TStrings[j];
@@ -235,7 +235,7 @@ void CData::Find()
             {
                 WORD id = item->ID;
 
-                // prohledame dialogy
+                // scan the dialogs
                 for (i = 0; i < DlgData.Count; i++)
                 {
                     CDialogData* dialog = DlgData[i];
@@ -260,7 +260,7 @@ void CData::Find()
                     }
                 }
 
-                // prohledame menu
+                // scan the menus
                 for (i = 0; i < MenuData.Count; i++)
                 {
                     CMenuData* menu = MenuData[i];
@@ -286,7 +286,7 @@ void CData::Find()
                     }
                 }
 
-                // prohledame strings
+                // scan the string resources
                 for (i = 0; i < StrData.Count; i++)
                 {
                     CStrData* strData = StrData[i];
@@ -323,7 +323,7 @@ void CData::Find()
     if (count == 0)
         OutWindow.FocusLastItem();
     else
-        PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_WND_OUTPUT, 0); // aktivace Output okna
+        PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_WND_OUTPUT, 0); // activate the Output window
 
     OutWindow.EnablePaint(TRUE);
 
@@ -344,11 +344,11 @@ void CData::FindUntranslated(BOOL* completelyUntranslated)
     OutWindow.AddLine(buff, mteInfo);
 
     int i, j;
-    WORD lvIndex; // index v ListView
+    WORD lvIndex; // index in the ListView
 
     BOOL complUntrl = TRUE;
 
-    // prohledame dialogy
+    // scan the dialogs
     for (i = 0; i < DlgData.Count; i++)
     {
         CDialogData* dialog = DlgData[i];
@@ -377,7 +377,7 @@ void CData::FindUntranslated(BOOL* completelyUntranslated)
         }
     }
 
-    // prohledame menu
+    // scan the menus
     for (i = 0; i < MenuData.Count; i++)
     {
         CMenuData* menu = MenuData[i];
@@ -399,7 +399,7 @@ void CData::FindUntranslated(BOOL* completelyUntranslated)
         }
     }
 
-    // prohledame strings
+    // scan the string resources
     for (i = 0; i < StrData.Count; i++)
     {
         CStrData* strData = StrData[i];
@@ -430,9 +430,9 @@ void CData::FindUntranslated(BOOL* completelyUntranslated)
         swprintf_s(buff, L"%d occurrence(s) have been found.", count - 1);
     OutWindow.AddLine(buff, mteSummary);
     if (count <= 1)
-        PostMessage(FrameWindow.HWindow, WM_FOCLASTINOUTPUTWND, 0, 0); // Output okno jeste nemusi existovat
+        PostMessage(FrameWindow.HWindow, WM_FOCLASTINOUTPUTWND, 0, 0); // the Output window might not exist yet
     else
-        PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_WND_OUTPUT, 0); // aktivace Output okna
+        PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_WND_OUTPUT, 0); // activate the Output window
 
     OutWindow.EnablePaint(TRUE);
 

--- a/src/translator/datamui.cpp
+++ b/src/translator/datamui.cpp
@@ -33,9 +33,9 @@ BOOL TrimOnSecondUnderscore(char* masked)
     return FALSE;
 }
 
-// pokusi se v prelozenem strome zacinajicim na 'translatedMUIRoot' dohledat soubor 'fileName' na podceste 'originalMUIDir'
-// pokud takovy soubor nalezne, ulozi jeho cestu do 'translatedFileName' a vrati TRUE
-// jinak vrati FALSE
+// try to locate 'fileName' in the translated tree rooted at 'translatedMUIRoot' under the subpath 'originalMUIDir'
+// if found, store its path in 'translatedFileName' and return TRUE
+// otherwise return FALSE
 BOOL LookupForTranslatedFile(const char* originalMUIRoot, const char* originalMUISubDir, const char* fileName,
                              const char* translatedMUIRoot, char* translatedFileName)
 {
@@ -43,7 +43,7 @@ BOOL LookupForTranslatedFile(const char* originalMUIRoot, const char* originalMU
     char buff[MAX_PATH];
     lstrcpy(buff, translatedMUIRoot);
 
-    // nazev adesare obsahuje na konci za druhym podtrzitkem nejake cisla, ktera musime "zariznout", potoze jsou ruzna pro kazdou lokalizaci
+    // the directory name ends with numbers after the second underscore that we must trim because they differ for each localization
     char trim[MAX_PATH];
     lstrcpy(trim, originalMUISubDir);
     TrimOnSecondUnderscore(trim);
@@ -54,7 +54,7 @@ BOOL LookupForTranslatedFile(const char* originalMUIRoot, const char* originalMU
     if (hFind != INVALID_HANDLE_VALUE)
     {
         do
-        { // hledame prvni level podadresaru
+        { // look for the first level of subdirectories
             if (find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
             {
                 if (find.cFileName[0] != 0 && strcmp(find.cFileName, ".") != 0 && strcmp(find.cFileName, "..") != 0)
@@ -89,7 +89,7 @@ BOOL EnumMUIFiles(CData* data, const char* originalMUIRoot, const char* original
     if (hFind != INVALID_HANDLE_VALUE)
     {
         do
-        { // hledame soubory
+        { // look for files
             if ((find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0)
             {
                 if (find.cFileName[0] != 0)
@@ -102,7 +102,7 @@ BOOL EnumMUIFiles(CData* data, const char* originalMUIRoot, const char* original
                     char translatedFileName[MAX_PATH];
                     if (LookupForTranslatedFile(originalMUIRoot, originalMUISubPath, find.cFileName, translatedMUIRoot, translatedFileName))
                     {
-                        // nacte resourcy z original a translated DLL
+                        // load resources from the original and translated DLL
                         data->Load(originalFileName, translatedFileName, FALSE);
                     }
                     else
@@ -129,13 +129,13 @@ BOOL EnumMUIDirectories(CData* data, const char* originalMUIRoot, const char* tr
     if (hFind != INVALID_HANDLE_VALUE)
     {
         do
-        { // hledame prvni level podadresaru
+        { // look for the first level of subdirectories
             if (find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
             {
                 if (find.cFileName[0] != 0 && strcmp(find.cFileName, ".") != 0 && strcmp(find.cFileName, "..") != 0)
                 {
-                    // nasli jsou adresar, ktery jiz muze obsahovat vlastni *.dll.mui DLLka
-                    // jdeme se po nich podivat
+                    // found a directory that may already contain its own *.dll.mui files
+                    // inspect them
                     EnumMUIFiles(data, originalMUIRoot, find.cFileName, translatedMUIRoot);
                 }
             }
@@ -147,7 +147,7 @@ BOOL EnumMUIDirectories(CData* data, const char* originalMUIRoot, const char* tr
 
 BOOL CData::LoadMUIPackages(const char* originalMUI, const char* translatedMUI)
 {
-    // sestrelime existujici data
+    // clear the existing data
     StrData.DestroyMembers();
     MenuData.DestroyMembers();
     DlgData.DestroyMembers();
@@ -158,7 +158,7 @@ BOOL CData::LoadMUIPackages(const char* originalMUI, const char* translatedMUI)
     DataRH.Clean();
 
     MUIMode = TRUE;
-    MUIDialogID = 1; // reset counteru pro unikatni ID
+    MUIDialogID = 1; // reset the counter for unique IDs
     MUIMenuID = 1;
     MUIStringID = 1;
 

--- a/src/translator/datasel.cpp
+++ b/src/translator/datasel.cpp
@@ -356,10 +356,8 @@ void CDialogData::SelCtrlsSizeToContent(HWND hDialog)
         if (idealSizeX != -1)
         {
             if (control->IsStaticText(FALSE, TRUE)) // Expand right-aligned texts to the left
-                control->TX = control->TX + control->TCX -
-                              (idealSizeX + 2) /* artificially widen the control to reduce clipping risk when the font changes */;
-            control->TCX =
-                idealSizeX + 2 /* artificially widen the control to reduce clipping risk when the font changes */;
+                control->TX = control->TX + control->TCX - (idealSizeX + 2) /* artificially widen the control to reduce clipping risk when the font changes */;
+            control->TCX = idealSizeX + 2 /* artificially widen the control to reduce clipping risk when the font changes */;
         }
         if (idealSizeY != -1)
             control->TCY = idealSizeY;

--- a/src/translator/datasel.cpp
+++ b/src/translator/datasel.cpp
@@ -9,8 +9,8 @@ COLORREF GetSelectionColor(BOOL clipped)
         return RGB(255, 0, 0);
     else
         return RGB(0, 162, 232);
-    // Pod Win10 neslo rozlisit vybrane tlacitko od default, takze
-    // jsme odesli od barvy GetSysColor(COLOR_HIGHLIGHT)
+    // Windows 10 cannot visually distinguish the selected button from the default one, so
+    // we stopped using GetSysColor(COLOR_HIGHLIGHT)
 }
 
 void CDialogData::SetHighlightControl(int index)
@@ -32,7 +32,7 @@ void CDialogData::SetDialogSelected(BOOL value)
 int CDialogData::GetSelectedControlsCount()
 {
     int count = 0;
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (control->Selected)
@@ -54,7 +54,7 @@ int CDialogData::SelCtrlsGetCurrentControlIndex()
 {
     if (GetSelectedControlsCount() != 1)
         return -1;
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (control->Selected)
@@ -73,7 +73,7 @@ HWND CDialogData::SelCtrlsGetCurrentControlHandle(HWND hDialog)
 
 int CDialogData::SelCtrlsGetFirstControlIndex()
 {
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (control->Selected)
@@ -85,7 +85,7 @@ int CDialogData::SelCtrlsGetFirstControlIndex()
 HWND CDialogData::GetControlHandle(HWND hDialog, int index)
 {
     HWND hChild = GetWindow(hDialog, GW_CHILD);
-    int i = 1; // 0-ty prvek preskocime, obsahuje nazev dialogu
+    int i = 1; // skip index 0; it stores the dialog title
     do
     {
         if (i == index)
@@ -102,7 +102,7 @@ HWND CDialogData::GetControlHandle(HWND hDialog, int index)
 int CDialogData::GetControlIndex(HWND hDialog, HWND hControl)
 {
     HWND hChild = GetWindow(hDialog, GW_CHILD);
-    int i = 1; // 0-ty prvek preskocime, obsahuje nazev dialogu
+    int i = 1; // skip index 0; it stores the dialog title
     do
     {
         if (hChild == hControl)
@@ -115,7 +115,7 @@ int CDialogData::GetControlIndex(HWND hDialog, HWND hControl)
 
 void CDialogData::CtrlsMove(BOOL selectedOnly, int deltaX, int deltaY)
 {
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (selectedOnly && !control->Selected)
@@ -128,16 +128,16 @@ void CDialogData::CtrlsMove(BOOL selectedOnly, int deltaX, int deltaY)
 
 void CDialogData::SelCtrlsResize(CEdgeEnum edge, int delta, const RECT* originalR)
 {
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
             continue;
 
-        if (control->IsIcon()) // nechceme zmeny rozmeru ikon
+        if (control->IsIcon()) // do not allow resizing icons
             continue;
 
-        if (control->IsComboBox() && (edge == edgeTop || edge == edgeBottom)) // u comboboxu potlacime zmenu vysky
+        if (control->IsComboBox() && (edge == edgeTop || edge == edgeBottom)) // suppress height changes for combo boxes
             continue;
 
         if (originalR != NULL)
@@ -211,19 +211,19 @@ void CDialogData::DialogResize(BOOL horizontal, int delta, const RECT* originalR
 
 void CDialogData::SelCtrlsSetSize(int width, int height)
 {
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
             continue;
 
-        if (control->IsIcon()) // nechceme zmeny rozmeru ikon
+        if (control->IsIcon()) // do not allow resizing icons
             continue;
 
         if (width != -1)
             control->TCX = width;
 
-        if (control->IsComboBox()) // u comboboxu potlacime zmenu vysky
+        if (control->IsComboBox()) // suppress height changes for combo boxes
             continue;
 
         if (height != -1)
@@ -242,11 +242,11 @@ void CDialogData::SelCtrlsAlign(CEdgeEnum edge)
     if (GetSelectedControlsCount() < 2)
         return;
 
-    // dohledame opsanej obdelnik
+    // locate the bounding rectangle
     RECT outline = {0};
     SelCtrlsGetOuterRect(&outline);
 
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
@@ -286,11 +286,11 @@ void CDialogData::SelCtrlsCenter(BOOL horizontal)
     if (GetSelectedControlsCount() < 2)
         return;
 
-    // dohledame opsanej obdelnik
+    // locate the bounding rectangle
     RECT outline = {0};
     SelCtrlsGetOuterRect(&outline);
 
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
@@ -301,7 +301,7 @@ void CDialogData::SelCtrlsCenter(BOOL horizontal)
         else
         {
             short ctrlH = control->TCY;
-            if (control->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+            if (control->IsComboBox()) // for combo boxes use their collapsed size
                 ctrlH = COMBOBOX_BASE_HEIGHT;
             control->TY = (short)(outline.top + (outline.bottom - outline.top - ctrlH) / 2);
         }
@@ -313,18 +313,18 @@ void CDialogData::SelCtrlsCenterToDialog(BOOL horizontal)
     if (GetSelectedControlsCount() < 1)
         return;
 
-    // dohledame opsanej obdelnik
+    // locate the bounding rectangle
     RECT outline = {0};
     SelCtrlsGetOuterRect(&outline);
 
-    // rozmery dialogu
+    // dialog dimensions
     short dlgW = TCX;
     short dlgH = TCY;
 
     short deltaX = (short)((dlgW - (outline.right - outline.left)) / 2 - outline.left);
     short deltaY = (short)((dlgH - (outline.bottom - outline.top)) / 2 - outline.top);
 
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
@@ -342,7 +342,7 @@ void CDialogData::SelCtrlsSizeToContent(HWND hDialog)
     if (GetSelectedControlsCount() < 1)
         return;
 
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
@@ -355,20 +355,22 @@ void CDialogData::SelCtrlsSizeToContent(HWND hDialog)
                          multiTextOrComboItem, checkLstItem);
         if (idealSizeX != -1)
         {
-            if (control->IsStaticText(FALSE, TRUE)) // vpravo zarovnane texty rozsirime vlevo
-                control->TX = control->TX + control->TCX - (idealSizeX + 2) /* umele control zvetsime, zmensime riziko orezu kvuli zmene fontu */;
-            control->TCX = idealSizeX + 2 /* umele control zvetsime, zmensime riziko orezu kvuli zmene fontu */;
+            if (control->IsStaticText(FALSE, TRUE)) // Expand right-aligned texts to the left
+                control->TX = control->TX + control->TCX -
+                              (idealSizeX + 2) /* artificially widen the control to reduce clipping risk when the font changes */;
+            control->TCX =
+                idealSizeX + 2 /* artificially widen the control to reduce clipping risk when the font changes */;
         }
         if (idealSizeY != -1)
             control->TCY = idealSizeY;
 
-        // upravime layout vodorovnych oddelovacu za static texty a radio/check boxy
+        // adjust horizontal separators that follow static text and radio/check boxes
         if (control->IsStaticText(TRUE) ||
             control->IsRadioOrCheckBox())
         {
             CControl* line = NULL;
             BOOL moreLines = FALSE;
-            for (int j = 1; j < Controls.Count; j++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+            for (int j = 1; j < Controls.Count; j++) // skip index 0; it stores the dialog title
             {
                 CControl* c = Controls[j];
                 if (c->IsHorizLine() && c->IsTVertContainedIn(control))
@@ -403,7 +405,7 @@ void CDialogData::SelCtrlsAlignTo(const CAlignToParams* params)
         refR.top = refCtrl->TY;
         refR.right = refCtrl->TX + refCtrl->TCX;
         int ctrlH = refCtrl->TCY;
-        if (refCtrl->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+        if (refCtrl->IsComboBox()) // for combo boxes use their collapsed size
             ctrlH = COMBOBOX_BASE_HEIGHT;
         refR.bottom = refCtrl->TY + ctrlH;
     }
@@ -449,13 +451,13 @@ void CDialogData::SelCtrlsAlignTo(const CAlignToParams* params)
     if (params->MoveAsGroup)
         SelCtrlsGetOuterRect(&selR);
 
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
             continue;
 
-        // pokud oznacene prvky posouvame individualne, vytahneme jejich pozici
+        // when moving controls individually, keep their position
         if (!params->MoveAsGroup)
             control->GetTRect(&selR, FALSE);
 
@@ -490,7 +492,7 @@ void CDialogData::SelCtrlsAlignTo(const CAlignToParams* params)
             {
             case atpeTop:
             {
-                if (control->IsComboBox() || control->IsHorizLine()) // pro tyto prvky nemenime vysku
+                if (control->IsComboBox() || control->IsHorizLine()) // do not change the height for these controls
                     break;
                 if (control->TY > ref)
                 {
@@ -509,7 +511,7 @@ void CDialogData::SelCtrlsAlignTo(const CAlignToParams* params)
 
             case atpeBottom:
             {
-                if (control->IsComboBox() || control->IsHorizLine()) // pro tyto prvky nemenime vysku
+                if (control->IsComboBox() || control->IsHorizLine()) // do not change the height for these controls
                     break;
                 if (control->TY < ref)
                     control->TCY = ref - control->TY;
@@ -558,16 +560,16 @@ void CDialogData::SelCtrlsEqualSpacing(BOOL horizontal, int delta)
     if (count < 2)
         return;
 
-    // dohledame opsanej obdelnik
+    // locate the bounding rectangle
     RECT outline = {0};
     SelCtrlsGetOuterRect(&outline);
     short outlineW = (short)(outline.right - outline.left);
     short outlineH = (short)(outline.bottom - outline.top);
 
-    // celkova sirka a vyska controlu
+    // total width and height of the controls
     int controlsW = 0;
     int controlsH = 0;
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
@@ -575,18 +577,18 @@ void CDialogData::SelCtrlsEqualSpacing(BOOL horizontal, int delta)
 
         controlsW += control->TCX;
         short ctrlH = control->TCY;
-        if (control->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+        if (control->IsComboBox()) // for combo boxes use their collapsed size
             ctrlH = COMBOBOX_BASE_HEIGHT;
         controlsH += ctrlH;
     }
 
-    // mezera mezi prvky (posledni prvek to muze posunout); mezera muze byt i zaporna
+    // spacing between controls (the last one may shift it); spacing can be negative
     short spaceH = (outlineW - controlsW) / (count - 1);
     short spaceV = (outlineH - controlsH) / (count - 1);
 
-    // seradime prvky podle jeji left/top hrany
+    // sort controls by their left/top edge
     TDirectArray<DWORD> indexes(count, 1);
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
         if (Controls[i]->Selected)
             indexes.Add(i);
 
@@ -608,7 +610,7 @@ void CDialogData::SelCtrlsEqualSpacing(BOOL horizontal, int delta)
         {
             control->TY = (short)outline.top + pos;
             short ctrlH = control->TCY;
-            if (control->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+            if (control->IsComboBox()) // for combo boxes use their collapsed size
                 ctrlH = COMBOBOX_BASE_HEIGHT;
             pos += ctrlH + spaceV;
         }
@@ -625,9 +627,9 @@ void CDialogData::SelCtrlsResize(CResizeControlsEnum resize)
     WORD maxHeight = 0;
     WORD minHeight = 0;
 
-    // dohledame mezni hodnoty
+    // determine boundary values
     BOOL first = TRUE;
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
@@ -645,13 +647,13 @@ void CDialogData::SelCtrlsResize(CResizeControlsEnum resize)
             first = FALSE;
     }
 
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
             continue;
 
-        if (control->IsIcon()) // u ikon potlacime zmenu rozmeru
+        if (control->IsIcon()) // suppress resizing for icons
             continue;
         switch (resize)
         {
@@ -667,13 +669,13 @@ void CDialogData::SelCtrlsResize(CResizeControlsEnum resize)
         }
         case rceHeightLarge:
         {
-            if (!control->IsComboBox()) // u comboboxu poltacime zmenu vysky
+            if (!control->IsComboBox()) // suppress height changes for combo boxes
                 control->TCY = maxHeight;
             break;
         }
         case rceHeightSmall:
         {
-            if (!control->IsComboBox()) // u comboboxu poltacime zmenu vysky
+            if (!control->IsComboBox()) // suppress height changes for combo boxes
                 control->TCY = minHeight;
             break;
         }
@@ -702,7 +704,7 @@ BOOL CDialogData::SelCtrlsGetCurrentControlRect(RECT* r)
         r->top = control->TY;
         r->right = control->TX + control->TCX;
         int ctrlH = control->TCY;
-        if (control->IsComboBox()) // u comboboxu chceme jejich "zabaleny" rozmer
+        if (control->IsComboBox()) // for combo boxes use their collapsed size
             ctrlH = COMBOBOX_BASE_HEIGHT;
         r->bottom = control->TY + ctrlH;
     }
@@ -775,7 +777,7 @@ void CDialogData::GetDialogResizeDelta(const RECT* originalR, CEdgeEnum edge, in
 
 BOOL CDialogData::SelCtrlsContains(HWND hDialog, HWND hControl)
 {
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
@@ -801,7 +803,7 @@ BOOL CDialogData::SelCtrlsContainsControlWithIndex(int index)
 void CDialogData::SelectControlByID(int id)
 {
     ClearSelection();
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (control->ID == id)
@@ -817,7 +819,7 @@ void CDialogData::SelectNextPrevControl(BOOL next)
     int selCount = GetSelectedControlsCount();
     if (selCount > 1)
     {
-        for (int i = 1; i < Controls.Count && selCount > 1; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+        for (int i = 1; i < Controls.Count && selCount > 1; i++) // skip index 0; it stores the dialog title
         {
             CControl* control = Controls[i];
             if (control->Selected)
@@ -829,7 +831,7 @@ void CDialogData::SelectNextPrevControl(BOOL next)
     }
     else
     {
-        // vytahneme aktualne vybranou polozku (-1:zadna 0..Count-1:control Count:dialog)
+        // fetch the currently selected item (-1:none 0..Count-1:control Count:dialog)
         int selectedIndex = -1;
         if (selCount == 1)
         {
@@ -848,7 +850,7 @@ void CDialogData::SelectNextPrevControl(BOOL next)
                 selectedIndex = 0;
             selectedIndex++;
             if (selectedIndex > Controls.Count)
-                selectedIndex = 1; // preskocim title
+                selectedIndex = 1; // skip the title
         }
         else
         {
@@ -856,7 +858,7 @@ void CDialogData::SelectNextPrevControl(BOOL next)
                 selectedIndex = Controls.Count + 1;
             selectedIndex--;
             if (selectedIndex < 1)
-                selectedIndex = Controls.Count; // preskocim title
+                selectedIndex = Controls.Count; // skip the title
         }
         if (selectedIndex != -1 && selectedIndex != Controls.Count)
         {
@@ -901,7 +903,7 @@ void CDialogData::ModifySelection(HWND hDialog, CModifySelectionMode mode, HWND 
 
 void CDialogData::ClearSelection()
 {
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
         Controls[i]->Selected = FALSE;
 }
 
@@ -913,10 +915,10 @@ void CDialogData::SelectControlsGroup(HWND hDialog, HWND hControl, BOOL keepSele
     int fromIndex = GetControlIndex(hDialog, hControl);
     if (fromIndex != -1)
     {
-        // vzorovy prvek pridame v kazdem pripade
+        // always include the reference control
         Controls[fromIndex]->Selected = TRUE;
 
-        // pokusime se pridat prvky ze skupiny vpravo/vlevo a pokud nic nenajdeme, tak dole/nahore
+        // try to add controls from the group to the right/left, otherwise use below/above
         BOOL found = FALSE;
         for (int dir = forceVertical ? esdDown : esdRight; dir <= esdUp; dir++)
         {
@@ -932,7 +934,7 @@ void CDialogData::SelectControlsGroup(HWND hDialog, HWND hControl, BOOL keepSele
                 found = TRUE;
                 iterator = index;
             }
-            // pokud jsme nasli prvky vpravo/vlevo, koncime
+            // stop once controls are found to the left/right
             if (dir == esdLeft && found)
                 break;
         }
@@ -946,20 +948,20 @@ void CDialogData::SelectControlsByCage(BOOL add, const RECT* cageR)
 
     int selected = 0;
 
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         RECT controlR;
         control->GetTRect(&controlR, TRUE);
 
         RECT myCageR = *cageR;
-        if (myCageR.top == myCageR.bottom) // nulova vyska klece musi take fachcit
+        if (myCageR.top == myCageR.bottom) // zero-height cages must also work
             myCageR.bottom = myCageR.top + 1;
-        if (myCageR.left == myCageR.right) // nulova sirka klece musi take fachcit
+        if (myCageR.left == myCageR.right) // zero-width cages must work as well
             myCageR.right = myCageR.left + 1;
-        if (controlR.left == controlR.right) // nulova sirka controlu musi take fachcit
+        if (controlR.left == controlR.right) // zero-width controls must work as well
             controlR.right = controlR.left + 1;
-        if (controlR.top == controlR.bottom) // nulova vyska controlu musi take fachcit
+        if (controlR.top == controlR.bottom) // zero-height controls must work as well
             controlR.top = controlR.bottom + 1;
 
         RECT dummy;
@@ -1004,7 +1006,7 @@ void CDialogData::OutlineControls(HWND hDialog, HDC hDC)
     int childIndex = 1;
     do
     {
-        // musim kreslit do parenta, pri kresleni do hwndDlg je ramecek prerusovany controly (DC dialogu je tam asi oclipovane, ci co)
+        // draw into the parent; drawing into hwndDlg produces a dashed frame (its DC is likely clipped)
         if (hChild != NULL)
         {
             RECT r;
@@ -1023,7 +1025,7 @@ void CDialogData::OutlineControls(HWND hDialog, HDC hDC)
             r.bottom = p2.y;
 
             BOOL isClipped = FALSE;
-            // pokud control obsahuje dummy texty, nebudeme pro ne detekovat zda nejsou orezane
+            // skip clipping detection for controls containing dummy texts
             BOOL isEmpty = (Controls[childIndex]->TWindowName[0] == 0);
             if (!isEmpty)
             {
@@ -1058,13 +1060,13 @@ void CDialogData::PaintSelection(HWND hDialog, HDC hDC)
         GetChildRectPx(hParent, hDialog, &r);
         PaintSelectionRect(hDC, &r, GetSelectionColor(FALSE));
     }
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
             continue;
 
-        // musim kreslit do parenta, pri kresleni do hwndDlg je ramecek prerusovany controly (DC dialogu je tam asi oclipovane, ci co)
+        // draw into the parent; drawing into hwndDlg produces a dashed frame (its DC is likely clipped)
         HWND hChild = GetControlHandle(hDialog, i);
         if (hChild != NULL)
         {
@@ -1096,7 +1098,7 @@ void CDialogData::PaintHighlight(HWND hDialog, HDC hDC)
     }
     else
     {
-        // musim kreslit do parenta, pri kresleni do hwndDlg je ramecek prerusovany controly (DC dialogu je tam asi oclipovane, ci co)
+        // draw into the parent; drawing into hwndDlg produces a dashed frame (its DC is likely clipped)
         HWND hChild = GetControlHandle(hDialog, HighlightIndex);
         if (hChild != NULL)
         {
@@ -1127,7 +1129,7 @@ void CDialogData::GetChildRectPx(HWND hParent, HWND hChild, RECT* r)
 BOOL CDialogData::SelCtrlsGetOuterRectPx(HWND hDialog, RECT* r)
 {
     BOOL first = TRUE;
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
@@ -1158,9 +1160,9 @@ BOOL CDialogData::SelCtrlsGetOuterRectPx(HWND hDialog, RECT* r)
 
 BOOL CDialogData::SelCtrlsGetOuterRect(RECT* r)
 {
-    // dohledame opsanej obdelnik
+    // locate the bounding rectangle
     BOOL first = TRUE;
-    for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+    for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
     {
         CControl* control = Controls[i];
         if (!control->Selected)
@@ -1192,7 +1194,7 @@ BOOL CDialogData::SelCtrlsGetOuterRect(RECT* r)
 void
 CDialogData::SelCtrlsEnlargeSelectionBox(RECT *box)
 {
-  for (int i = 1; i < Controls.Count; i++) // 0-ty prvek preskocime, obsahuje nazev dialogu
+  for (int i = 1; i < Controls.Count; i++) // skip index 0; it stores the dialog title
   {
     CControl *control = Controls[i];
     if (!control->Selected)

--- a/src/translator/datastr.cpp
+++ b/src/translator/datastr.cpp
@@ -138,7 +138,7 @@ BOOL CData::SaveStrings(HANDLE hUpdateRes)
         }
 
         BOOL result = TRUE;
-        if (strData->TLangID != MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL)) // resource neni "neutral", musime ho smaznout, aby ve vyslednem .SLG nebyly stringy dva
+        if (strData->TLangID != MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL)) // Remove non-neutral resource to avoid duplicating strings in the final .SLG
         {
             result = UpdateResource(hUpdateRes, RT_STRING, MAKEINTRESOURCE(strData->ID),
                                     strData->TLangID,

--- a/src/translator/dataui.cpp
+++ b/src/translator/dataui.cpp
@@ -12,7 +12,7 @@ void CData::FillTree()
 {
     HWND hTree = TreeWindow.GetTreeView();
 
-    SendMessage(hTree, WM_SETREDRAW, FALSE, 0); // zakazeme zbytecne kresleni behem pridavani polozek
+    SendMessage(hTree, WM_SETREDRAW, FALSE, 0); // disable unnecessary redraws while populating items
 
     TreeView_DeleteAllItems(hTree);
 
@@ -32,7 +32,7 @@ void CData::FillTree()
 
     if (DlgData.Count > 0)
     {
-        tvis.item.lParam = TREE_TYPE_NONE | TREE_TYPE_NONE_DIALOGS; // nadpis
+        tvis.item.lParam = TREE_TYPE_NONE | TREE_TYPE_NONE_DIALOGS; // section header
         tvis.item.pszText = (char*)"Dialog";
         tvis.item.cChildren = 1;
         tvis.item.state = 0;
@@ -72,7 +72,7 @@ void CData::FillTree()
 
     if (MenuData.Count > 0)
     {
-        tvis.item.lParam = TREE_TYPE_NONE | TREE_TYPE_NONE_MENUS; // nadpis
+        tvis.item.lParam = TREE_TYPE_NONE | TREE_TYPE_NONE_MENUS; // section header
         tvis.item.pszText = (char*)"Menu";
         tvis.item.cChildren = 1;
         tvis.item.state = 0;
@@ -113,7 +113,7 @@ void CData::FillTree()
 
     if (StrData.Count > 0)
     {
-        tvis.item.lParam = TREE_TYPE_NONE | TREE_TYPE_NONE_STRINGS; // nadpis
+        tvis.item.lParam = TREE_TYPE_NONE | TREE_TYPE_NONE_STRINGS; // section header
         tvis.item.pszText = (char*)"String Table";
         tvis.item.cChildren = 1;
         tvis.item.state = 0;
@@ -156,7 +156,7 @@ void CData::FillTree()
     TreeWindow.HMenuTreeItem = hMenu;
     TreeWindow.HStrTreeItem = hStr;
 
-    SendMessage(hTree, WM_SETREDRAW, TRUE, 0); // povolime prekreslovani
+    SendMessage(hTree, WM_SETREDRAW, TRUE, 0); // re-enable redraw
 }
 
 void CData::FillTexts(DWORD lParam)
@@ -189,7 +189,7 @@ void CData::FillTexts(DWORD lParam)
             swprintf_s(buffW, L"Texts for strings <%d>", (block - 1) << 4);
             SetWindowTextW(TextWindow.HWindow, buffW);
 
-            SendMessage(hListView, WM_SETREDRAW, FALSE, 0); // zakazeme zbytecne kresleni behem pridavani polozek
+            SendMessage(hListView, WM_SETREDRAW, FALSE, 0); // disable unnecessary redraws while inserting items
 
             CStrData* data = StrData[index];
             int pos = 0;
@@ -225,7 +225,7 @@ void CData::FillTexts(DWORD lParam)
             }
             if (pos > 0)
                 ListView_SetItemState(hListView, 0, LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED);
-            SendMessage(hListView, WM_SETREDRAW, TRUE, 0); // povolime prekreslovani
+            SendMessage(hListView, WM_SETREDRAW, TRUE, 0); // re-enable redraw
         }
         break;
     }
@@ -244,7 +244,7 @@ void CData::FillTexts(DWORD lParam)
             sprintf_s(buffA, "Preview for dialog %s", DataRH.GetIdentifier(id));
             SetWindowText(PreviewWindow.HWindow, buffA);
 
-            SendMessage(hListView, WM_SETREDRAW, FALSE, 0); // zakazeme zbytecne kresleni behem pridavani polozek
+            SendMessage(hListView, WM_SETREDRAW, FALSE, 0); // disable unnecessary redraws while inserting items
 
             CDialogData* data = DlgData[index];
             PreviewWindow.PreviewDialog(index);
@@ -289,7 +289,7 @@ void CData::FillTexts(DWORD lParam)
             }
             if (pos > 0)
                 ListView_SetItemState(hListView, 0, LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED);
-            SendMessage(hListView, WM_SETREDRAW, TRUE, 0); // povolime prekreslovani
+            SendMessage(hListView, WM_SETREDRAW, TRUE, 0); // re-enable redraw
         }
         break;
     }
@@ -309,7 +309,7 @@ void CData::FillTexts(DWORD lParam)
             sprintf_s(buffA, "Preview: click in this window to display menu %s", DataRH.GetIdentifier(id));
             SetWindowText(PreviewWindow.HWindow, buffA);
 
-            SendMessage(hListView, WM_SETREDRAW, FALSE, 0); // zakazeme zbytecne kresleni behem pridavani polozek
+            SendMessage(hListView, WM_SETREDRAW, FALSE, 0); // disable unnecessary redraws while inserting items
 
             CMenuData* data = MenuData[index];
             int pos = 0;
@@ -339,9 +339,9 @@ void CData::FillTexts(DWORD lParam)
                 lvi.mask = LVIF_TEXT;
                 lvi.pszText = buffW;
 
-                // vnorena submenu odhodime o level vpravo
+                // indent nested submenu entries
                 int j = 0;
-                while (j < data->Items[i].Level * 5) // pet mezer je jeste na dalsim miste
+                while (j < data->Items[i].Level * 5) // keep five spaces reserved for each indentation level
                 {
                     buffW[j] = ' ';
                     j++;
@@ -359,7 +359,7 @@ void CData::FillTexts(DWORD lParam)
             }
             if (pos > 0)
                 ListView_SetItemState(hListView, 0, LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED);
-            SendMessage(hListView, WM_SETREDRAW, TRUE, 0); // povolime prekreslovani
+            SendMessage(hListView, WM_SETREDRAW, TRUE, 0); // re-enable redraw
         }
         break;
     }

--- a/src/translator/dialogs.cpp
+++ b/src/translator/dialogs.cpp
@@ -14,7 +14,7 @@ const char* ERROR_TITLE = "Error";
 
 void CenterWindowToWindow(HWND hWnd, HWND hBaseWnd)
 {
-    // centrujeme k hlavnimu oknu
+    // Center relative to the main window
     RECT r1;
     GetWindowRect(hWnd, &r1);
     int w = r1.right - r1.left;
@@ -26,7 +26,7 @@ void CenterWindowToWindow(HWND hWnd, HWND hBaseWnd)
     SystemParametersInfo(SPI_GETWORKAREA, 0, &workArea, FALSE);
 
     RECT r2;
-    // pri minimalizovanem okne se centrujeme k obrazovce
+    // If the base window is minimized, center relative to the screen
     if (hBaseWnd != NULL && !IsIconic(hBaseWnd))
     {
         GetWindowRect(hBaseWnd, &r2);
@@ -63,7 +63,7 @@ BOOL CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (CenterToWindow && !IsIconic(HWindow) && !IsZoomed(HWindow))
         {
-            // centrujeme k hlavnimu oknu
+            // Center relative to the main window
             RECT r1;
             GetWindowRect(HWindow, &r1);
             int w = r1.right - r1.left;
@@ -77,7 +77,7 @@ BOOL CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             HWND hFrame = GetMsgParent();
 
             RECT r2;
-            // pri minimalizovanem okne se centrujeme k obrazovce
+            // If the frame window is minimized, center relative to the screen
             if (hFrame != NULL && !IsIconic(hFrame))
             {
                 GetWindowRect(hFrame, &r2);
@@ -102,7 +102,7 @@ BOOL CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         else
         {
-            // centrujeme k obrazovce
+            // Center relative to the screen
             RECT r;
             GetWindowRect(HWindow, &r);
             RECT workArea;
@@ -132,7 +132,7 @@ void BrowseFileName(HWND hParent, int editlineResID, const char* filter)
     strcpy_s(buf, filter);
     char* s = buf;
     ofn.lpstrFilter = s;
-    while (*s != 0) // vytvoreni double-null terminated listu
+    while (*s != 0) // build the double-null-terminated filter list
     {
         if (*s == '|')
             *s = 0;
@@ -218,19 +218,19 @@ CNewDialog::Validate(CTransferInfo &ti)
   ti.EditLine(IDC_NEW_DESTINATION, target, MAX_PATH);
   ti.EditLine(IDC_NEW_INCLUDE, include, MAX_PATH);
 
-  // oba soubory musi existovat a nesmi se jednat o stejny soubor
+  // Both files must exist and they cannot refer to the same path
 
-  // zkusim source otevrit pro cteni
+  // Try opening the source for reading
   HANDLE hSource = CreateFile(source, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
   if (hSource != INVALID_HANDLE_VALUE)
   {
-    // zkusim target otevrit pro zapis
+    // Try opening the destination for writing
     HANDLE hTarget = CreateFile(target, GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
     if (hTarget != INVALID_HANDLE_VALUE)
     {
       CloseHandle(hTarget);
 
-      // include musi jit cist
+      // The include file must be readable
       HANDLE hInclude = CreateFile(include, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
       if (hInclude != INVALID_HANDLE_VALUE)
       {
@@ -603,7 +603,7 @@ void CImportDialog ::Validate(CTransferInfo& ti)
     char project[MAX_PATH];
     ti.EditLine(IDC_IMPORT_PROJECT, project, MAX_PATH);
 
-    // zkusim project otevrit pro cteni
+    // Try opening the project file for reading
     HANDLE hProject = CreateFile(project, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
     if (hProject != INVALID_HANDLE_VALUE)
     {
@@ -618,12 +618,12 @@ void CImportDialog ::Validate(CTransferInfo& ti)
     }
 
     /*
-  // oba soubory musi existovat a nesmi se jednat o stejny soubor
-  // zkusim source otevrit pro cteni
+  // Both files must exist and they cannot refer to the same path
+  // Try opening the source for reading
   HANDLE hSource = CreateFile(original, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
   if (hSource != INVALID_HANDLE_VALUE)
   {
-    // zkusim target otevrit pro zapis
+    // Try opening the destination for writing
     HANDLE hTarget = CreateFile(translated, GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
     if (hTarget != INVALID_HANDLE_VALUE)
     {
@@ -861,7 +861,7 @@ BOOL CAgreementDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 void SetSmallDialogPosition(HWND hDlg, HWND hEditedDlg)
 {
-    // dialog umistime pod editovany dialog a pokud jsme mimo obrazovku, tak vpravo od nej
+    // Place the dialog below the edited dialog, and if that would leave the screen, move it to its right side instead.
     RECT r;
     GetWindowRect(hDlg, &r);
     RECT editedR;

--- a/src/translator/dialogs.h
+++ b/src/translator/dialogs.h
@@ -9,11 +9,11 @@ class CLayoutEditor;
 
 //*****************************************************************************
 //
-// horizontalne i vertikalne centrovany dialog k hlavnimu oknu
-// predek vsech dialogu
+// Dialog centered horizontally and vertically relative to the main window.
+// Serves as the base class for all translator dialogs.
 //
-// pokud je 'centerToWindow' rovno TRUE, je centrovany k hlavnimu oknu
-// jinak je centrovany k obrazovce
+// If 'centerToWindow' is TRUE the dialog is centered to the main window,
+// otherwise it is centered to the screen.
 //
 
 class CCommonDialog : public CDialog

--- a/src/translator/ignorelst.cpp
+++ b/src/translator/ignorelst.cpp
@@ -11,44 +11,44 @@
 #include "wndout.h"
 #include "datarh.h"
 
-/* popis formatu ignore.lst
-Overlap in dialog: 580: 590 x 591      --1. cislo je dialog ID, 2. a 3. jsou IDcka koliznich controlu
+/* ignore.lst format description
+Overlap in dialog: 580: 590 x 591      -- first number is the dialog ID; the second and third are IDs of the overlapping controls
 
-Clipped text in dialog: 500: 502       --1. cislo je dialog ID, 2. je ID controlu u nejz mame ignorovat oriznuti textu
+Clipped text in dialog: 500: 502       -- first number is the dialog ID; the second is the control ID whose clipping should be ignored
 
-Size of icon is small: 750: 776        --1. cislo je dialog ID, 2. je ID ikony, ktera je mala (16x16) a ne velka (32x32), tedy je treba ignorovat velikost a misto ni pouzit 10x10 dlg-units
+Size of icon is small: 750: 776        -- first number is the dialog ID; the second is the icon ID that stays small (16x16) instead of large (32x32), so the size check must be skipped and 10x10 dialog units used instead
 
-Hotkeys collision in dialog: 1000: 1004 x 1003  --1. cislo je dialog ID, 2. a 3. jsou IDcka koliznich controlu
+Hotkeys collision in dialog: 1000: 1004 x 1003  -- first number is the dialog ID; the second and third are IDs of controls with colliding hotkeys
 
-Too close to dialog frame: 2500: 2510  --1. cislo je dialog ID, 2. je ID controlu, ktery muze byt az tesne na okraji
+Too close to dialog frame: 2500: 2510  -- first number is the dialog ID; the second is the control ID that may sit right at the edge
 
-Misaligned controls in dialog: 150: 152 x 159  --1. cislo je dialog ID, 2. a 3. jsou IDcka nezarovnanych controlu
+Misaligned controls in dialog: 150: 152 x 159  -- first number is the dialog ID; the second and third are IDs of misaligned controls
 
-Different sized controls in dialog: 560: 567 x 571  --1. cislo je dialog ID, 2. a 3. jsou IDcka mirne se velikosti lisicich controlu
+Different sized controls in dialog: 560: 567 x 571  -- first number is the dialog ID; the second and third are IDs of controls whose sizes differ slightly
 
-Different spacing between controls: 2500: 2510  --1. cislo je dialog ID, 2. je ID controlu, ktery muze byt nepravidelne umisten mezi ostatnimi
+Different spacing between controls: 2500: 2510  -- first number is the dialog ID; the second is the control ID that may be spaced irregularly among its neighbours
 
-Not standard control size: 2500: 2510  --1. cislo je dialog ID, 2. je ID controlu, ktery muze byt nestandardne veliky
+Not standard control size: 2500: 2510  -- first number is the dialog ID; the second is the control ID that can have a non-standard size
 
-Incorrectly placed label: 560: 567 x 571  --1. cislo je dialog ID, 2. a 3. jsou IDcka nespravne zarovnaneho labelu a jeho controlu
+Incorrectly placed label: 560: 567 x 571  -- first number is the dialog ID; the second and third are IDs of a label and its control that may be misaligned
 
-Missing colon at end of text: 1017  -- 1. cislo je ID stringu, ve kterem proti originalu chybi dvojtecka na konci (diskcopy: "...drive %c:." v nemcine "Laufwerk %c: nicht bestimmen." - takze text ending je ruzny, ale chyba to neni)
+Missing colon at end of text: 1017  -- first number is the string ID that intentionally lacks the colon present in the source (diskcopy: "...drive %c:." versus German "Laufwerk %c: nicht bestimmen."), so the different ending is acceptable
 
-Inconsistent text endings in control: 535: 1153  --1. cislo je dialog ID, 2. je ID controlu, u ktereho se nekontroluje zakonceni textu proti originalni verzi (prvni az predposledni radek z odstavce)
+Inconsistent text endings in control: 535: 1153  -- first number is the dialog ID; the second is the control ID whose paragraph ending is not compared with the source (we allow differences from the first up to the penultimate line)
 
-Inconsistent text endings in string: 10401  -- 1. cislo je ID stringu, u ktereho se nekontroluje zakonceni textu proti originalni verzi
+Inconsistent text endings in string: 10401  -- first number is the string ID whose ending is not compared with the source version
 
-Inconsistent text beginnings in string: 10401  -- 1. cislo je ID stringu, u ktereho se nekontroluje zacatek textu proti originalni verzi
+Inconsistent text beginnings in string: 10401  -- first number is the string ID whose beginning is not compared with the source version
 
-Inconsistent control characters in string: 1210  -- 1. cislo je ID stringu, u ktereho se nekontroluji control-chars (\r, \n, \t) proti originalni verzi
+Inconsistent control characters in string: 1210  -- first number is the string ID whose control characters (\r, \n, \t) are not compared with the source version
 
-Inconsistent hot keys in string: 12137  -- 1. cislo je ID stringu, u ktereho se nekontroluji hotkeys ('&') proti originalni verzi
+Inconsistent hot keys in string: 12137  -- first number is the string ID whose hotkeys ('&') are not compared with the source version
 
-Control is progress bar: 2500: 2510  --1. cislo je dialog ID, 2. je ID controlu, na jehoz miste bude progress bar (proste nejde o static text, jak by se mohlo zdat)
+Control is progress bar: 2500: 2510  -- first number is the dialog ID; the second is the control ID that represents a progress bar (so it is not a static text as one might assume)
 
-Inconsistent format specifier in string: 1210  -- 1. cislo je ID stringu, u ktereho se nekontroluji format-specifiers (%d, %f, atd.) proti originalni verzi
+Inconsistent format specifier in string: 1210  -- first number is the string ID whose format specifiers (%d, %f, etc.) are not compared with the source version
 
-Inconsistent format specifier in control: 2500: 2510  --1. cislo je dialog ID, 2. je ID controlu, u ktereho se nekontroluji format-specifiers (%d, %f, atd.) proti originalni verzi
+Inconsistent format specifier in control: 2500: 2510  -- first number is the dialog ID; the second is the control ID whose format specifiers (%d, %f, etc.) are not compared with the source version
 */
 
 BOOL ProcessIgnoreLstLineAux(const char* overlapHeader, BOOL readCtrlID1, BOOL readCtrlID2, const char*& p,
@@ -120,16 +120,16 @@ BOOL CData::ProcessIgnoreLstLine(const char* line, const char* lineEnd, int row)
 {
     const char* p = line;
 
-    // preskocim uvodni whitespacy
+    // skip leading whitespace
     while (p < lineEnd && (*p == ' ' || *p == '\t'))
         p++;
 
-    // orizneme whitespacy na konci radku
+    // trim whitespace at the end of the line
     while ((lineEnd - 1) > line && (*(lineEnd - 1) == ' ' || *(lineEnd - 1) == '\t'))
         lineEnd--;
 
     BOOL ret = TRUE;
-    if (p < lineEnd) // zajimaji nas jen neprazdne radky
+    if (p < lineEnd) // only non-empty lines are relevant
     {
         CIgnoreLstItemType type;
         int dlgID = 0;
@@ -292,7 +292,7 @@ BOOL CData::LoadIgnoreLst(const char* fileName)
     char* ignoreLstData = (char*)malloc(ignoreLstDataSize + 1);
     if (ignoreLstData == NULL)
     {
-        TRACE_E("Nedostatek pameti");
+        TRACE_E("Out of memory");
         HANDLES(CloseHandle(hFile));
         return FALSE;
     }
@@ -308,7 +308,7 @@ BOOL CData::LoadIgnoreLst(const char* fileName)
         HANDLES(CloseHandle(hFile));
         return FALSE;
     }
-    ignoreLstData[ignoreLstDataSize] = 0; // vlozime terminator
+    ignoreLstData[ignoreLstDataSize] = 0; // append a terminator
 
     const char* lineStart = ignoreLstData;
     const char* lineEnd = ignoreLstData;

--- a/src/translator/ms_init.cpp
+++ b/src/translator/ms_init.cpp
@@ -3,8 +3,8 @@
 
 #include "precomp.h"
 
-// modul MS_INIT zajistuje volani konstruktoru statickych objektu ve spravnem poradi
-// a na urovni "lib" (pred "user")
+// the MS_INIT module ensures static constructors run in the proper order
+// and at the "lib" level (before "user")
 
 #pragma warning(3 : 4706) // warning C4706: assignment within conditional expression
 
@@ -47,7 +47,7 @@ void Initialize__Trace();
 // EnableExceptionsOn64
 //
 
-// Chceme se dozvedet o SEH Exceptions i na x64 Windows 7 SP1 a dal
+// Report SEH exceptions even on x64 Windows 7 SP1 and later
 // http://blog.paulbetts.org/index.php/2010/07/20/the-case-of-the-disappearing-onload-exception-user-mode-callback-exceptions-in-x64/
 // http://connect.microsoft.com/VisualStudio/feedback/details/550944/hardware-exceptions-on-x64-machines-are-silently-caught-in-wndproc-messages
 // http://support.microsoft.com/kb/976038

--- a/src/translator/precomp.cpp
+++ b/src/translator/precomp.cpp
@@ -3,9 +3,9 @@
 
 #include "precomp.h"
 
-// projekt ALTAPDB obsahuje tri skupiny modulu
+// the ALTAPDB project contains three groups of modules
 //
-// 1) modul precomp.cpp, ktery postavi altapdb.pch (/Yc"precomp.h")
-// 2) moduly vyuzivajici altapdb.pch (/Yu"precomp.h")
-// 3) commony a tasklist.cpp maji vlastni, automaticky generovany
+// 1) precomp.cpp builds altapdb.pch (/Yc"precomp.h")
+// 2) modules that use altapdb.pch (/Yu"precomp.h")
+// 3) commons and tasklist.cpp have their own automatically generated
 //    WINDOWS.PCH (/YX"windows.h" /Fp"$(OutDir)\WINDOWS.PCH")

--- a/src/translator/restart.cpp
+++ b/src/translator/restart.cpp
@@ -83,7 +83,7 @@ BOOL StartSalamander(const char* path)
     se.hwnd = FrameWindow.HWindow;
     se.nShow = SW_SHOWNORMAL;
     se.lpFile = path;
-    se.lpParameters = "-i 2"; // modra ikona
+    se.lpParameters = "-i 2"; // blue icon
     ShellExecuteEx(&se);
     return TRUE;
 }

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -3,22 +3,22 @@
 
 #pragma once
 
-extern int QuietValidate;                       // 0 = nebyl pouzit switch "-quiet-validate-???" prikazove radky, 1 = all, 2 = layout
-extern int QuietTranslate;                      // 0 = nebyl pouzit switch "-quiet-translate", 1 = byl pouzit
-extern int QuietMarkChAsTrl;                    // 0 = nebyl pouzit switch "-quiet-mark-changed-as-translated", 1 = byl pouzit
-extern char QuietImport[MAX_PATH];              // prazdny retezec = nic neimportovat; jinak cesta k adresari, ze ktereho mame provest import stareho prekladu, dalsi info viz QuietImportOnlyDlgLayout (na dalsim radku)
-extern int QuietImportOnlyDlgLayout;            // jen pri neprazdnem QuietImport: 0 = byl pouzit switch "-quiet-import", 1 = "-quiet-import-only-dialog-layout"
-extern char QuietImportTrlProp[MAX_PATH];       // prazdny retezec = nic neimportovat; jinak nazev projektu, ze ktereho mame provest import translation properties
-extern char QuietExportSLT[MAX_PATH];           // prazdny retezec = nic neexportovat; jinak adresar, do ktereho mame provest export SLT
-extern char QuietExportSDC[MAX_PATH];           // prazdny retezec = nic neexportovat; jinak adresar, do ktereho mame provest export SDC
-extern BOOL QuietExportSLTForDiff;              // TRUE = export do SLT bez version infa (pro porovnani dat mezi verzemi)
-extern char QuietImportSLT[MAX_PATH];           // prazdny retezec = nic neimportovat; jinak adresar, ze ktereho mame provest import SLT
-extern char QuietExportSpellChecker[MAX_PATH];  // prazdny retezec = nic neexportovat; jinak adresar, do ktereho mame provest export textu pro spell checker
-extern char OpenLayoutEditorDialogID[MAX_PATH]; // prazdny retezec = LE neotevirat; jinak ID dialogu, pro ktery mame otevrit LE
-extern BYTE* SharedMemoryCopy;                  // NULL = nedrzime kopii sdilene pameti
+extern int QuietValidate;                       // 0 = the "-quiet-validate-???" command-line switch was not used; 1 = all, 2 = layout only
+extern int QuietTranslate;                      // 0 = the "-quiet-translate" switch was not used, 1 = it was supplied
+extern int QuietMarkChAsTrl;                    // 0 = the "-quiet-mark-changed-as-translated" switch was not used, 1 = it was supplied
+extern char QuietImport[MAX_PATH];              // empty string = do not import anything; otherwise the directory with the legacy translation to import (see QuietImportOnlyDlgLayout below)
+extern int QuietImportOnlyDlgLayout;            // applies only when QuietImport is non-empty: 0 = "-quiet-import", 1 = "-quiet-import-only-dialog-layout"
+extern char QuietImportTrlProp[MAX_PATH];       // empty string = do not import; otherwise the project name whose translation properties should be imported
+extern char QuietExportSLT[MAX_PATH];           // empty string = do not export; otherwise the directory where the SLT should be exported
+extern char QuietExportSDC[MAX_PATH];           // empty string = do not export; otherwise the directory where the SDC should be exported
+extern BOOL QuietExportSLTForDiff;              // TRUE = export the SLT without version info (for comparing data between builds)
+extern char QuietImportSLT[MAX_PATH];           // empty string = do not import; otherwise the directory from which the SLT should be imported
+extern char QuietExportSpellChecker[MAX_PATH];  // empty string = do not export; otherwise the directory for exporting spell-checker text
+extern char OpenLayoutEditorDialogID[MAX_PATH]; // empty string = do not open the layout editor; otherwise ID of the dialog to open
+extern BYTE* SharedMemoryCopy;                  // NULL = we do not keep a copy of the shared memory block
 
-char* GetErrorText(DWORD error); // prevadi cislo chyby na string
-char* LoadStr(int resID);        // taha string z resourcu
+char* GetErrorText(DWORD error); // converts an error code to a human-readable string
+char* LoadStr(int resID);        // retrieves a string from resources
 
 BOOL GetTargetDirectory(HWND parent, const char* title, const char* comment,
                         char* path, const char* initDir);
@@ -49,7 +49,7 @@ inline BOOL SalIsWindowsVersionOrGreater(WORD wMajorVersion, WORD wMinorVersion,
                                                                                VER_MINORVERSION, VER_GREATER_EQUAL),
                                                            VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
 
-    SecureZeroMemory(&osvi, sizeof(osvi)); // nahrada za memset (nevyzaduje RTLko)
+    SecureZeroMemory(&osvi, sizeof(osvi)); // replacement for memset (does not require the CRT)
     osvi.dwOSVersionInfoSize = sizeof(osvi);
     osvi.dwMajorVersion = wMajorVersion;
     osvi.dwMinorVersion = wMinorVersion;

--- a/src/translator/trldata.h
+++ b/src/translator/trldata.h
@@ -8,7 +8,7 @@
 
 #define COMBOBOX_BASE_HEIGHT 13 // dialog units
 
-// z editwindow vytahne text a prealokuje string
+// Extract text from an edit window and preallocate the resulting string.
 BOOL GetStringFromWindow(HWND hWindow, wchar_t** string);
 
 wchar_t* dupstr(const wchar_t* s);
@@ -20,14 +20,14 @@ void FillControlsWithDummyValues(HWND hDlg);
 
 void RemoveAmpersands(wchar_t* buff);
 
-// orizne white-spaces z obou stran primo v 'str' a vraci 'str'
+// Trim whitespace on both ends of 'str' and return the same pointer.
 char* StripWS(char* str);
 
 BOOL DecodeString(const wchar_t* iter, int len, wchar_t** string);
 void EncodeString(wchar_t* iter, wchar_t** string);
 
-// vraci TRUE, pokud retezec obsahuje nejake prekladatelne znaky
-// (a neobsahuje text "_dummy_" -- tohle jsem zatim vyradil)
+// Return TRUE if the string contains translatable characters
+// (and does not contain the text "_dummy_"—currently not used).
 BOOL IsTranslatableControl(const wchar_t* text);
 
 COLORREF GetSelectionColor(BOOL clipped);
@@ -41,7 +41,7 @@ BOOL __GetNextChar(wchar_t& charValue, wchar_t*& start, wchar_t* end);
 
 enum CSearchDirection
 {
-    esdRight, // POZOR, zalezi na poradi prvku, vyuziva se v SelectControlsGroup()
+    esdRight, // The order matters; used by SelectControlsGroup().
     esdLeft,
     esdDown,
     esdUp
@@ -67,11 +67,11 @@ enum CAlignToPartEnum
 #pragma pack(4)
 struct CAlignToParams
 {
-    CAlignToOperationEnum Operation; // jaka operace se ma provest (move / resize)
-    BOOL MoveAsGroup;                // TRUE: zvolene polozky budou posouvany jako skupina, jinak individualne
-    CAlignToPartEnum SelPart;        // ke ktere casti oznacenych prvku se operace vztahuje
-    CAlignToPartEnum RefPart;        // vztazna cast na referencnim prvku
-    int HighlightIndex;              // kopie pro predani do jine instance translatoru
+    CAlignToOperationEnum Operation; // Operation to execute (move or resize).
+    BOOL MoveAsGroup;                // TRUE moves the selected items as a group, otherwise individually.
+    CAlignToPartEnum SelPart;        // Which part of the selected elements the operation references.
+    CAlignToPartEnum RefPart;        // Reference part on the anchor element.
+    int HighlightIndex;              // Copy used when passing to another translator instance.
 };
 #pragma pack(pop)
 
@@ -120,7 +120,7 @@ public:
     CStrData();
     ~CStrData();
 
-    // nacist 16 retezcu
+    // Load 16 strings for the specified table.
     BOOL LoadStrings(WORD group, const wchar_t* original, const wchar_t* translated, CData* data);
 
     //    BOOL GetTString(HWND hWindow, int index);
@@ -133,15 +133,15 @@ public:
 
 struct CMenuItem
 {
-    wchar_t* OString; // alokovany retezec
-    wchar_t* TString; // alokovany retezec
-    WORD ID;          // pokud se nejdena o POPUP, command polozky
+    wchar_t* OString; // Allocated original string.
+    wchar_t* TString; // Allocated translated string.
+    WORD ID;          // Menu ID (command items only; POPUP entries use zero).
 
-    WORD Flags; // zacatek/konec popupu nebo polozka
+    WORD Flags; // Start/end of a popup or a regular item.
 
     WORD State;        // translated/untranslated/...
-    int Level;         // stupen zanoreni
-    int ConflictGroup; // polozky se stejnym ConflictGroup budou posuzovany z hlediska konfliktu horkych klaves; 0 odpovida top-level, 1 prvnimu zanorenemu, atd
+    int Level;         // Nesting depth.
+    int ConflictGroup; // Items with the same ConflictGroup are compared for hotkey conflicts; 0 is top level, 1 is the first nested level, etc.
 };
 
 class CMenuData
@@ -150,19 +150,19 @@ public:
     WORD ID;
     WORD TLangID;
     TDirectArray<CMenuItem> Items;
-    int ConflictGroupsCount; // celkovy pocet unikatnich ConflictGroup
+    int ConflictGroupsCount; // Total number of unique ConflictGroup values.
 
-    BOOL IsEX; // MENUEX umime pouze "vyprasene" nacist v MUIMode, v Salamanderu ho nepouzivame, takze ukladani jsem nepsal
+    BOOL IsEX; // MENUEX is only partially supported in MUI mode; Salamander does not use it so saving is not implemented.
 
 public:
     CMenuData();
     ~CMenuData();
 
-    // parsuje resource
+    // Parse menu resources.
     BOOL LoadMenu(LPCSTR original, LPCSTR translated, CData* data);
     BOOL LoadMenuEx(LPCSTR original, LPCSTR translated, CData* data);
 
-    // vrati index polozky s odpovidajicim id nebo -1, pokud neexistuje
+    // Return the index of the item with the given ID or -1 if it is missing.
     int FindItemIndex(WORD id);
 };
 
@@ -192,10 +192,10 @@ public:
 
 enum CModifySelectionMode
 {
-    emsmSelectDialog,     // odvybere controly, vybere dialog
-    emsmSelectControl,    // odvybere dialog, vybere prvek; pokud je hControll NULL, pouze zrusi vyber
-    emsmToggleControl,    // odvybere dialog, zmeni vyber pro prvek
-    emsmSelectAllControls // odvybere dialog, vybere vsechny controly; hControl musi byt NULL
+    emsmSelectDialog,     // deselect controls and select the dialog itself
+    emsmSelectControl,    // deselect the dialog and select a control; if hControl is NULL the selection is cleared
+    emsmToggleControl,    // deselect the dialog and toggle the control selection state
+    emsmSelectAllControls // deselect the dialog and select every control; hControl must be NULL
 };
 
 enum CResizeControlsEnum
@@ -234,16 +234,16 @@ public:
     short TCX;
     short TCY;
 
-    wchar_t* ClassName;   // alokovany retezec
-    wchar_t* OWindowName; // alokovany retezec
-    wchar_t* TWindowName; // alokovany retezec
+    wchar_t* ClassName;   // Allocated string.
+    wchar_t* OWindowName; // Allocated string.
+    wchar_t* TWindowName; // Allocated string.
 
     // DLGITEMTEMPLATEEX support
     DWORD ExHelpID;
 
     WORD State; // translated/untranslated/...
 
-    BOOL Selected; // TRUE pokud je prvek vybrany v layout editoru, jinak FALSE
+    BOOL Selected; // TRUE when the control is selected in the layout editor.
 
 public:
     CControl();
@@ -251,7 +251,7 @@ public:
 
     void Clean();
 
-    // hluboka kopie
+    // Deep copy.
     void LoadFrom(CControl* src);
 
     BOOL ShowInLVWithControls(int i);
@@ -270,46 +270,47 @@ public:
     BOOL IsTContainedIn(CControl const* c) const;
     BOOL IsTVertContainedIn(CControl const* c) const;
 
-    // vraci obdelnik prvku v dlg units; pro combobox vraci zabalenou velikost
+    // Return the control rectangle in dialog units; for combo boxes return the collapsed size.
     void GetTRect(RECT* r, BOOL adjustZeroSize);
 
-    // vraci vzdalenost od obdelniku 'r' (v dlg units) ve smeru 'direction'
-    // pokud prvek nelezi v danem smeru, vraci -1
-    // pokud se zkouma smer vpravo, porovnavaji se vzdalenosti pravych stran obdelniku, atd.
+    // Return the distance from rectangle 'r' (dialog units) in the given direction.
+    // Returns -1 when the control is not located in that direction.
+    // When scanning to the right we compare the right edges, etc.
     int GetDistanceFromRect(const RECT* r, CSearchDirection direction);
 };
 
-// pridani nove transformace:
-// 1. doplnit novou polozku do 'CTransformationEnum'
-// 2. doplnit do CTransformation::TryMergeWith() - metoda se stara o slouceni stejnych operaci
-// 3. doplnit do CTransformation::SetTransformationWithNoParam() nebo SetTransformationWithIntParam() nebo SetTransformationWith2IntParams() - dle poctu parametru
-// 4. doplnit do CDialogData::ExecuteTransformation() - stara se o provedeni transformace
+// Adding a new transformation requires the following steps:
+// 1. Add a value to CTransformationEnum.
+// 2. Extend CTransformation::TryMergeWith(), which merges identical operations.
+// 3. Update CTransformation::SetTransformationWithNoParam(), SetTransformationWithIntParam(),
+//    or SetTransformationWith2IntParams() depending on the number of parameters.
+// 4. Update CDialogData::ExecuteTransformation(), which performs the transformation.
 enum CTransformationEnum
 {
     eloInit,
-    eloSelect,              // [] zmena Selection
-    eloMove,                // [deltaX, deltaY] posun controlu o 'deltaX' a 'deltaY'
-    eloResize,              // [edge, delta] zmena rozmeru controlu; 'edge' urcuje kterou hranou hybeme, 'delta' o kolik dlg units
-    eloResizeDlg,           // [horizontal, delta] zmena rozmeru dialogu; pokud je 'horizontal' TRUE, meni se sirka, jinak vyska dialogu o 'delta' dlg units
-    eloResizeControls,      // [resize] prikaz Resize upravi sirku nebo vysku prvku dle 'resize'
-    eloSizeToContent,       // [] prikaz Size to Content
-    eloSetSize,             // [width, height] zmena rozmeru controlu; 'width' a 'height' urcuji rozmery, pokud je hodnota -1, dany rozmer se nemeni
-    eloAlignTo,             // [] prikaz Align To
-    eloAlignControls,       // [edge] prikaz Align zarovna prvky na hranu 'edge'
-    eloCenterControls,      // [horizontal] prikaz Center centruje prvky navzajem vodorovne nebo svisle dle 'horizontal'
-    eloCenterControlsToDlg, // [horizontal] prikaz Center Controls To Dialog centruje prvky vuci dialogu vodorovne nebo svisle dle 'horizontal'
-    eloEqualSpacing,        // [horizontal, delta] prikaz Equal Spacing usporada prvky vodorovne nebo svisle dle 'horizontal' tak, aby byly oddeleny konstantni vzdalenosti 'delta'
-    eloNormalizeLayout,     // [wide] normalizuje layout standard dialogu; pokud je 'wide' TRUE, normalizuje na sirokouhly dialog, jinak na standardni
-    eloTemplateReset,       // [] vraceni se k originalnimu template
-    eloPreviewLayout,       // [] preview jine verze layoutu
+    eloSelect,              // [] Modify the current selection.
+    eloMove,                // [deltaX, deltaY] Move the control by the given offsets.
+    eloResize,              // [edge, delta] Resize the control; 'edge' selects the side, 'delta' is the amount in dialog units.
+    eloResizeDlg,           // [horizontal, delta] Resize the dialog; when 'horizontal' is TRUE adjust the width, otherwise the height.
+    eloResizeControls,      // [resize] Resize command adjusts control width or height according to 'resize'.
+    eloSizeToContent,       // [] Size to Content command.
+    eloSetSize,             // [width, height] Set explicit control size; -1 keeps the current dimension.
+    eloAlignTo,             // [] Align To command.
+    eloAlignControls,       // [edge] Align command snaps controls to the specified edge.
+    eloCenterControls,      // [horizontal] Center controls relative to each other horizontally or vertically.
+    eloCenterControlsToDlg, // [horizontal] Center controls relative to the dialog horizontally or vertically.
+    eloEqualSpacing,        // [horizontal, delta] Evenly distribute controls horizontally or vertically with spacing 'delta'.
+    eloNormalizeLayout,     // [wide] Normalize layout; 'wide' TRUE switches to wide dialogs, otherwise standard layout.
+    eloTemplateReset,       // [] Revert to the original template.
+    eloPreviewLayout,       // [] Preview a different layout version.
 };
 
 class CTransformation
 {
 public:
-    CTransformationEnum Transformation; // urcuje tranformaci
-    void* Params;                       // alokovane parametry transformace (lisi se dle 'Transformation')
-    int ParamsSize;                     // pocet alokovanych bajtu pro 'Params'
+    CTransformationEnum Transformation; // Type of transformation.
+    void* Params;                       // Allocated parameters (shape depends on 'Transformation').
+    int ParamsSize;                     // Number of bytes allocated for 'Params'.
 
 public:
     CTransformation();
@@ -358,11 +359,11 @@ public:
     short TCX;
     short TCY;
 
-    wchar_t* MenuName;  // alokovany retezec
-    wchar_t* ClassName; // alokovany retezec
+    wchar_t* MenuName;  // Allocated string.
+    wchar_t* ClassName; // Allocated string.
 
     WORD FontSize;
-    wchar_t* FontName; // alokovany retezec
+    wchar_t* FontName; // Allocated string.
 
     // DLGTEMPLATEEX support
     BOOL IsEX;
@@ -373,15 +374,15 @@ public:
     BYTE ExItalic;
     BYTE ExCharset;
 
-    // polozka na indexu 0 obsahuje nazev dialogu a Selected stav pro dialog
-    // polozky od indexu 1 jsou jiz vlastni controly dialogu
+    // Entry at index 0 contains the dialog caption and selection state.
+    // Entries starting at index 1 describe the dialog controls.
     TIndirectArray<CControl> Controls;
 
-    // index referencniho prvku pro prikaz AlignTo
-    int HighlightIndex; // -1: nic, 0: dlg, >0: controly
+    // Index of the reference element for the Align To command.
+    int HighlightIndex; // -1: nothing, 0: dialog, >0: control index.
 
-    // transformace provedena nad dialogem (a controly), aby bylo dosazeno aktualniho stavu
-    // slouzi k predani provedenych uprav do dalsi instance Translatoru
+    // Transformations applied to the dialog (and its controls) to reach the current layout.
+    // Used to pass edits to another Translator instance.
     CTransformation Transformation;
 
 public:
@@ -390,90 +391,86 @@ public:
 
     void Clean();
 
-    // parsuje resource
+    // Parse dialog resources.
     BOOL LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
                     BOOL* showExStyleWarning, BOOL* showDlgEXWarning,
                     CData* data);
 
-    // vytvori v bufferu sablonu pro Save nebo pro preview
-    // pokud je addProgress == TRUE, ukladaji se stavy prelozeni
-    // vraci puzitou velikost v bajtech
-    // pro preview nastavit 'forPreview' na TRUE, aby se custom classy nahradily za neco registrovaneho
-    // pokud ma natahnout dialog pres vsechny controly, nastavit 'extendDailog' na TRUE
+    // Build a template in the buffer for saving or previewing.
+    // When addProgress == TRUE the translation states are stored as well.
+    // Returns the number of bytes used.
+    // Set 'forPreview' to TRUE when generating preview data so custom classes are replaced with registered ones.
+    // Set 'extendDailog' to TRUE to stretch the dialog so it spans every control.
     DWORD PrepareTemplate(WORD* buff, BOOL addProgress, BOOL forPreview, BOOL extendDailog);
 
-    // v bufferu sablony prida a odebira styly nastavene na logickou 1
+    // Add or remove styles set to logical 1 within the template buffer.
     void TemplateAddRemoveStyles(WORD* buff, DWORD addStyles, DWORD removeStyles);
-    // v bufferu sablony nastavi souradnice
+    // Set coordinates in the template buffer.
     void TemplateSetPos(WORD* buff, short x, short y);
 
-    // vrati index okna s odpovidajicim id nebo -1, pokud neexistuje
+    // Return the index of the window with the requested ID, or -1 when missing.
     int FindControlIndex(WORD id, BOOL isDlgTitle);
 
-    // vraci index controlu Controls[controlIndex] v listview s texty pro dialog
-    // pokud v tom listview control neni, vraci FALSE
+    // Return the list-view index for Controls[controlIndex] that stores the dialog texts.
+    // Return FALSE when the control is not present in that list view.
     BOOL GetControlIndexInLV(int controlIndex, int* indexLV);
 
-    // hluboka kopie
+    // Deep copy.
     void LoadFrom(CDialogData* src, BOOL keepLangID = FALSE);
 
-    // nacte selection
+    // Load the selection state.
     void LoadSelectionFrom(CDialogData* src);
 
-    // vtati TRUE, pokud se layout zmenil proti originalu; urceno pro layout editor, kde muze dojit skutecne pouze k zmene layoutu
+    // Return TRUE when the layout differs from the original; used by the layout editor where only layout changes are possible.
     BOOL DoesLayoutChanged(CDialogData* orgDialogData);
-    BOOL DoesLayoutChanged2(CDialogData* orgDialogData); // robustnejsi verze slouzici pro import starych prekladu
+    BOOL DoesLayoutChanged2(CDialogData* orgDialogData); // more robust version for importing older translations
 
-    // vrati index sousedniho prvku (vuci prvku 'fromIndex') ve smeru 'dir' nebo -1 pokud zadny prvek nenalezne
-    // za sousedni prvek se povazuje nejblizsi prvek zasahujici do prumetu prvku 'fromIndex' danym smerem
-    // pokud je 'wideScan' TRUE, bude hledaci pruh rozsiren pres celou sirku/vysku dialogu
+    // Return the index of the neighbouring item relative to 'fromIndex' in direction 'dir'; return -1 when no such item exists.
+    // A neighbouring item is the closest control intersecting the projection of 'fromIndex' in the requested direction.
+    // When 'wideScan' is TRUE the scan band covers the full width/height of the dialog.
     int GetNearestControlInDirection(int fromIndex, CSearchDirection direction, BOOL wideScan);
 
-    // vraci TRUE, pokud prvek 'testIndex' patri do stejne skupiny jako prvej 'fromIndex'; jinak vraci FALSE
-    // stejnou skupinou se mysli vyber pomoc doubleclicku, napriklad tlacitek v rade
+    // Return TRUE when 'testIndex' belongs to the same group as 'fromIndex'; otherwise return FALSE.
+    // A group corresponds to double-click selection (for example a row of buttons).
     BOOL BelongsToSameSelectionGroup(int fromIndex, int testIndex);
 
-    // vraci TRUE, pokud oba prvky maji stejny horni nebo levy okraj (dle 'direction')
-    // jinak vraci FALSE
+    // Return TRUE when both controls share the same top or left edge (depending on 'direction'); otherwise return FALSE.
     BOOL ControlsHasSameGroupEdge(int fromIndex, int testIndex, CSearchDirection direction);
 
-    // vrati TRUE pokud dialog obsahuje control (nebo vice) za hranici dialogu
+    // Return TRUE when the dialog contains controls placed outside its bounds.
     BOOL HasOuterControls();
 
-    // vrati rozmery obdelniku opsaneho kolem prvku dialogu
-    // ignoruje vodorovne separatory a prvky lezici za hranici dialogu
-    // vraci TRUE v pripade uspechu, jinek FALSE
+    // Return the bounding rectangle encompassing dialog controls.
+    // Horizontal separators and controls outside the dialog bounds are ignored.
+    // Return TRUE on success; otherwise return FALSE.
     BOOL GetControlsRect(BOOL ignoreSeparators, BOOL ignoreOuterControls, RECT* r);
 
-    // vraci TRUE, pokud lze layout normalizovat, jinak vraci FALSE
-    // normalizace neni podporovana, pokud existuji vnejsi prvky lezici mimo pravou
-    // stranu dialogu - takove dialogy jsem u nas nenasel, takze nebyla potreba
-    // tuto situaci resit (i kdyz by to urcite slo vymyslet)
+    // Return TRUE when the layout can be normalized; otherwise return FALSE.
+    // Normalization is not supported when outer controls protrude beyond the right edge of the dialog.
+    // We have not encountered such dialogs, so the case was never implemented (even though it could be).
     BOOL CanNormalizeLayout();
 
-    // ucese layout do standardnich rozmeru
+    // Trim the layout to standard dimensions.
     void AdjustSeparatorsWidth(CStringList* errors);
     void NormalizeLayout(BOOL wide, CStringList* errors);
 
-    // naplni pole 'footer' indexem separatoru (pokud existuje, bude prvni polozkou pole) a indexama
-    // tlacitek umistenych na spodni hrande dialogu (casto jde o OK/Cancel/Yes/No/Skip/Overwrite/Help/...)
-    // na zacatku vycisti pole 'footer'
-    // vraci TRUE v pripade, ze stejnomerne rozmistena tlacitka (a pripadne separator) byla nalezena a vlozena do pole
-    // pripadne pokud zadna tlacitka nalezena nebyla; vraci FALSE pokud tlacitka nalezena byla, ale nejsou stejnomerne
-    // rozmistena - bude zobrazeno varovnai
+    // Populate 'footer' with the separator index (if present, it becomes the first entry) and with the indices
+    // of buttons located on the bottom edge of the dialog (typically OK/Cancel/Yes/No/Skip/Overwrite/Help/...).
+    // The method clears 'footer' before populating it.
+    // Return TRUE when evenly spaced buttons (and the optional separator) were found and stored, or when no buttons were found.
+    // Return FALSE when buttons were found but are not evenly spaced— a warning is displayed in that case.
     BOOL GetFooterSeparatorAndButtons(TDirectArray<DWORD>* footer);
 
-    // funkce prepoklada, ze indexy v poli 'footer' jsou serazeny podle x-ovych pozic prvku zleva doprava
+    // The function assumes the indices in 'footer' are sorted by the controls' X positions from left to right.
     void AdjustFooter(BOOL wide, TDirectArray<DWORD>* footer);
 
-    // prenese rozmery dialogu a controlu z Original do Translated
+    // Copy dialog and control dimensions from the Original set to the Translated one.
     void LoadOriginalLayout();
 
-    // selection related methods
-    // TODO: nasledujici skupina metod patrila puvodni objektu CSelectedControls pro spravu vybranych polozek
-    // postupne se ukazalo, ze jde o spatnou koncepci, protoze vyber by napriklad mel byt soucasti undo, takze
-    // jsme metody prenesli sem
-    // bylo by dobre je lepe/vice logicky pojmenovat misto prefixu SelCtrls
+    // Selection-related methods.
+    // TODO: the following methods originally belonged to CSelectedControls, which handled selection management.
+    // That concept proved impractical—selection should participate in undo—so the methods moved here.
+    // Renaming them to something more descriptive than the SelCtrls prefix would still be helpful.
 
     int GetSelectedControlsCount();
 
@@ -514,7 +511,7 @@ public:
     void PaintHighlight(HWND hDialog, HDC hDC);
 
     void GetChildRectPx(HWND hParent, HWND hChild, RECT* r);
-    // vrati opsany obdelnik kolem vybranych polozek
+    // Return the bounding rectangle around selected controls.
     BOOL SelCtrlsGetOuterRectPx(HWND hDialog, RECT* r);
     BOOL SelCtrlsGetOuterRect(RECT* r);
 
@@ -551,18 +548,18 @@ public:
     wchar_t Author[500];        // name of translation author
     wchar_t Web[500];           // web of translation author
     wchar_t Comment[500];       // comment for translation author
-    wchar_t HelpDir[100];       // nazev adresare s help soubory (slovensky preklad Salamandera muze pouzivat ceske helpy)
-    BOOL HelpDirExist;          // je v SLG obsazena polozka HelpDir? (jen u Salamanderiho .slg)
-    wchar_t SLGIncomplete[200]; // prazdne = preklad Salama i pluginu je kompletni, jinak link, kam smerovat uzivatele pri prvnim spusteni Salama v teto jazykove verzi (rekrutujeme nove prekladatele)
-    BOOL SLGIncompleteExist;    // je v SLG obsazena polozka SLGIncomplete? (jen u Salamanderiho .slg)
+    wchar_t HelpDir[100];       // Name of the directory with help files (the Slovak translation may reuse the Czech help).
+    BOOL HelpDirExist;          // Does the SLG contain the HelpDir entry? (Salamander .slg only.)
+    wchar_t SLGIncomplete[200]; // Empty = Salamander and plugins are fully translated; otherwise link shown on first launch of this language (recruiting translators).
+    BOOL SLGIncompleteExist;    // Does the SLG contain the SLGIncomplete entry? (Salamander .slg only.)
 
-    // CRC SLT souboru, ze ktereho se naposledy importilo nebo do ktereho se naposledy exportilo
-    // z tohoto SLG souboru, hodnoty:
-    // "not found" - promenna v SLG vubec neni,
-    // "none" - EN verze,
-    // "" - zmenena verze, ktera nebyla importena/exportena do SLT,
-    // "00000000 SLT" - tesne po exportu do SLT nebo importu z SLT,
-    // "00000000" - zmenena verze, ktera byla importena/exportena do SLT
+    // CRC of the SLT file last imported from or exported to by this SLG file
+    // Possible values:
+    // "not found" - the variable does not exist in the SLG,
+    // "none" - official English version,
+    // "" - modified version that has not been imported/exported to SLT,
+    // "00000000 SLT" - immediately after exporting to or importing from SLT,
+    // "00000000" - modified version that has been imported/exported to SLT
     wchar_t CRCofImpSLT[100];
 
 public:
@@ -586,12 +583,12 @@ public:
 
     void SLTDataChanged()
     {
-        if (wcscmp(CRCofImpSLT, L"none") == 0) // z "EN verze" udelame "zmenenou verzi, ktera nebyla importena/exportena do SLT"
+        if (wcscmp(CRCofImpSLT, L"none") == 0) // convert "official EN version" to "modified version that has not gone through SLT"
             lstrcpyW(CRCofImpSLT, L"");
         else
         {
             int len = wcslen(CRCofImpSLT);
-            if (len > 4 && wcscmp(CRCofImpSLT + len - 4, L" SLT") == 0) // z "tesne po exportu do SLT nebo importu z SLT" udelame "zmenenou verzi, ktera byla importena/exportena do SLT"
+            if (len > 4 && wcscmp(CRCofImpSLT + len - 4, L" SLT") == 0) // convert "just after export/import to SLT" to "modified version processed via SLT"
                 CRCofImpSLT[len - 4] = 0;
         }
     }
@@ -599,23 +596,23 @@ public:
     BOOL IsSLTDataAfterImportOrExport()
     {
         int len = wcslen(CRCofImpSLT);
-        return len > 4 && wcscmp(CRCofImpSLT + len - 4, L" SLT") == 0; // je "tesne po exportu do SLT nebo importu z SLT"?
+        return len > 4 && wcscmp(CRCofImpSLT + len - 4, L" SLT") == 0; // is it "just after export/import to SLT"?
     }
 
     void SetCRCofImpSLTIfFound(wchar_t* crc)
     {
-        if (wcscmp(CRCofImpSLT, L"not found") != 0) // pokud promenna v SLG je, nastavime ji novou hodnotu
+        if (wcscmp(CRCofImpSLT, L"not found") != 0) // update the stored value when the variable exists in the SLG
             lstrcpynW(CRCofImpSLT, crc, _countof(CRCofImpSLT));
     }
 
     BOOL IsSLTDataChanged()
     {
-        if (wcscmp(CRCofImpSLT, L"") == 0) // zmenena verze, ktera nebyla importena/exportena do SLT
+        if (wcscmp(CRCofImpSLT, L"") == 0) // modified version that has not been imported/exported to SLT
             return TRUE;
         wchar_t* s = CRCofImpSLT;
         while (*s >= L'0' && *s <= L'9' || *s >= L'a' && *s <= L'f' || *s >= L'A' && *s <= L'F')
             s++;
-        if (*s == 0 && (s - CRCofImpSLT) == 8) // CRC bez koncovky " SLT": zmenena verze, ktera byla importena/exportena do SLT
+        if (*s == 0 && (s - CRCofImpSLT) == 8) // CRC without the " SLT" suffix: modified version that was imported/exported to SLT
             return TRUE;
         return FALSE;
     }
@@ -629,23 +626,23 @@ struct CProgressItem
 
 enum CCheckLstItemType
 {
-    cltPropPgSameSize,       // kontrola, ze jsou vsechny property pages stejne velike
-    cltMultiTextControl,     // kontrola, jestli se do daneho controlu v dialogu vejdou vsechny uvedene texty (text primo v dialogu se kontroluje take)
-    cltMultiTextControlBold, // cltMultiTextControl, ale omeruje se BOLD fontem
-    cltDropDownButton,       // kontrola, jestli je tlacitko dost velke, aby se vesel symbol drop-down menu (sipka dolu vpravo na tlacitku)
-    cltMoreButton,           // kontrola, jestli je tlacitko dost velke, aby se vesel symbol more menu (dve sipky dolu vpravo na tlacitku)
-    cltComboBox,             // kontrola, jestli je combo box dost velky pro vsechny uvedene texty
-    cltAboutDialogTitle,     // specialitka pro About dialogy
-    cltProgressDialogStatus, // specialitka pro Progress dialog
-    cltStringsWithCSV,       // kontrola, ze sedi pocet carek v originalnim a prelozenem textu
+    cltPropPgSameSize,       // verify that every property page has the same size
+    cltMultiTextControl,     // verify that all listed strings fit into the dialog control (including the inline dialog text)
+    cltMultiTextControlBold, // same as cltMultiTextControl but measured with the bold font
+    cltDropDownButton,       // verify that the button is wide enough to display the drop-down glyph (down arrow on the right)
+    cltMoreButton,           // verify that the button is wide enough to display the more-menu glyph (double down arrows on the right)
+    cltComboBox,             // verify that the combo box fits all specified strings
+    cltAboutDialogTitle,     // special handling for About dialogs
+    cltProgressDialogStatus, // special handling for the Progress dialog
+    cltStringsWithCSV,       // verify that the number of commas matches in the original and translated text
 };
 
 struct CCheckLstItem
 {
     CCheckLstItemType Type;
-    WORD DialogID;             // cltPropPgSameSize+cltStringsWithCSV nepouziva
-    WORD ControlID;            // cltPropPgSameSize+cltStringsWithCSV nepouziva
-    TDirectArray<WORD> IDList; // cltDropDownButton+cltMoreButton+cltAboutDialogTitle+cltProgressDialogStatus nepouzivaji
+    WORD DialogID;             // unused by cltPropPgSameSize and cltStringsWithCSV
+    WORD ControlID;            // unused by cltPropPgSameSize and cltStringsWithCSV
+    TDirectArray<WORD> IDList; // unused by cltDropDownButton, cltMoreButton, cltAboutDialogTitle, and cltProgressDialogStatus
 
     CCheckLstItem() : IDList(5, 5)
     {
@@ -658,33 +655,33 @@ struct CCheckLstItem
 
 enum CIgnoreLstItemType
 {
-    iltOverlap,            // kolize dvou controlu v dialogu
-    iltClip,               // text controlu v dialogu je oriznuty, control je pro nej kratky
-    iltSmIcon,             // velikost ikony: ikona je mala, tedy pouzit velikost 10x10 dlg-units, misto std. 20x20
-    iltHotkeysInDlg,       // kolize dvou hotkeys controlu v dialogu
-    iltTooClose,           // prilis blizko okraji dialogu
-    iltMisaligned,         // dva controly v dialogu nejsou zarovnane
-    iltDiffSized,          // dva controly v dialogu se mirne lisi velikosti
-    iltDiffSpacing,        // control v dialogu je nepravidelne umisteny mezi ostatnimi controly
-    iltNotStdSize,         // control v dialogu je nestandardne veliky
-    iltIncorPlLbl,         // nespravne zarovnany label a jeho control
-    iltMisColAtEnd,        // chybejici ':' na konci stringu
-    iltInconTxtEnds,       // control v dialogu jehoz zakonceni textu se nema kontrolovat
-    iltInconStrEnds,       // zakonceni stringu se nema kontrolovat
-    iltInconStrBegs,       // zacatek stringu se nema kontrolovat
-    iltInconCtrlChars,     // nekonzistentni control-chars (\r, \n, \t)
-    iltInconHotKeys,       // nekonzistentni hotkeys ('&')
-    iltProgressBar,        // jde o progress bar (nejde o static text)
-    iltInconFmtSpecif,     // nekonzistentni format-specifiers (%d, %f, atd.)
-    iltInconFmtSpecifCtrl, // control v dialogu muze mit nekonzistentni format-specifiers (%d, %f, atd.)
+    iltOverlap,            // two dialog controls overlap
+    iltClip,               // dialog control text is clipped because the control is too short
+    iltSmIcon,             // icon size: icon is small; use 10x10 dialog units instead of the default 20x20
+    iltHotkeysInDlg,       // conflicting hotkeys for controls in a dialog
+    iltTooClose,           // too close to the dialog edge
+    iltMisaligned,         // two dialog controls are misaligned
+    iltDiffSized,          // two dialog controls differ slightly in size
+    iltDiffSpacing,        // dialog control spacing is irregular among neighbouring controls
+    iltNotStdSize,         // dialog control has a non-standard size
+    iltIncorPlLbl,         // misaligned label and its control
+    iltMisColAtEnd,        // missing ':' at the end of the string
+    iltInconTxtEnds,       // dialog control whose text ending should not be validated
+    iltInconStrEnds,       // string ending should not be validated
+    iltInconStrBegs,       // string beginning should not be validated
+    iltInconCtrlChars,     // inconsistent control characters (\r, \n, \t)
+    iltInconHotKeys,       // inconsistent hotkeys ('&')
+    iltProgressBar,        // indicates a progress bar (not static text)
+    iltInconFmtSpecif,     // inconsistent format specifiers (%d, %f, etc.)
+    iltInconFmtSpecifCtrl, // dialog control may contain inconsistent format specifiers (%d, %f, etc.)
 };
 
 struct CIgnoreLstItem
 {
     CIgnoreLstItemType Type;
     WORD DialogID;
-    WORD ControlID1; // pouziva vse krome: iltMisColAtEnd, iltInconStrEnds, iltInconStrBegs, iltInconCtrlChars, iltInconHotKeys,iltInconFmtSpecif
-    WORD ControlID2; // pouziva jen Type iltOverlap, iltHotkeysInDlg, iltMisaligned, iltDiffSized a iltIncorPlLbl
+    WORD ControlID1; // used for all types except iltMisColAtEnd, iltInconStrEnds, iltInconStrBegs, iltInconCtrlChars, iltInconHotKeys, iltInconFmtSpecif
+    WORD ControlID2; // used only for iltOverlap, iltHotkeysInDlg, iltMisaligned, iltDiffSized, and iltIncorPlLbl
 
     CIgnoreLstItem(CIgnoreLstItemType type, WORD dialogID, WORD controlID1, WORD controlID2)
     {
@@ -698,13 +695,13 @@ struct CIgnoreLstItem
 class CSalMenuSection
 {
 private:
-    char* TemplateName; // alokovany nazev sablony
+    char* TemplateName; // allocated template name
 
 public:
-    WORD SectionDialogID;         // dialog, se kterym je sekce svazana (0 pokud neni)
-    WORD SectionControlDialogID;  // control, se kterym je sekce svazana: ID dialogu s controlem (0 pokud neni)
-    WORD SectionControlControlID; // control, se kterym je sekce svazana: ID controlu (0 pokud neni)
-    TDirectArray<WORD> StringsID; // ID stringu sekce
+    WORD SectionDialogID;         // dialog associated with the section (0 if none)
+    WORD SectionControlDialogID;  // dialog that owns the associated control (0 if none)
+    WORD SectionControlControlID; // control ID linked with the section (0 if none)
+    TDirectArray<WORD> StringsID; // string IDs belonging to the section
 
 public:
     CSalMenuSection() : StringsID(20, 20)
@@ -750,7 +747,7 @@ enum CProjectSectionEnum
     pseNone,
     pseFiles,
     pseSettings,
-    pseDummy, // sekci ignorujeme
+    pseDummy, // ignore this section
     pseDialogsTranslation,
     pseMenusTranslation,
     pseStringsTranslation,
@@ -773,7 +770,7 @@ struct CBookmark
 class CMenuPreview
 {
 public:
-    TDirectArray<DWORD> Lines; // pro ktere radky output okna se ma seznam zobrazit
+    TDirectArray<DWORD> Lines; // output window lines for which the list should be shown
     TDirectArray<wchar_t*> Texts;
 
 public:
@@ -823,7 +820,7 @@ private:
     TDirectArray<CProgressItem> MenusTranslationStates;
     TDirectArray<CProgressItem> StringsTranslationStates;
 
-    TDirectArray<CBookmark> Bookmarks; // ID dialugu, ktere je treba znovu layoutovat (po importu stare konfigurace)
+    TDirectArray<CBookmark> Bookmarks; // dialog IDs that need to be relayouted (after importing an old configuration)
 
 public:
     TIndirectArray<CStrData> StrData;
@@ -833,19 +830,19 @@ public:
     TIndirectArray<CIgnoreLstItem> IgnoreLstItems;
     TIndirectArray<CCheckLstItem> CheckLstItems;
 
-    TDirectArray<WORD> Relayout; // ID dialugu, ktere je treba znovu layoutovat (po importu stare konfigurace)
+    TDirectArray<WORD> Relayout; // dialog IDs that need to be relayouted (after importing an old configuration)
 
-    TIndirectArray<CMenuPreview> MenuPreview; // slouzi k reseni kolizi v menu
+    TIndirectArray<CMenuPreview> MenuPreview; // used to resolve menu conflicts
 
-    // promenne pro enumaraci
+    // variables used during enumeration
     BOOL EnumReturn;
     HINSTANCE HTranModule;
     BOOL Importing;
     BOOL ShowStyleWarning;
     BOOL ShowExStyleWarning;
     BOOL ShowDlgEXWarning;
-    BOOL MUIMode;      // importujeme (nebo to jiz probehlo) MUI baliky pro lokalizaci W7
-    DWORD MUIDialogID; // unikatni ID, maji vyznam pouze pokud je 'MUIMode' TRUE
+    BOOL MUIMode;      // importing (or already imported) MUI packages for the Windows 7 localization
+    DWORD MUIDialogID; // unique ID that matters only when 'MUIMode' is TRUE
     DWORD MUIMenuID;
     DWORD MUIStringID;
 
@@ -853,20 +850,20 @@ public:
 
     CVersionInfo VersionInfo;
 
-    // cesta k souborum
+    // file paths
     char ProjectFile[MAX_PATH];
     char SourceFile[MAX_PATH];
     char TargetFile[MAX_PATH];
-    char IncludeFile[MAX_PATH]; // vsechna RH sloucena do jednoho souboru
+    char IncludeFile[MAX_PATH]; // all resource headers merged into a single file
     char SalMenuFile[MAX_PATH];
     char IgnoreLstFile[MAX_PATH];
     char CheckLstFile[MAX_PATH];
     char SalamanderExeFile[MAX_PATH];
-    char ExportFile[MAX_PATH]; // export as text: pro spellchecker
+    char ExportFile[MAX_PATH]; // export as text: consumed by the spellchecker
     char ExportAsTextArchiveFile[MAX_PATH];
     char FullSourceFile[MAX_PATH];
     char FullTargetFile[MAX_PATH];
-    char FullIncludeFile[MAX_PATH]; // vsechna RH sloucena do jednoho souboru
+    char FullIncludeFile[MAX_PATH]; // all resource headers merged into a single file
     char FullSalMenuFile[MAX_PATH];
     char FullIgnoreLstFile[MAX_PATH];
     char FullCheckLstFile[MAX_PATH];
@@ -874,7 +871,7 @@ public:
     char FullExportFile[MAX_PATH];
     char FullExportAsTextArchiveFile[MAX_PATH];
 
-    // stav stromu
+    // tree state
     BOOL OpenStringTables;
     BOOL OpenMenuTables;
     BOOL OpenDialogTables;
@@ -894,57 +891,57 @@ public:
     BOOL Load(const char* original, const char* translated, BOOL import);
     BOOL Save();
 
-    // nacte salmenu.mnu, ktere Petr generuje perl skriptem ze zdrojaku
-    // soubor obsahuje struktury nasich internich menu definovanych pomoci MENU_TEMPLATE_ITEM
+    // Load salmenu.mnu generated from the sources by Petr's Perl script
+    // the file stores our internal menu structures defined with MENU_TEMPLATE_ITEM
     BOOL LoadSalMenu(const char* fileName);
     BOOL ProcessSalMenuLine(const char* line, const char* lineEnd, int row, CSalMenuDataParserState* parserState);
 
-    // nacte ignore.lst: obsahuje prekryvy a orezy, ktere se maji ignorovat
+    // Load ignore.lst: describes overlaps and clipping issues that should be ignored
     BOOL LoadIgnoreLst(const char* fileName);
     BOOL ProcessIgnoreLstLine(const char* line, const char* lineEnd, int row);
 
-    // nacte check.lst: obsahuje veci, ktere se maji zkontrolovat (napr. shoda velikosti property-pages)
+    // Load check.lst: items that must be validated (for example matching property-page sizes)
     BOOL LoadCheckLst(const char* fileName);
     BOOL ProcessCheckLstLine(const char* line, const char* lineEnd, int row);
 
-    // natahne starou verzi prekladu a aplikuje ji na soucasna data
-    // pokud je 'trlPropOnly' TRUE, nactou se pouze translation propoerties
+    // Load an older translation and apply it to the current data
+    // When 'trlPropOnly' is TRUE only translation properties are loaded
     BOOL Import(const char* project, BOOL trlPropOnly, BOOL onlyDlgLayouts);
 
-    // naleje prelozenou cast dat do textoveho souboru,
-    // aby bylo mozne provest kontrolu gramatiky
+    // Dump the translated portion of data into a text file
+    // so that the proofreader can check the grammar
     BOOL Export(const char* fileName);
 
-    // export prelozenych textu do unicode souboru, ktery jsme schopny drzet/mergovat na CVSku
-    // nasledne ho muzeme zase importovat zpet
+    // Export translated strings to a Unicode file that we can store/merge in CVS
+    // the same file can be imported back later
     BOOL ExportAsTextArchive(const char* fileName, BOOL withoutVerInfo);
-    BOOL ImportTextArchive(const char* fileName, BOOL testOnly); // pokud je 'testOnly' TRUE, pouze se provede kontrola zda data v souboru lze 1:1 premapovat na nase data
+    BOOL ImportTextArchive(const char* fileName, BOOL testOnly); // if 'testOnly' is TRUE, only verify that the file content maps 1:1 to our data
 
-    // export velikosti dialogu a controlu, pouziva se pro zmenu .rc modulu obsahujicich
-    // zdrojaky resourcu pro anglickou jazykovou verzi, ktera se z .rc kompiluje
+    // Export dialog/control sizes; used when modifying .rc modules containing
+    // resource sources for the English language version compiled from the .rc
     BOOL ExportDialogsAndControlsSizes(const char* fileName);
 
-    // nasosne MS MUI jazykova balicky pro Win7 (CABy)
+    // Fetch Microsoft MUI language packages for Windows 7 (CAB files)
     BOOL LoadMUIPackages(const char* originalMUI, const char* translatedMUI);
 
-    // zkontroluje data; pokud je bude mozne ulozit, vrati TRUE; jinak vrati FALSE
+    // Validate data; return TRUE when it is safe to save, otherwise FALSE
     //    BOOL Validate();
 
-    // naplni strom pro volbu editovaneho resourcu
+    // Populate the tree used to pick the edited resource
     void FillTree();
 
     void UpdateNode(HTREEITEM hItem);
     void UpdateSelectedNode();
-    void UpdateAllNodes(); // nastavime translated stavy na treeview
-    void UpdateTexts();    // update list view v okne Texts
+    void UpdateAllNodes(); // update translated states in the tree view
+    void UpdateTexts();    // update the list view in the Texts window
 
-    // naplni okno texts
+    // populate the Texts window
     void FillTexts(DWORD lParam);
 
     void SetDirty(BOOL dirty = TRUE);
     BOOL IsDirty() { return Dirty; }
 
-    // vrati stav pro dane ID
+    // return the state for the specified ID
     TDirectArray<CProgressItem>* GetTranslationStates(CTranslationTypeEnum type);
     void CleanTranslationStates();
     BOOL AddTranslationState(CTranslationTypeEnum type, WORD id1, WORD id2, WORD state);
@@ -955,29 +952,29 @@ public:
     void AddRelayout(WORD id);
     BOOL RemoveRelayout(WORD id);
 
-    // prohleda data na zaklade kriterii v Config
+    // search data using criteria from Config
     void Find();
 
-    // hleda neprelozene retezce
+    // find untranslated strings
     void FindUntranslated(BOOL* completelyUntranslated = NULL);
 
-    // hleda dialogy, ktere je potreba po importu puvodniho prekladu znovu layoutovat
+    // find dialogs that require relayout after importing the original translation
     void FindDialogsForRelayout();
 
-    // hleda dialogy obsahujici controly lezici za hranici dialogu
+    // find dialogs with controls positioned outside the dialog bounds
     void FindDialogsWithOuterControls();
 
-    // hleda konflikty horkych klaves; vysledek laduje do okna Output
+    // find conflicting hotkeys; results are written to the Output window
     void ValidateTranslation(HWND hParent);
 
-    // hleda kolize IDecek v dialogu, vola se po nacteni projektu
-    // vysledky naleje do output window
+    // look for control-ID collisions within a dialog; called after loading the project
+    // dump results into the Output window
     void LookForIdConflicts();
 
-    // vsechny zmenene texty oznaci jako Translated
+    // mark all modified strings as Translated
     void MarkChangedTextsAsTranslated();
 
-    // vsechny dialogy nastavi na layout originalu
+    // reset every dialog to the original layout
     void ResetDialogsLayoutsToOriginal();
 
     int FindStrData(WORD id);
@@ -987,59 +984,59 @@ public:
     BOOL FindStringWithID(WORD id, int* index = NULL, int* subIndex = NULL, int* lvIndex = NULL);
     BOOL GetStringWithID(WORD id, wchar_t* buf, int bufSize);
 
-    // najde v CheckLstItems polozky pro zadany dialogID a controlID (anyControl==TRUE = libovolny control z dialogu)
+    // find CheckLstItems entries for the specified dialogID/controlID (anyControl==TRUE = any control in the dialog)
     BOOL GetItemFromCheckLst(WORD dialogID, WORD controlID, CCheckLstItem** multiTextOrComboItem,
                              CCheckLstItem** checkLstItem, BOOL anyControl = FALSE);
 
-    // najde v CheckLstItems polozky cltStringsWithCSV a overi, jestli 'strID' neni v jejich seznamu IDcek
+    // find cltStringsWithCSV entries in CheckLstItems and ensure 'strID' is not listed
     BOOL IsStringWithCSV(WORD strID);
 
-    // hleda problem v poli IgnoreLstItems, vraci TRUE pokud se ma problem ignorovat
-    // (byl nalezen)
+    // search IgnoreLstItems for the issue and return TRUE when it should be ignored
+    // (was found)
     BOOL IgnoreProblem(CIgnoreLstItemType type, WORD dialogID, WORD controlID1, WORD controlID2);
 
-    // zjisti, jestli se ma ignorovat velikost ikony a ma se pouzit rozmer male ikony (16x16)
+    // determine whether the icon size should be ignored and the small 16x16 size used
     BOOL IgnoreIconSizeIconIsSmall(WORD dialogID, WORD controlID);
 
-    // zjisti, jestli se ma ignorovat konflikt hotkeys mezi controly 'controlID1' a 'controlID2'
-    // v dialogu 'dialogID'
+    // determine whether the hotkey conflict between controlID1 and controlID2 should be ignored
+    // within dialog 'dialogID'
     BOOL IgnoreDlgHotkeysConflict(WORD dialogID, WORD controlID1, WORD controlID2);
 
-    // zjisti, jestli ma ignorovat, ze je control prilis blizko okraji dialogu
+    // determine whether a control being too close to the dialog edge should be ignored
     BOOL IgnoreTooCloseToDlgFrame(WORD dialogID, WORD controlID);
 
-    // zjisti, jestli jde o progress bar (je potreba ignorovat, ze jde o static)
+    // determine whether the control is a progress bar (ignore it being a static)
     BOOL IgnoreStaticItIsProgressBar(WORD dialogID, WORD controlID);
 
-    // zjisti, jestli ma ignorovat, ze je control nepravidelne umisten mezi ostatnimi controly v dialogu
+    // determine whether irregular placement among other controls should be ignored
     BOOL IgnoreDifferentSpacing(WORD dialogID, WORD controlID);
 
-    // zjisti, jestli ma ignorovat, ze je control nestandardne veliky
+    // determine whether a control with a non-standard size should be ignored
     BOOL IgnoreNotStdSize(WORD dialogID, WORD controlID);
 
-    // zjisti, jestli ma ignorovat, ze stringu chybi dvojtecka na konci
+    // determine whether a missing colon at the end of the string should be ignored
     BOOL IgnoreMissingColonAtEnd(WORD stringID);
 
-    // zjisti, jestli se nema kontrolovat zakonceni textu controlu v dialogu
-    // (napr. viceradkovy text rozdeleny do jednotlivych staticu po radcich)
+    // determine whether the ending of a control text in a dialog should be skipped
+    // (e.g., multi-line text split across multiple static controls)
     BOOL IgnoreInconTxtEnds(WORD dialogID, WORD controlID);
 
-    // zjisti, jestli se u stringu ma kontrolovat zakonceni
+    // determine whether a string ending should be validated
     BOOL IgnoreInconStringEnds(WORD stringID);
 
-    // zjisti, jestli se u stringu ma kontrolovat zacatek
+    // determine whether a string beginning should be validated
     BOOL IgnoreInconStringBegs(WORD stringID);
 
-    // zjisti, jestli se u stringu maji kontrolovat control-chars (\r, \n, \t)
+    // determine whether control characters (\r, \n, \t) should be validated
     BOOL IgnoreInconCtrlChars(WORD stringID);
 
-    // zjisti, jestli se u stringu maji kontrolovat hotkeys ('&')
+    // determine whether hotkeys ('&') should be validated
     BOOL IgnoreInconHotKeys(WORD stringID);
 
-    // zjisti, jestli se u stringu maji kontrolovat format-specifiers (%d, %f, atd.)
+    // determine whether format specifiers (%d, %f, etc.) should be validated
     BOOL IgnoreInconFmtSpecif(WORD stringID);
 
-    // zjisti, jestli ma ignorovat format-specifiers (%d, %f, atd.) u controlu
+    // determine whether format specifiers (%d, %f, etc.) should be ignored for a control
     BOOL IgnoreInconFmtSpecifCtrl(WORD dialogID, WORD controlID);
 
     void ToggleBookmark(DWORD treeItem, WORD textItem);
@@ -1048,7 +1045,7 @@ public:
     int GetBookmarksCount();
     BOOL FindBookmark(DWORD treeItem, WORD textItem);
 
-    // vraci TRUE, pokud ma nacteny projekt jako jazyk English
+    // return TRUE when the loaded project language is English
     BOOL IsEnglishProject();
 
 protected:
@@ -1070,7 +1067,7 @@ protected:
 
     BOOL CompareStrings(const wchar_t* _string, const wchar_t* _pattern);
 
-    // nacitani / ukladani projektu
+    // project loading/saving
     BOOL ProcessProjectLine(CProjectSectionEnum* section, const char* line, int row);
     BOOL WriteProjectLine(HANDLE hFile, const char* line);
 
@@ -1089,6 +1086,6 @@ BOOL IsControlClipped(const CDialogData* dialog, const CControl* control, HWND h
 
 void BufferKey(WORD vk, BOOL bExtended = FALSE, BOOL down = TRUE, BOOL up = TRUE);
 
-// p je bod v screen souradnich, pro ktery je vracen index child window
-// pokud neni nalezeno zadne okno, vraci se NULL
+// 'p' is a point in screen coordinates; return the index of the child window at that position
+// return NULL when no window is found
 HWND GetChildWindow(POINT p, HWND hDialog, int* index = NULL);

--- a/src/translator/trlipc.h
+++ b/src/translator/trlipc.h
@@ -8,8 +8,8 @@
 struct CSharedMemory
 {
     DWORD Version; // SHARED_MEMORY_VERSION
-    BOOL Taken;    // zdrojovy proces nastavi na FALSE, cilovy na TRUE po te, co si vytvori kopii dat do lokalniho bufferu; zdrojovy pak sdilenou pamet zahodi
-    DWORD Size;    // velikost sdilene pameti v bajtech
+    BOOL Taken;    // Source sets this to FALSE; the destination switches it to TRUE after copying the data to its local buffer, letting the source dispose of the shared memory
+    DWORD Size;    // Size of the shared memory block in bytes
                    // stream...
 };
 #pragma pack(pop)

--- a/src/translator/wndframe.h
+++ b/src/translator/wndframe.h
@@ -31,8 +31,8 @@ public:
 
     void SetTitle();
 
-    // pokud je mozne program zavrit, vrati TRUE; jinak vrati FALSE
-    // jsou-li zmenena data, nabidne ulozeni a provede ho
+    // Returns TRUE when it is safe to close the program; otherwise FALSE.
+    // Offers to save modified data and performs the save when required.
     BOOL QueryClose();
 
     void ProcessCmdLineParams(char* argv[], int p);

--- a/src/translator/wndout.cpp
+++ b/src/translator/wndout.cpp
@@ -30,7 +30,7 @@ void OnGoto(HWND hWnd)
         COutLine* outLine = &OutWindow.OutLines[lineIndex];
         if (outLine->Type != rteNone)
         {
-            // vyhledame spravny list v tree okne a zvolime ho
+            // find the appropriate entry in the tree window and select it
             LPARAM lParam = outLine->OwnerID;
             switch (outLine->Type)
             {
@@ -159,7 +159,7 @@ ListViewWindowProcW(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_TIMER:
     {
-        return 0; // pod W7 chodi nejakej cizi timer, ktery nam zpusobi ensure visible
+        return 0; // Windows 7 delivers a foreign timer that triggers EnsureVisible
     }
     }
     return DefListViewWndProc(hWnd, uMsg, wParam, lParam);
@@ -328,7 +328,7 @@ void COutWindow::Navigate(BOOL next)
             }
         }
     }
-    // -1 -> zadna selection
+    // -1 -> no selection
     ListView_SetItemState(HListView, newIndex, LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED);
     ListView_EnsureVisible(HListView, newIndex, FALSE);
     if (newIndex != -1)
@@ -342,7 +342,7 @@ COutWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_CREATE:
     {
-        // priradim oknu ikonku
+        // assign an icon to the window
         //      SendMessage(HWindow, WM_SETICON, ICON_BIG,
         //                  (LPARAM)LoadIcon(HInstance, MAKEINTRESOURCE(IDI_MAIN)));
 
@@ -414,7 +414,7 @@ COutWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_CLOSE:
     {
-        PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_CLOSE, 0); // bezpecny close-window
+        PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_CLOSE, 0); // safe window close
         return 0;
     }
 
@@ -458,7 +458,7 @@ COutWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     return CDRF_NOTIFYITEMDRAW;
 
                 if (cd->nmcd.dwDrawStage == CDDS_ITEMPREPAINT)
-                    return CDRF_NOTIFYSUBITEMDRAW; // pozadame si o zaslani notifikace CDDS_ITEMPREPAINT | CDDS_SUBITEM
+                    return CDRF_NOTIFYSUBITEMDRAW; // request a CDDS_ITEMPREPAINT | CDDS_SUBITEM notification
 
                 if (cd->nmcd.dwDrawStage == (CDDS_ITEMPREPAINT | CDDS_SUBITEM))
                 {

--- a/src/translator/wndout.h
+++ b/src/translator/wndout.h
@@ -30,10 +30,10 @@ struct COutLine
 {
     CMessageTypeEnum MsgType; // info, warning, error
     CResTypeEnum Type;        // dialog, menu, string
-    WORD OwnerID;             // ID dialogu, menu, skupiny stringu
-    WORD LVIndex;             // na ktere pozici je prezentovan v listview
-    WORD ControlID;           // jen dialogy: 0 = pouzit LVIndex, jinak je to ID controlu v dialogu
-    wchar_t* Text;            // drzeny text
+    WORD OwnerID;             // ID of the dialog, menu, or string group
+    WORD LVIndex;             // position where it is presented in the list view
+    WORD ControlID;           // dialogs only: 0 = use LVIndex; otherwise control ID in the dialog
+    wchar_t* Text;            // stored text
 };
 
 class COutWindow : public CWindow
@@ -50,11 +50,11 @@ public:
 
     void Clear();
 
-    void EnablePaint(BOOL enable); // pro optimalizaci plneni
+    void EnablePaint(BOOL enable); // optimize population
     void AddLine(const wchar_t* text, CMessageTypeEnum msgType, CResTypeEnum type = rteNone, WORD ownerID = 0, WORD lvIndex = 0, WORD controlID = 0);
 
     int GetLinesCount() { return OutLines.Count; }
-    // vrati pocet radek, ktere odkazuji na nejake objekty
+    // return the number of lines referencing actual objects
     int GetSelectableLinesCount() { return SelectableCount; }
 
     int GetErrorLines();

--- a/src/translator/wndprev.h
+++ b/src/translator/wndprev.h
@@ -13,7 +13,7 @@ extern const char* PREVIEWWINDOW_NAME;
 class CPreviewWindow : public CWindow
 {
 public:
-    HWND HDialog; // prave zobrazeny dialog
+    HWND HDialog; // Currently displayed dialog window.
     CDialogData* CurrentDialog;
     int CurrentDialogIndex;
     int HighlightedControlID;
@@ -26,21 +26,21 @@ public:
     CPreviewWindow();
     ~CPreviewWindow();
 
-    // zobrazi napis, ze nemuze zobrazit dialog
+    // Show a message stating that the dialog cannot be previewed.
     void SetInvalidPreview();
 
-    // zobrazi nahled na dialog urceny indexem
-    // pokud je index == -1, zhasne soucasny nahled
+    // Display a preview for the dialog identified by 'index'.
+    // Passing -1 clears the current preview.
     void PreviewDialog(int index);
 
-    // prekresli preview prave zobrazeneho dialogu
+    // Repaint the preview of the currently displayed dialog.
     void RefreshDialog();
 
-    // 'index' je do pole Data.MenuPreview
+    // 'index' addresses an entry in Data.MenuPreview.
     void PreviewMenu(int index);
 
-    // zobrazi dany prvek jako aktivni
-    // pokud je id == 0, zhasne se aktivni control
+    // Mark the specified control as active.
+    // Passing 0 clears the highlighted control.
     void HighlightControl(WORD id);
     BOOL GetHighlightControl() { return HighlightedControlID; }
 
@@ -49,7 +49,7 @@ public:
 protected:
     virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-    // zobrazi pod dialog info o vybranem controlu
+    // Show information about the selected control below the dialog preview.
     void DisplayControlInfo();
 
     void DisplayMenuPreview();

--- a/src/translator/wndrh.cpp
+++ b/src/translator/wndrh.cpp
@@ -104,7 +104,7 @@ CRHListBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
 
     case WM_CHAR:
-        return 0; // jinak hleda podle prvniho znaku, coz je nechtene
+        return 0; // Otherwise it searches by the first character, which we do not want
 
     case WM_KEYDOWN:
     {
@@ -211,7 +211,7 @@ CRHWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         GetFixedLogFont(&lf);
         HFont = HANDLES(CreateFontIndirect(&lf));
 
-        // priradim oknu ikonku
+        // Assign an icon to the window
         //      SendMessage(HWindow, WM_SETICON, ICON_BIG,
         //                  (LPARAM)LoadIcon(HInstance, MAKEINTRESOURCE(IDI_MAIN)));
         ListBox.CreateEx(WS_EX_STATICEDGE, "SysListView32", "", WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_VSCROLL | LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOCOLUMNHEADER | LVS_NOSORTHEADER,

--- a/src/translator/wndrh.h
+++ b/src/translator/wndrh.h
@@ -31,7 +31,7 @@ class CRHWindow : public CWindow
 public:
     CRHListBox ListBox;
     HFONT HFont;
-    int VisibleItems; // pocet zobrazenych polozek
+    int VisibleItems; // Number of items currently visible
 
 public:
     CRHWindow();

--- a/src/translator/wndtext.cpp
+++ b/src/translator/wndtext.cpp
@@ -63,7 +63,7 @@ EditWindowProcW(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (SkipNextCharacter)
         {
-            SkipNextCharacter = FALSE; // zamezime pipnuti
+            SkipNextCharacter = FALSE; // Prevent the audible beep
             return FALSE;
         }
 
@@ -74,7 +74,7 @@ EditWindowProcW(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 TextWindow.ChangeCurrentState(TRUE /*!controlPressed*/);
                 if (controlPressed)
-                    PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_GOTO_NEXT, 0); // dalsi polozka z Find
+                    PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_GOTO_NEXT, 0); // Advance to the next Find result
                 else
                     TextWindow.Navigate(TRUE);
             }
@@ -95,7 +95,7 @@ EditWindowProcW(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (wParam == 'A' && controlPressed && !shiftPressed && !altPressed)
         {
             SendMessage(hWnd, EM_SETSEL, 0, -1);
-            SkipNextCharacter = TRUE; // zamezime pipnuti
+            SkipNextCharacter = TRUE; // Prevent the audible beep
             return 0;
         }
 
@@ -188,7 +188,7 @@ CListView::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             TextWindow.ChangeCurrentState(/*!controlPressed*/ TRUE);
             if (controlPressed)
-                PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_GOTO_NEXT, 0); // dalsi polozka z Find
+                PostMessage(FrameWindow.HWindow, WM_COMMAND, CM_GOTO_NEXT, 0); // Advance to the next Find result
             else
                 TextWindow.Navigate(TRUE);
             return 0;
@@ -226,7 +226,7 @@ void CTextWindow::InitListView()
 
     lvc.mask = LVCF_FMT | LVCF_TEXT | LVCF_SUBITEM;
     lvc.fmt = LVCFMT_LEFT;
-    for (int i = 0; i < 3; i++) // vytvorim sloupce
+    for (int i = 0; i < 3; i++) // Create the columns
     {
         lvc.pszText = (char*)header[i];
         lvc.iSubItem = i;
@@ -340,7 +340,7 @@ void CTextWindow::SelectItem(WORD id)
         int groupIndex = LOWORD(lvi.lParam);
         int ctrlIndex = HIWORD(lvi.lParam);
 
-        if (ctrlIndex > 0) // na indexu 0 je titulek dialogu, ten nehledame
+        if (ctrlIndex > 0) // index 0 stores the dialog caption; skip it
         {
             CControl* control = Data.DlgData[groupIndex]->Controls[ctrlIndex];
             if (control->ID == id)
@@ -393,7 +393,7 @@ BOOL CTextWindow::CanLeaveText()
     }
     }
 
-    if (wcslen(str) == 0 && // prazdne texty nejsou povolene krome statickych textu v dialozich
+    if (wcslen(str) == 0 && // Empty strings are forbidden except for static dialog texts
         (Mode != TREE_TYPE_DIALOG || strIndex == 0 ||
          !Data.DlgData[groupIndex]->Controls[strIndex]->IsStaticText()))
     {
@@ -620,7 +620,7 @@ CTextWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CREATE:
     {
 
-        // priradim oknu ikonku
+        // Assign an icon to the window
         //      SendMessage(HWindow, WM_SETICON, ICON_BIG,
         //                  (LPARAM)LoadIcon(HInstance, MAKEINTRESOURCE(IDI_MAIN)));
 
@@ -648,10 +648,10 @@ CTextWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                                           HInstance,
                                           NULL);
 
-        // Stara particka common controls (listbox, editline, ...) funguji jinak nez nove controls
-        // jako je listview. U novych controlu se data drzi v unicode a prevadi pri setovani/ziskavani
-        // do/z controlu. U starych controlu zalezi na tom, jak control vytvorime (zda ansi pres
-        // CreateWindowEx() nebo UNICODE pres CreateWindowExW()
+        // Older common controls (list boxes, edit lines, etc.) behave differently from newer controls
+        // such as the list view. New controls keep their data in Unicode and convert it while values
+        // are set or read. For the old controls the encoding depends on whether we created the control
+        // via the ANSI CreateWindowEx() or the Unicode CreateWindowExW().
         DWORD otherFlags = 0;
         if (Data.MUIMode)
             otherFlags = ES_READONLY;
@@ -666,7 +666,7 @@ CTextWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DefEditWndProc = (WNDPROC)GetWindowLongW(HTranslated, GWL_WNDPROC);
         SetWindowLongW(HTranslated, GWL_WNDPROC, (LONG)EditWindowProcW);
 
-        SendMessage(HTranslated, EM_LIMITTEXT, 5000, 0); // omezim velikost pro buffery
+        SendMessage(HTranslated, EM_LIMITTEXT, 5000, 0); // Limit the buffer size
 
         HOriginalLabel = CreateWindowEx(0, "static", "&Original text:",
                                         WS_CHILDWINDOW | WS_VISIBLE | WS_CLIPSIBLINGS,
@@ -800,9 +800,9 @@ CTextWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                     GetStringFromWindow(HTranslated, &Data.MenuData[groupIndex]->Items[strIndex].TString);
 
-                    // vnorena submenu odhodime o level vpravo
+                    // Indent nested submenus one level to the right
                     int j = 0;
-                    while (j < Data.MenuData[groupIndex]->Items[strIndex].Level * 5) // pet mezer je jeste na dalsim miste
+                    while (j < Data.MenuData[groupIndex]->Items[strIndex].Level * 5) // Five spaces per level still leave room for the caption
                     {
                         buff[j] = ' ';
                         j++;
@@ -832,7 +832,7 @@ CTextWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     lvi.iSubItem = 1;
                     SendMessageW(ListView.HWindow, LVM_SETITEMW, 0, (LPARAM)&lvi);
 
-                    // na nultem indexu je nazev dialog; potom jsou controly
+                    // Index zero stores the dialog caption; the controls follow afterwards
                     HWND hWnd = PreviewWindow.HDialog;
                     if (strIndex > 0)
                         hWnd = GetDlgItem(hWnd, control->ID);

--- a/src/translator/wndtext.h
+++ b/src/translator/wndtext.h
@@ -47,7 +47,7 @@ public:
 
     void Navigate(BOOL down);
 
-    // provede kontrolu textu, zda je mozne prejit na jinou polozku
+    // Validate the current text before allowing the selection to move elsewhere
     BOOL CanLeaveText();
 
     void ChangeCurrentState(BOOL forceTranslated = FALSE);
@@ -63,7 +63,7 @@ public:
 protected:
     virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-    // naplni sloupce do ListView
+    // Populate the columns in the list view
     void InitListView();
     void OnContextMenu(int x, int y);
 };

--- a/src/translator/wndtree.cpp
+++ b/src/translator/wndtree.cpp
@@ -31,7 +31,7 @@ CTreeView::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (SkipNextCharacter)
         {
-            SkipNextCharacter = FALSE; // zamezime pipnuti
+            SkipNextCharacter = FALSE; // Prevent the audible beep
             return FALSE;
         }
         break;
@@ -44,7 +44,7 @@ CTreeView::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         case VK_RETURN:
         {
             TreeWindow.OnEditLayout();
-            SkipNextCharacter = TRUE; // zamezime pipnuti
+            SkipNextCharacter = TRUE; // Prevent the audible beep
             return 0;
         }
         }
@@ -203,7 +203,7 @@ void CTreeWindow::OnEditLayout()
     HTREEITEM hHit = TreeView_GetNextItem(GetTreeView(), NULL, TVGN_NEXTSELECTED);
     if (hHit != NULL)
     {
-        // vytahneme lParam z nechame rozbalit menu
+        // Retrieve the item's lParam so the context menu can react accordingly
         TVITEM tvi;
         tvi.mask = TVIF_HANDLE | TVIF_PARAM;
         tvi.hItem = hHit;
@@ -222,7 +222,7 @@ CTreeWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_CREATE:
     {
-        //      // priradim oknu ikonku
+        //      // Assign an icon to the window
         //      SendMessage(HWindow, WM_SETICON, ICON_BIG,
         //                  (LPARAM)LoadIcon(HInstance, MAKEINTRESOURCE(IDI_MAIN)));
 
@@ -303,7 +303,7 @@ CTreeWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 HTREEITEM hHit = TreeView_HitTest(GetTreeView(), &hti);
                 if (hHit != NULL && (hti.flags & TVHT_ONITEM) != 0)
                 {
-                    // vytahneme lParam z nechame rozbalit menu
+                    // Retrieve the item's lParam so the context menu can react accordingly
                     TVITEM tvi;
                     tvi.mask = TVIF_HANDLE | TVIF_PARAM;
                     tvi.hItem = hHit;

--- a/src/translator/wndtree.h
+++ b/src/translator/wndtree.h
@@ -43,10 +43,10 @@ public:
 
     void Navigate(BOOL down);
 
-    // vyhleda handle listu a vrati ho; pokud neexistuje, vrati NULL
+    // Find the tree item handle; returns NULL when the item does not exist.
     HTREEITEM GetItem(DWORD lParam);
 
-    // vrati LPARAM, ktery je pri pristim spustni mozno predat do GetItem, abychom dostali stejnou polozku
+    // Return the LPARAM that can be supplied to GetItem next time to obtain the same entry.
     DWORD GetCurrentItem();
 
     void SelectItem(HTREEITEM hItem);


### PR DESCRIPTION
## Summary
- translate the remaining Czech comments in the version-info serializer and dialog sizing helpers
- update window management comments across the translator UI (frame, layout, tree, text, RH windows) to clear English wording
- expand the Czech keyword list and grep the translator sources to confirm no untranslated comments remain

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2e95585748322bf9afc2153f09b6e