### PR TITLE
translated sheets.cpp and sheets.h

### DIFF
--- a/src/common/sheets.cpp
+++ b/src/common/sheets.cpp
@@ -44,7 +44,7 @@ void CElasticLayout::AddResizeCtrl(int resID)
         RECT r;
         GetWindowRect(hChild, &r);
 
-        // pokud je spodni hrana prvku vetsi nez SplitY, posuneme SplitY hranici
+        // if the control extends past the current SplitY divider, stretch SplitY to cover it
         POINT p = {r.right, r.bottom};
         ScreenToClient(HWindow, &p);
         if (p.y > SplitY)
@@ -67,7 +67,7 @@ CElasticLayout::FindMoveControls(HWND hChild, LPARAM lParam)
 {
     CElasticLayout* el = (CElasticLayout*)lParam;
 
-    // pokud prvek lezi pod SplitY, pridame ho do seznamu prvku, ktere budou posouvat
+    // if the control's top edge is at or below SplitY, add it to the moving-control list
     RECT r;
     GetWindowRect(hChild, &r);
     POINT p = {r.left, r.top};
@@ -87,7 +87,7 @@ void CElasticLayout::FindMoveCtrls()
 {
     EnumChildWindows(HWindow, FindMoveControls, (LPARAM)this);
 
-    // najdeme obalku vsech 'move' prvku
+    // compute the bounding rectangle that encloses every control scheduled to move
     RECT rEnvelope = {0};
     for (int i = 0; i < MoveCtrls.Count; i++)
     {
@@ -107,11 +107,11 @@ void CElasticLayout::FindMoveCtrls()
     POINT p = {rEnvelope.right, rEnvelope.bottom};
     ScreenToClient(HWindow, &p);
     int envelopeBottom = p.y;
-    // souradnice 'MoveCtrlsY' budou vztazene od spodni hrany obalky
+    // store each moving control's Y offset measured from the envelope's bottom edge
     for (int i = 0; i < MoveCtrls.Count; i++)
         MoveCtrls[i].Pos.y = envelopeBottom - MoveCtrls[i].Pos.y;
 
-    // pro prvky ResizeCtrls ulozime jejich vzdalenost spodni hrany od spodni hrany obalky
+    // cache how far each resizable control's bottom edge sits above that envelope
     for (int i = 0; i < ResizeCtrls.Count; i++)
     {
         if (ResizeCtrls[i].Pos.y == 0)
@@ -198,7 +198,7 @@ void CPropSheetPage::Init(const TCHAR* title, HINSTANCE modul, int resID,
     Flags = flags;
     Icon = icon;
 
-    ParentDialog = NULL; // nastavuje se z CPropertyDialog::Execute()
+    ParentDialog = NULL; // set from CPropertyDialog::Execute()
     ParentPage = NULL;
     HTreeItem = NULL;
     Expanded = NULL;
@@ -290,7 +290,7 @@ CPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         TransferData(ttDataToWindow);
         if (ElasticLayout != NULL)
             ElasticLayout->LayoutCtrls();
-        return TRUE; // chci focus od DefDlgProc
+        return TRUE; // request focus from DefDlgProc
     }
 
     case WM_SIZE:
@@ -309,7 +309,7 @@ CPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                                (GetKeyState(VK_SHIFT) & 0x8000) != 0);
             return TRUE;
         }
-        break; // F1 nechame propadnout do parenta
+        break; // allow F1 to fall through to the parent window
     }
 
     case WM_CONTEXTMENU:
@@ -321,26 +321,26 @@ CPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_NOTIFY:
     {
-        if (((NMHDR*)lParam)->code == PSN_KILLACTIVE) // deaktivace stranky
+        if (((NMHDR*)lParam)->code == PSN_KILLACTIVE) // PSN_KILLACTIVE (page deactivation)
         {
             if (ValidateData())
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, FALSE);
-            else // nepovolime deaktivaci stranky
+            else // keep the page from deactivating
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, TRUE);
             return TRUE;
         }
 
-        if (((NMHDR*)lParam)->code == PSN_SETACTIVE) // aktivace stranky
+        if (((NMHDR*)lParam)->code == PSN_SETACTIVE) // PSN_SETACTIVE (page activation)
         {
             if (ParentDialog != NULL && ParentDialog->LastPage != NULL)
-            { // zapamatovani posledni stranky
+            { // remember which page was last active
                 *ParentDialog->LastPage = ParentDialog->GetCurSel();
             }
             break;
         }
 
         if (((NMHDR*)lParam)->code == PSN_APPLY)
-        { // stisknuto tlacitko ApplyNow nebo OK
+        { // Apply Now or OK button pressed
             if (TransferData(ttDataFromWindow))
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, PSNRET_NOERROR);
             else
@@ -349,15 +349,15 @@ CPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
 
         if (((NMHDR*)lParam)->code == PSN_WIZFINISH)
-        { // stisknuto tlacitko Finish
-            // neprislo PSN_KILLACTIVE - provedu validaci
+        { // Finish button pressed
+            // PSN_KILLACTIVE was not sent, so validate explicitly
             if (!ValidateData())
             {
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, TRUE);
                 return TRUE;
             }
 
-            // obehnu vsechny stranky pro transfer
+            // iterate over every page to transfer its data
             for (int i = 0; i < ParentDialog->Count; i++)
             {
                 if (ParentDialog->At(i)->HWindow != NULL)
@@ -385,7 +385,7 @@ CPropSheetPage::CPropSheetPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam,
     CPropSheetPage* dlg;
     switch (uMsg)
     {
-    case WM_INITDIALOG: // prvni zprava - pripojeni objektu k dialogu
+    case WM_INITDIALOG: // first message: attach the object to the dialog
     {
         dlg = (CPropSheetPage*)((PROPSHEETPAGE*)lParam)->lParam;
         if (dlg == NULL)
@@ -397,25 +397,25 @@ CPropSheetPage::CPropSheetPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam,
         {
             dlg->HWindow = hwndDlg;
             dlg->Parent = ::GetParent(hwndDlg);
-            //--- zarazeni okna podle hwndDlg do seznamu oken
-            if (!WindowsManager.AddWindow(hwndDlg, dlg)) // chyba
+            // insert hwndDlg into the window list
+            if (!WindowsManager.AddWindow(hwndDlg, dlg)) // error
             {
                 TRACE_ET(_T("Unable to create dialog."));
                 return TRUE;
             }
-            dlg->NotifDlgJustCreated(); // zavedeno jako misto pro upravu layoutu dialogu
+            dlg->NotifDlgJustCreated(); // provides a hook for tweaking the dialog layout
         }
         break;
     }
 
-    case WM_DESTROY: // posledni zprava - odpojeni objektu od dialogu
+    case WM_DESTROY: // final message: detach the object from the dialog
     {
         dlg = (CPropSheetPage*)WindowsManager.GetWindowPtr(hwndDlg);
-        INT_PTR ret = FALSE; // pro pripad, ze ji nezpracuje
+        INT_PTR ret = FALSE; // in case it is not handled
         if (dlg != NULL && dlg->Is(otDialog))
         {
-            // Petr: posunul jsem dolu pod wnd->WindowProc(), aby behem WM_DESTROY
-            //       jeste dochazely zpravy (potreboval Lukas)
+            // Petr: I moved it below wnd->WindowProc() so that messages still arrive during WM_DESTROY
+            //       (Lukas needed that)
             // WindowsManager.DetachWindow(hwndDlg);
 
             ret = dlg->DialogProc(uMsg, wParam, lParam);
@@ -424,7 +424,7 @@ CPropSheetPage::CPropSheetPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam,
             if (dlg->IsAllocated())
                 delete dlg;
             else
-                dlg->HWindow = NULL; // informace o odpojeni
+                dlg->HWindow = NULL; // notify the object that the window was detached
         }
         return ret;
     }
@@ -441,11 +441,11 @@ CPropSheetPage::CPropSheetPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam,
 #endif
     }
     }
-    //--- zavolani metody DialogProc(...) prislusneho objektu dialogu
+    // finally call the dialog object's DialogProc(...)
     if (dlg != NULL)
         return dlg->DialogProc(uMsg, wParam, lParam);
     else
-        return FALSE; // chyba nebo message neprisla mezi WM_INITDIALOG a WM_DESTROY
+        return FALSE; // report an error or that the message missed the WM_INITDIALOG...WM_DESTROY window
 }
 
 //
@@ -511,14 +511,14 @@ int CPropertyDialog::GetCurSel()
 #define _TPD_IDC_CAPTION 3
 #define _TPD_IDC_RECT 4
 #define _TPD_IDC_OK 5
-// rozmery v dlg units
-#define _TPD_LEFTMARGIN 4  // odsazeni TreeView a Captionu od leveho okraje
-#define _TPD_TOPMARGIN 4   // odsazeni TreeView a Captionu od horniho okraje
-#define _TPD_TREE_W 100    // sirka TreeView
-#define _TPD_CAPTION_H 16  // vyska captionu
-#define _TPD_BUTTON_W 50   // sirka tlacitek
-#define _TPD_BUTTON_H 14   // vyska tlacitek
-#define _TPD_BUTTON_MARG 4 // rozestup mezi tlacitky
+// dimensions in dialog units
+#define _TPD_LEFTMARGIN 4  // offset of the TreeView and Caption from the left edge
+#define _TPD_TOPMARGIN 4   // offset of the TreeView and Caption from the top edge
+#define _TPD_TREE_W 100    // TreeView width
+#define _TPD_CAPTION_H 16  // caption height
+#define _TPD_BUTTON_W 50   // button width
+#define _TPD_BUTTON_H 14   // button height
+#define _TPD_BUTTON_MARG 4 // spacing between buttons
 
 CTPHCaptionWindow::CTPHCaptionWindow(HWND hDlg, int ctrlID)
     : CWindow(hDlg, ctrlID, ooAllocated)
@@ -568,7 +568,7 @@ CTPHCaptionWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         GetClientRect(HWindow, &r);
 
         int devCaps = GetDeviceCaps(hdc, NUMCOLORS);
-        if (devCaps == -1) // gradient pouzijeme pouze pri vice nez 256 barvach
+        if (devCaps == -1) // use the gradient only when the display offers more than 256 colors
         {
             HBRUSH hOldBrush = (HBRUSH)GetCurrentObject(hdc, OBJ_BRUSH);
 #define TPH_STEPS 100
@@ -609,7 +609,7 @@ CTPHCaptionWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             HFONT hSrcFont = (HFONT)HANDLES(GetStockObject(DEFAULT_GUI_FONT));
             GetObject(hSrcFont, sizeof(srcLF), &srcLF);
             srcLF.lfHeight = (int)(srcLF.lfHeight * 1.2);
-            // srcLF.lfWeight = FW_BOLD; // na vistach vypada bold dost hnusne + necitelne
+            // srcLF.lfWeight = FW_BOLD; // on Vista bold text looks quite ugly and unreadable
             hFont = CreateFontIndirect(&srcLF);
             hOldFont = (HFONT)SelectObject(hdc, hFont);
 
@@ -641,7 +641,7 @@ CTPHGripWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_SETCURSOR:
     {
-        // chceme pouze north-south kurzor
+        // force a north-south sizing cursor
         SetCursor(LoadCursor(NULL, IDC_SIZENS));
         return TRUE;
     }
@@ -666,9 +666,9 @@ CTreePropHolderDlg::CTreePropHolderDlg(HWND hParent, DWORD* windowHeight)
 INT_PTR
 CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-    // WM_INITDIALOG zavolame az ve chvili, kdy budeme znat rozmery okna
+    // defer forwarding WM_INITDIALOG until the window dimensions are known
     if (TPD != NULL && uMsg != WM_INITDIALOG)
-        TPD->DialogProc(uMsg, wParam, lParam); // forward zprav
+        TPD->DialogProc(uMsg, wParam, lParam); // forward messages
     switch (uMsg)
     {
     case WM_INITDIALOG:
@@ -695,12 +695,12 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (appIsThemed)
         {
             RECT rect = {0, 0, 4, 8};
-            MapDialogRect(HWindow, &rect); // ziskame baseUnitX a baseUnitY pro prepocet dlg-units na pixels
-            treeIndent = MulDiv(9 /* odsazeni v dlg-units */, rect.right /* baseUnitX */, 4);
+            MapDialogRect(HWindow, &rect); // retrieve baseUnitX and baseUnitY for converting dialog units to pixels
+            treeIndent = MulDiv(9 /* indentation in dlg-units */, rect.right /* baseUnitX */, 4);
             TreeView_SetIndent(HTreeView, treeIndent);
         }
 
-        // dlg units -> pixels conversions
+        // convert dialog units to pixels
         RECT r = {_TPD_BUTTON_W, _TPD_BUTTON_H, _TPD_LEFTMARGIN, _TPD_TOPMARGIN};
         MapDialogRect(HWindow, &r);
         ButtonSize.cx = r.left;
@@ -722,7 +722,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         GripWindow = new CTPHGripWindow(HWindow, _TPD_IDC_GRIP);
 
-        // default rozmery jsou minimalni - ulozime si je, abychom je nasledne mohli hlidat
+        // capture the minimal dimensions so we can enforce them later
         GetWindowRect(HWindow, &r);
         RECT cR;
         GetClientRect(HWindow, &cR);
@@ -734,9 +734,9 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                            MarginSize.cy + 1 + MarginSize.cy +
                            ButtonSize.cy + MarginSize.cy + marginH;
 
-        // nastavime uzivatelsky rozmer okna a provedeme layout prvku
+        // set the user-specified window size and lay out the controls
         int height = (int)*WindowHeight;
-        RECT clipR; // nechceme byt vetsi nez vyska obrazovky
+        RECT clipR; // ensure the dialog never exceeds the screen height
         MultiMonGetClipRectByWindow(HWindow, &clipR, NULL);
         if (height > clipR.bottom - clipR.top)
             height = clipR.bottom - clipR.top;
@@ -748,7 +748,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         LayoutControls();
         TreeView_EnsureVisible(HTreeView, TPD->At(TPD->StartPage)->HTreeItem);
 
-        TPD->DialogProc(uMsg, wParam, lParam); // forward zprav
+        TPD->DialogProc(uMsg, wParam, lParam); // forward messages
 
         break;
     }
@@ -761,7 +761,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                                (GetKeyState(VK_CONTROL) & 0x8000) != 0,
                                (GetKeyState(VK_SHIFT) & 0x8000) != 0);
         }
-        return TRUE; // F1 nenechame propadnout do parenta ani pokud nevolame WinLibHelp->OnHelp()
+        return TRUE; // prevent F1 from falling through to the parent even if WinLibHelp->OnHelp() is not invoked
     }
 
     case WM_COMMAND:
@@ -787,11 +787,11 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         case _TPD_IDC_OK:
         {
-            // musim provest validaci aktualni stranky
+            // validate the current page first
             if (!ChildDialog->ValidateData())
                 return TRUE;
 
-            // obehnu vsechny stranky pro transfer
+            // walk through all pages to transfer their data
             for (int i = 0; i < TPD->Count; i++)
                 if (TPD->At(i)->HWindow != NULL)
                     if (!TPD->At(i)->TransferData(ttDataFromWindow))
@@ -805,7 +805,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         }
 
-        // preposleme message, aby chodil enter na default tlacitka
+        // forward the command so Enter triggers the default buttons
         if (ChildDialog != NULL && HIWORD(wParam) == BN_CLICKED)
             ::SendMessage(ChildDialog->HWindow, uMsg, wParam, lParam);
 
@@ -873,7 +873,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_NCHITTEST:
     {
-        // Resize chceme pouze ve svyslem smeru
+        // restrict resizing to the vertical axis
         LRESULT ht = DefWindowProc(HWindow, uMsg, wParam, lParam);
         switch (ht)
         {
@@ -902,7 +902,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_GETMINMAXINFO:
     {
-        // Resize chceme pouze ve svyslem smeru
+        // restrict resizing to the vertical axis
         LPMINMAXINFO lpmmi = (LPMINMAXINFO)lParam;
         lpmmi->ptMinTrackSize.x = MinWindowSize.cx;
         lpmmi->ptMaxTrackSize.x = MinWindowSize.cx;
@@ -952,14 +952,14 @@ void CTreePropHolderDlg::LayoutControls()
     HDWP hdwp = HANDLES(BeginDeferWindowPos(8));
     if (hdwp != NULL)
     {
-        // treeview
+        // TreeView control
         hdwp = HANDLES(DeferWindowPos(hdwp, HTreeView, NULL,
                                       MarginSize.cx,
                                       MarginSize.cy,
                                       TreeWidth,
                                       sepY - 2 * MarginSize.cy,
                                       SWP_NOZORDER));
-        // caption
+        // caption bar
         int captionX = MarginSize.cx + TreeWidth + MarginSize.cx;
         HWND hCaption = GetDlgItem(HWindow, _TPD_IDC_CAPTION);
         hdwp = HANDLES(DeferWindowPos(hdwp, hCaption, NULL,
@@ -968,7 +968,7 @@ void CTreePropHolderDlg::LayoutControls()
                                       cRect.right - MarginSize.cx - captionX,
                                       CaptionHeight,
                                       SWP_NOZORDER));
-        // child dialog
+        // hosted child dialog
         int dlgX = MarginSize.cx + TreeWidth + MarginSize.cx;
         int dlgY = MarginSize.cy + CaptionHeight + MarginSize.cy;
         ChildDialogRect.left = dlgX;
@@ -981,7 +981,7 @@ void CTreePropHolderDlg::LayoutControls()
                                       ChildDialogRect.right - ChildDialogRect.left,
                                       ChildDialogRect.bottom - ChildDialogRect.top,
                                       SWP_NOZORDER));
-        // separator
+        // separator line
         HWND hSeparator = GetDlgItem(HWindow, _TPD_IDC_SEP);
         hdwp = HANDLES(DeferWindowPos(hdwp, hSeparator, NULL,
                                       MarginSize.cx,
@@ -1015,7 +1015,7 @@ void CTreePropHolderDlg::LayoutControls()
                                       ButtonSize.cx,
                                       ButtonSize.cy,
                                       SWP_NOZORDER));
-        // Grip (resize)
+        // resize grip
         HWND hGrip = GetDlgItem(HWindow, _TPD_IDC_GRIP);
         hdwp = HANDLES(DeferWindowPos(hdwp, hGrip, NULL,
                                       cRect.right - GripSize.cx,
@@ -1025,9 +1025,9 @@ void CTreePropHolderDlg::LayoutControls()
                                       SWP_NOZORDER));
 
         HANDLES(EndDeferWindowPos(hdwp));
-        // hack: v treeview/common controls je zrejme chyba: pokud naskoci diky obsahu scrollbar,
-        // neprekresli se selected polozka, takze je vpravo orizla; muze to souviset s full row
-        // select a jeste aero lookem; kazdopadne prekresleni pod W7 neblika, asi si ho muzeme dovolit
+        // hack: there is apparently a bug in the tree view/common controls: if a scrollbar appears because of the content,
+        // the selected item is not repainted, so it is cropped on the right; it may be related to full-row select and
+        // the Aero look. Repainting on Windows 7 does not flicker, so we can probably afford it.
         InvalidateRect(HTreeView, NULL, false);
     }
 }
@@ -1046,19 +1046,19 @@ int CTreePropHolderDlg::BuildAndMeasureTree()
         tvis.item.pszText = TPD->At(i)->Title;
         tvis.item.cchTextMax = (int)_tcslen(TPD->At(i)->Title);
         tvis.item.state = 0;
-        // POZOR: expandovatelne polozky zde musime expandovat, jinak nasledne TreeView_GetItemRect() vrati FALSE
-        // a nahodna data v obdelniku RECT r
+        // NOTE: expandable items must be expanded here, otherwise TreeView_GetItemRect() later returns FALSE
+        // and random data in the RECT r rectangle
         if (TPD->At(i)->Expanded != NULL)
             tvis.item.state |= TVIS_EXPANDED;
         tvis.item.stateMask = tvis.item.state;
         tvis.item.lParam = (LPARAM)TPD->At(i);
         TPD->At(i)->HTreeItem = TreeView_InsertItem(HTreeView, &tvis);
         RECT r;
-        // Radeji navratovou hodnotu TreeView_GetItemRect() vezmeme v potaz
+        // Account for the TreeView_GetItemRect() return value
         if (TreeView_GetItemRect(HTreeView, TPD->At(i)->HTreeItem, &r, TRUE) && r.right - r.left > width)
             width = r.right - r.left;
     }
-    // Nyni jiz muzeme pozavirat neexpandovane polozky
+    // Collapse any items that should not remain expanded
     for (int i = 0; i < TPD->Count; i++)
     {
         if (TPD->At(i)->Expanded != NULL && *TPD->At(i)->Expanded == FALSE)
@@ -1189,7 +1189,7 @@ int WinLibCopyText(WCHAR* buf, const TCHAR* text, int bufLen)
 int CTreePropDialog::AddItemEx(LPWORD& lpw, const TCHAR* className, WORD id, int x, int y, int cx, int cy,
                                UINT style, UINT exStyle, const TCHAR* text)
 {
-    lpw = lpdwAlign(lpw); // align DLGITEMTEMPLATEEX on DWORD boundary
+    lpw = lpdwAlign(lpw); // align the DLGITEMTEMPLATEEX structure on a DWORD boundary
     *(DWORD*)lpw = 0;     // helpID
     lpw += 2;
     *(DWORD*)lpw = exStyle; // exStyle
@@ -1224,7 +1224,7 @@ int CTreePropDialog::Execute(const TCHAR* buttonOK,
         RECT maxPageRect;
         SetRectEmpty(&maxPageRect);
 
-        // zjistim maximalni rozmery
+        // determine the maximum page dimensions
         for (int i = 0; i < Count; i++)
         {
             At(i)->ParentDialog = this;
@@ -1252,9 +1252,9 @@ int CTreePropDialog::Execute(const TCHAR* buttonOK,
             dlgStyle = *(DWORD*)(pageTemplate + 6); // style
             dlgCX = *(short*)(pageTemplate + 11);   // cx
             dlgCY = *(short*)(pageTemplate + 12);   // cy
-            WORD* t = pageTemplate + 13;            // menu, preskocime na tridu dialogu, a pak na jeho titulek
+            WORD* t = pageTemplate + 13;            // menu: skip to the dialog class and then to its title
             if (*t == 0)
-                t++; // zadne menu
+                t++; // no menu
             else
             {
                 if (*t == 0xffff)
@@ -1263,13 +1263,13 @@ int CTreePropDialog::Execute(const TCHAR* buttonOK,
                     t += wcslen((wchar_t*)t) + 1; // menu string
             }
             if (*t == 0)
-                t++; // zadna trida dialogu
+                t++; // no dialog class
             else
             {
                 if (*t == 0xffff)
-                    t += 2; // ID tridy dialogu
+                    t += 2; // dialog class ID
                 else
-                    t += wcslen((wchar_t*)t) + 1; // string tridy dialogu
+                    t += wcslen((wchar_t*)t) + 1; // dialog class string
             }
             dlgTitle = (WCHAR*)t;
 
@@ -1302,7 +1302,7 @@ int CTreePropDialog::Execute(const TCHAR* buttonOK,
                 maxPageRect.bottom = dlgCY;
         }
 
-        // vyska od spodniho okraje dialogu ke spodku TreeView a ChildDialogu
+        // distance from the dialog's bottom edge to the bottoms of the TreeView and child dialog
         int lowMargin = 2 * _TPD_TOPMARGIN + _TPD_BUTTON_H + _TPD_TOPMARGIN + _TPD_TOPMARGIN / 2;
         SIZE dialogSize;
         dialogSize.cx = _TPD_LEFTMARGIN + _TPD_TREE_W + _TPD_LEFTMARGIN + maxPageRect.right +
@@ -1310,8 +1310,8 @@ int CTreePropDialog::Execute(const TCHAR* buttonOK,
         dialogSize.cy = _TPD_TOPMARGIN + _TPD_CAPTION_H + _TPD_TOPMARGIN + maxPageRect.bottom +
                         lowMargin;
 
-        // postavim template dialogu: DLG nebo DLGEX, podle formatu stranek, musi byt shodny,
-        // jinak dochazi k orezu controlu a lisi se pisma stranek a zbytku tree property dialogu
+        // build the dialog template: DLG or DLGEX must match the page format,
+        // otherwise controls are clipped and fonts differ between the pages and the rest of the tree property dialog
 
         HGLOBAL hgbl;
 
@@ -1320,7 +1320,7 @@ int CTreePropDialog::Execute(const TCHAR* buttonOK,
         hgbl = GlobalAlloc(GMEM_ZEROINIT, 1024);
         if (!hgbl)
             return -1;
-        lpw = (LPWORD)GlobalLock(hgbl); // Define a dialog box.
+        lpw = (LPWORD)GlobalLock(hgbl); // define a dialog box
         *lpw++ = 1;
         *lpw++ = 0xffff;  // DLGEX
         *(DWORD*)lpw = 0; // helpID
@@ -1340,7 +1340,7 @@ int CTreePropDialog::Execute(const TCHAR* buttonOK,
         *lpw++ = 0; // predefined dialog box class (by default)
         lpwsz = (LPWSTR)lpw;
         lpw += WinLibCopyText(lpwsz, Caption, 100); // title
-        *lpw++ = 8;                                 // velikost fontu
+        *lpw++ = 8;                                 // font size
         *lpw++ = FW_NORMAL;                         // font weight
         *(BYTE*)lpw = FALSE;                        // is font italic?
         *((BYTE*)lpw + 1) = ANSI_CHARSET;           // font charset
@@ -1361,7 +1361,7 @@ int CTreePropDialog::Execute(const TCHAR* buttonOK,
         AddItemEx(lpw, _T("static"), _TPD_IDC_CAPTION,
                   0, 0, 0, 0,
                   WS_CHILD | WS_VISIBLE, 0, NULL);
-        // Static, ktery je behem initu nahrazen child dialogem
+        // placeholder static control that the child dialog replaces during initialization
         AddItemEx(lpw, _T("static"), _TPD_IDC_RECT,
                   0, 0, maxPageRect.right, maxPageRect.bottom,
                   WS_CHILD, 0, NULL);
@@ -1369,7 +1369,7 @@ int CTreePropDialog::Execute(const TCHAR* buttonOK,
         AddItemEx(lpw, _T("static"), _TPD_IDC_SEP,
                   0, 0, 0, 0,
                   WS_GROUP | WS_CHILD | WS_VISIBLE | SS_ETCHEDHORZ, 0, NULL);
-        // Spodni rada tlacitek
+        // row of buttons along the bottom edge
         AddItemEx(lpw, _T("button"), _TPD_IDC_OK,
                   0, 0, 0, 0,
                   WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON | WS_TABSTOP, 0, buttonOK);

--- a/src/common/sheets.h
+++ b/src/common/sheets.h
@@ -10,17 +10,17 @@ class CTreePropHolderDlg;
 
 struct CElasticLayoutCtrl
 {
-    HWND HCtrl; // handl prvku, ktery mame posouvat
-    POINT Pos;  // pozice prvku vuci spodni hrane opsane obalky
+    HWND HCtrl; // handle of the control that will be repositioned or resized
+    POINT Pos;  // cached position or offset relative to the moving envelope's bottom edge
 };
 
-// pomocna trida slouzici pro layout prvku dialogu na zaklade jeho velikosti
+// helper that keeps dialog controls aligned with the dialog's current size
 class CElasticLayout
 {
 public:
     CElasticLayout(HWND hWindow);
     void AddResizeCtrl(int resID);
-    // provede rozmisteni prvku
+    // perform the layout pass using the collected metrics
     void LayoutCtrls();
 
 protected:
@@ -29,25 +29,24 @@ protected:
     void FindMoveCtrls();
 
 protected:
-    // handle dialogu, jehoz layout zajistujeme
+    // handle of the dialog whose layout we manage
     HWND HWindow;
-    // delici linka, od ktere jiz prvky posouvame (lezi na spodni hrane ResizeCntrls)
-    // client souradnice v bodech
+    // divider from which controls begin to move (aligned with the bottom edge of the resizable controls)
+    // stored in client coordinates (pixels)
     int SplitY;
-    // prvky ktere s velikosti natahujeme (typicky listview)
+    // controls stretched as the window grows (commonly a list view)
     TDirectArray<CElasticLayoutCtrl> ResizeCtrls;
-    // docasne pole plnene z FindMoveCtrls; idealne by slo o lokalni promennou, ale
-    // pro pohodlne volani callbacku FindMoveControls (kam ho potrebujeme predat)
-    // ho umistuji jako atribut tridy
+    // temporary array populated by FindMoveCtrls; ideally it would be local, but
+    // we keep it as a member so the FindMoveControls callback invoked by EnumChildWindows can fill it
     TDirectArray<CElasticLayoutCtrl> MoveCtrls;
 };
 
 class CPropSheetPage : protected CDialog
 {
 public:
-    CDialog::SetObjectOrigin; // zpristupneni povolenych metod predku
+    CDialog::SetObjectOrigin; // expose selected base-class methods
     CDialog::Transfer;
-    CDialog::HWindow; // HWindow zustane take pristupne
+    CDialog::HWindow; // keep HWindow accessible too
 
     CPropSheetPage(const TCHAR* title, HINSTANCE modul, int resID,
                    DWORD flags /* = PSP_USETITLE*/, HICON icon,
@@ -79,13 +78,13 @@ protected:
     DWORD Flags;
     HICON Icon;
 
-    CPropertyDialog* ParentDialog; // vlastnik teto stranky
-    // pro TreeDialog
+    CPropertyDialog* ParentDialog; // owner of this page
+    // references used by the tree property dialog variant
     CPropSheetPage* ParentPage;
     HTREEITEM HTreeItem;
     BOOL* Expanded;
 
-    // pokud je ruzne od NULL, se zmenou velikosti dialogu menime layout prvku
+    // when set, reflows the controls whenever the dialog changes size
     CElasticLayout* ElasticLayout;
 
     friend class CPropertyDialog;
@@ -119,7 +118,7 @@ public:
     virtual int GetCurSel();
 
 protected:
-    HWND Parent; // parametry pro vytvareni dialogu
+    HWND Parent; // parameters used when creating the dialog
     HWND HWindow;
     HINSTANCE Modul;
     HICON Icon;
@@ -128,7 +127,7 @@ protected:
     DWORD Flags;
     PFNPROPSHEETCALLBACK Callback;
 
-    DWORD* LastPage; // posledni zvolena stranka (muze byt NULL, pokud nezajima)
+    DWORD* LastPage; // last selected page (can be NULL if not needed)
 
     friend class CPropSheetPage;
 };
@@ -137,8 +136,8 @@ protected:
 
 class CTreePropDialog;
 
-// sedivy stinovany pruh nad property sheet v tree variante PropertyDialog,
-// kde je zobrazen nazev aktualni stranky
+// gray shaded strip above the property sheet in the tree variant of PropertyDialog
+// that displays the title of the active page
 class CTPHCaptionWindow : protected CWindow
 {
 protected:
@@ -155,7 +154,7 @@ protected:
     virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 };
 
-// na grip controlu chceme pouze top-down kurzor
+// restrict the grip control to a vertical resize cursor
 class CTPHGripWindow : public CWindow
 {
 public:
@@ -165,7 +164,7 @@ protected:
     virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 };
 
-// dialog, ktery drzi treeview, stinovany nadpis a aktualni property sheet
+// host dialog that contains the tree view, shaded caption, and current property sheet
 class CTreePropHolderDlg : public CDialog
 {
 protected:
@@ -176,17 +175,17 @@ protected:
     RECT ChildDialogRect;
     int CurrentPageIndex;
     CPropSheetPage* ChildDialog;
-    int ExitButton; // idcko tlacitka, ktere ukoncilo dialog
+    int ExitButton; // ID of the button that closed the dialog
 
-    // rozmery v bodech
-    SIZE MinWindowSize;  // minimalni rozmery dialogu (urcene podle nejvetsiho child dlg)
-    DWORD* WindowHeight; // aktualni vyska dialogu
-    int TreeWidth;       // sirka treeview, pocitana na zaklade obsahu
-    int CaptionHeight;   // vyska titulku
-    SIZE ButtonSize;     // rozmery tlacitek na spodni hrane dialogu
-    int ButtonMargin;    // mezera mezi tlacitky
-    SIZE GripSize;       // rozmery resize gripu v pravem spodnim rohu dialogu
-    SIZE MarginSize;     // vodorovny a svisly okraj
+    // layout metrics in pixels
+    SIZE MinWindowSize;  // minimum dialog dimensions (determined by the largest child dialog)
+    DWORD* WindowHeight; // pointer to the current dialog height
+    int TreeWidth;       // tree-view width derived from the content
+    int CaptionHeight;   // caption height
+    SIZE ButtonSize;     // button dimensions along the dialog's bottom edge
+    int ButtonMargin;    // spacing between buttons
+    SIZE GripSize;       // resize grip dimensions for the bottom-right corner of the dialog
+    SIZE MarginSize;     // horizontal and vertical dialog margins
 
 public:
     CTreePropHolderDlg(HWND hParent, DWORD* windowHeight);
@@ -205,7 +204,7 @@ protected:
     friend class CTreePropDialog;
 };
 
-// datovy drzak stranek pro tree verzi PropertyDialog
+// container for pages in the tree variant of PropertyDialog
 class CTreePropDialog : public CPropertyDialog
 {
 protected:
@@ -235,6 +234,6 @@ protected:
     //    DLGTEMPLATE *DoLockDlgRes(int page);
     friend class CTreePropHolderDlg;
 
-    // pouze pro forwarding zprav z CTreePropHolderDlg
+    // used solely to forward messages from CTreePropHolderDlg
     virtual void DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam) {};
 };


### PR DESCRIPTION
## Summary
- reword the elastic layout comments in `sheets.cpp` so the SplitY divider and moving-control offsets are clearer
- fine-tune the `sheets.h` documentation to explain the cached positions and why the callback keeps the moving list as a member

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e90ee841dc83228660f38e597251a9