### PR TITLE
translated strutils.cpp and strutils.h

### DIFF
--- a/src/common/strutils.cpp
+++ b/src/common/strutils.cpp
@@ -32,23 +32,23 @@ int ConvertU2A(const WCHAR* src, int srcLen, char* buf, int bufSize, BOOL compos
     int res = WideCharToMultiByte(codepage, compositeCheck ? WC_COMPOSITECHECK : 0, src, srcLen, buf, bufSize, NULL, NULL);
     if (srcLen != -1 && res > 0)
         res++;
-    if (compositeCheck && res == 0 && GetLastError() != ERROR_INSUFFICIENT_BUFFER) // nektere codepage nepodporuji WC_COMPOSITECHECK
+    if (compositeCheck && res == 0 && GetLastError() != ERROR_INSUFFICIENT_BUFFER) // some code pages do not support WC_COMPOSITECHECK
     {
         res = WideCharToMultiByte(codepage, 0, src, srcLen, buf, bufSize, NULL, NULL);
         if (srcLen != -1 && res > 0)
             res++;
     }
     if (res > 0 && res <= bufSize)
-        buf[res - 1] = 0; // uspech, zakoncime string nulou
+        buf[res - 1] = 0; // success, terminate the string with a null character
     else
     {
         if (res > bufSize || res == 0 && GetLastError() == ERROR_INSUFFICIENT_BUFFER)
         {
             SetLastError(ERROR_INSUFFICIENT_BUFFER);
-            buf[bufSize - 1] = 0; // maly buffer, vratime chybu, ale castecne prelozeny string nechame v bufferu
+            buf[bufSize - 1] = 0; // buffer too small: report an error but keep the partially converted string in the buffer
         }
         else
-            buf[0] = 0; // jina chyba, zajistime prazdny buffer
+            buf[0] = 0; // other error: ensure the buffer is empty
         res = 0;
     }
     return res;
@@ -85,7 +85,7 @@ char* ConvertAllocU2A(const WCHAR* src, int srcLen, BOOL compositeCheck, UINT co
     int len = WideCharToMultiByte(codepage, flags = (compositeCheck ? WC_COMPOSITECHECK : 0), src, srcLen, NULL, 0, NULL, NULL);
     if (srcLen != -1 && len > 0)
         len++;
-    if (compositeCheck && len == 0) // nektere codepage nepodporuji WC_COMPOSITECHECK
+    if (compositeCheck && len == 0) // some code pages do not support WC_COMPOSITECHECK
     {
         len = WideCharToMultiByte(codepage, flags = 0, src, srcLen, NULL, 0, NULL, NULL);
         if (srcLen != -1 && len > 0)
@@ -104,7 +104,7 @@ char* ConvertAllocU2A(const WCHAR* src, int srcLen, BOOL compositeCheck, UINT co
         if (srcLen != -1 && res > 0)
             res++;
         if (res > 0 && res <= len)
-            txt[res - 1] = 0; // uspech, zakoncime string nulou
+            txt[res - 1] = 0; // success, terminate the string with a null character
         else
         {
             DWORD err = GetLastError();
@@ -142,16 +142,16 @@ int ConvertA2U(const char* src, int srcLen, WCHAR* buf, int bufSizeInChars, UINT
     if (srcLen != -1 && res > 0)
         res++;
     if (res > 0 && res <= bufSizeInChars)
-        buf[res - 1] = 0; // uspech, zakoncime string nulou
+        buf[res - 1] = 0; // success, terminate the string with a null character
     else
     {
         if (res > bufSizeInChars || res == 0 && GetLastError() == ERROR_INSUFFICIENT_BUFFER)
         {
             SetLastError(ERROR_INSUFFICIENT_BUFFER);
-            buf[bufSizeInChars - 1] = 0; // maly buffer, vratime chybu, ale castecne prelozeny string nechame v bufferu
+            buf[bufSizeInChars - 1] = 0; // buffer too small: report an error but keep the partially converted string in the buffer
         }
         else
-            buf[0] = 0; // jina chyba, zajistime prazdny buffer
+            buf[0] = 0; // other error: ensure the buffer is empty
         res = 0;
     }
     return res;
@@ -200,7 +200,7 @@ WCHAR* ConvertAllocA2U(const char* src, int srcLen, UINT codepage)
         if (srcLen != -1 && res > 0)
             res++;
         if (res > 0 && res <= len)
-            txt[res - 1] = 0; // uspech, zakoncime string nulou
+            txt[res - 1] = 0; // success, terminate the string with a null character
         else
         {
             DWORD err = GetLastError();
@@ -283,12 +283,12 @@ LPTSTR FindString( // Return value: pointer to matched substring of text, or nul
   char buf[10];
   WCHAR *s1, *s2, *s3 = L"D:\\Á";
   res = ConvertU2A(s1 = L"", -1, buf, 10, TRUE);
-  res = ConvertU2A(s1 = L"ahoj", 0, buf, 10, TRUE);
-  res = ConvertU2A(s1 = L"ahoj", -1, buf, 5, TRUE);
-  res = ConvertU2A(s1 = L"ahoj", -1, buf, 4, TRUE);
-  res = ConvertU2A(s1 = L"ahoj", 4, buf, 5, TRUE);
-  res = ConvertU2A(s1 = L"ahoj", 4, buf, 4, TRUE);
-  res = ConvertU2A(s1 = L"ahoj", 4, buf, 3, TRUE);
+  res = ConvertU2A(s1 = L"hello", 0, buf, 10, TRUE);
+  res = ConvertU2A(s1 = L"hello", -1, buf, 5, TRUE);
+  res = ConvertU2A(s1 = L"hello", -1, buf, 4, TRUE);
+  res = ConvertU2A(s1 = L"hello", 4, buf, 5, TRUE);
+  res = ConvertU2A(s1 = L"hello", 4, buf, 4, TRUE);
+  res = ConvertU2A(s1 = L"hello", 4, buf, 3, TRUE);
   res = ConvertU2A(s1 = L"D:\\\x0061\x0308", -1, buf, 10, TRUE);  // L"D:\\\x00e4"
   res = ConvertU2A(s2 = L"D:\\á", -1, buf, 4);
   res = ConvertU2A(s1 = L"D:\\\xfb01-\x0061\x0308-\x00e4.txt", -1, buf, 10, TRUE);
@@ -298,24 +298,24 @@ LPTSTR FindString( // Return value: pointer to matched substring of text, or nul
   WCHAR *f = FindString(LOCALE_USER_DEFAULT, 0, s1, -1, L"fi", -1, &fLen);
   f = FindString(LOCALE_USER_DEFAULT, 0, s1, -1, L"f", -1, &fLen);
   f = FindString(LOCALE_USER_DEFAULT, 0, s1, -1, L"\x00e4", -1, &fLen);
-  f = FindString(LOCALE_USER_DEFAULT, 0, s1, -1, L"a", -1, &fLen);  // NEFUNGUJE !!!
+  f = FindString(LOCALE_USER_DEFAULT, 0, s1, -1, L"a", -1, &fLen);  // DOES NOT WORK!!!
   WCHAR *ss = wcsstr(s1, L"\x00e4");
-/ *  
-procist X:\ZUMPA\!\unicode\ch05.pdf - jak vubec ma vypadat to hledani v Unicode ???
+ / *
+ read X:\ZUMPA\!\unicode\ch05.pdf - what is the expected approach to searching in Unicode?
 
-Nekam odswapnout + casem proverit + odladit:
-Some time ago I implemented a FindString function which in most cases takes only O(n) time (around 1.5*n CompareString
-calls most of which return immediately). In the end I didn't use it because I wasn't sure whether the relevant statement
-in the CompareString documentation can be relied on in a strict sense: "If the two strings are of different lengths,
+ Move this elsewhere for now and later verify and fine-tune:
+Some time ago I implemented a FindString function that in most cases runs in only O(n) time (around 1.5 * n CompareString
+calls, most of which return immediately). In the end I didn't use it because I wasn't sure whether the relevant statement
+in the CompareString documentation can be trusted in the strict sense: "If the two strings are of different lengths,
 they are compared up to the length of the shortest one. If they are equal to that point, then the return value will
 indicate that the longer string is greater." More specifically, the function fails for TCHAR strings that are lexically
 before any of their substrings (from the beginning). For example, when looking for "á" = {U+00E1}, the function will not
-find the "a?" = {U+0061, U+0301} representation, if it sorts before "a" = {U+0061} in the specified locale. In other
-words: The function assumes that CompareString(lcid, flags, string, m, string, n never returns CSTR_GREATER_THAN if
-m <= n and the strings agree in the first m TCHARs.
+find the "a?" = {U+0061, U+0301} representation if it sorts before "a" = {U+0061} in the specified locale. In other
+words, the function assumes that CompareString(lcid, flags, string, m, string, n) never returns CSTR_GREATER_THAN if
+m <= n and the strings match in the first m TCHARs.
 
-Mozna by se hodilo pouzit "StringInfo Class", ktery umi rozebrat retezec
-na zobrazitelne znaky (sekvence WCHARu odpovidajici jednomu zobrazenemu znaku).
+ Maybe it would be useful to use the "StringInfo Class", which can break the string down
+ into displayable characters (sequences of WCHARs that correspond to one rendered character).
 
 * /
 
@@ -330,12 +330,12 @@ na zobrazitelne znaky (sekvence WCHARu odpovidajici jednomu zobrazenemu znaku).
   res = CompareString(LOCALE_USER_DEFAULT, 0, s1, -1, s2, -1);
 
   res = ConvertA2U("Âëŕäčěčđ", -1, wbuf, 10, 1251);
-  res = ConvertA2U("ahoj", 0, wbuf, 10);
-  res = ConvertA2U("ahoj", -1, wbuf, 5);
-  res = ConvertA2U("ahoj", -1, wbuf, 4);
-  res = ConvertA2U("ahoj", 4, wbuf, 5);
-  res = ConvertA2U("ahoj", 4, wbuf, 4);
-  res = ConvertA2U("ahoj", 4, wbuf, 3);
+  res = ConvertA2U("hello", 0, wbuf, 10);
+  res = ConvertA2U("hello", -1, wbuf, 5);
+  res = ConvertA2U("hello", -1, wbuf, 4);
+  res = ConvertA2U("hello", 4, wbuf, 5);
+  res = ConvertA2U("hello", 4, wbuf, 4);
+  res = ConvertA2U("hello", 4, wbuf, 3);
 
 
   res = CompareString(LOCALE_USER_DEFAULT, 0, s2, -1, s3, -1);
@@ -343,9 +343,9 @@ na zobrazitelne znaky (sekvence WCHARu odpovidajici jednomu zobrazenemu znaku).
   {
     char *res;
     res = ConvertU2A(L"", -1, TRUE);
-    res = ConvertU2A(L"ahoj", 0, TRUE);
-    res = ConvertU2A(L"ahoj", 2, TRUE);
-    res = ConvertU2A(L"ahoj", -1, TRUE);
+    res = ConvertU2A(L"hello", 0, TRUE);
+    res = ConvertU2A(L"hello", 2, TRUE);
+    res = ConvertU2A(L"hello", -1, TRUE);
     res = ConvertU2A(L"D:\\\x0061\x0308", -1, TRUE);
     res = ConvertU2A(L"D:\\\x0061\x0308", -1);
     res = ConvertU2A(L"D:\\\xfb01-\x0061\x0308-\x00e4.txt", -1, TRUE);
@@ -353,8 +353,8 @@ na zobrazitelne znaky (sekvence WCHARu odpovidajici jednomu zobrazenemu znaku).
     WCHAR *wres;
     wres = ConvertA2U("Âëŕäčěčđ", -1, 1251);
     wres = ConvertA2U("", -1);
-    wres = ConvertA2U("ahoj čěšťíňká", 0);
-    wres = ConvertA2U("ahoj čěšťíňká", 2);
-    wres = ConvertA2U("ahoj čěšťíňká", -1);
+    wres = ConvertA2U("hello accents", 0);
+    wres = ConvertA2U("hello accents", 2);
+    wres = ConvertA2U("hello accents", -1);
   }
 */

--- a/src/common/strutils.h
+++ b/src/common/strutils.h
@@ -3,52 +3,50 @@
 
 #pragma once
 
-// makro SAFE_ALLOC odstranuje kod, ve kterem se testuje, jestli se povedla alokace pameti (viz allochan.*)
+// The SAFE_ALLOC macro removes the code that checks whether a memory allocation succeeded (see allochan.*)
 
-// prevod Unicodoveho stringu (UTF-16) na ANSI multibytovy string; 'src' je Unicodovy string;
-// 'srcLen' je delka Unicodoveho stringu (bez zakoncujici nuly; pri zadani -1 se delka urci
-// podle zakoncujici nuly); 'bufSize' (musi byt vetsi nez 0) je velikost ciloveho bufferu
-// 'buf' pro ANSI string; je-li 'compositeCheck' TRUE, pouziva flag WC_COMPOSITECHECK
-// (viz MSDN), nesmi se pouzit pro jmena souboru (NTFS rozlisuje jmena zapsana jako
-// precomposed a composite, aneb neprovadi normalizaci jmen); 'codepage' je kodova stranka
-// ANSI stringu; vraci pocet znaku zapsanych do 'buf' (vcetne zakoncujici nuly); pri chybe
-// vraci nulu (detaily viz GetLastError()); vzdy zajisti nulou zakonceny 'buf' (i pri chybe);
-// je-li 'buf' maly, vraci funkce nulu, ale v 'buf' je prevedena aspon cast stringu
+// Conversion of a Unicode string (UTF-16) to an ANSI multibyte string. 'src' is the Unicode string.
+// 'srcLen' is the length of that string (without the terminating null; when -1 is provided the length is determined
+// from the terminating null). 'bufSize' (must be greater than 0) is the size of the target buffer 'buf' for the ANSI
+// string. If 'compositeCheck' is TRUE, the call uses the WC_COMPOSITECHECK flag (see MSDN); do not use it for file
+// names (NTFS distinguishes names written as precomposed and composite, i.e. it does not normalize names).
+// 'codepage' is the ANSI code page. The function returns the number of characters written to 'buf' (including the
+// terminating null); on error it returns zero (for details see GetLastError()). It always ensures that 'buf' is
+// null-terminated (even on error). If 'buf' is too small, the function returns zero but leaves at least part of the
+// converted string in 'buf'.
 int ConvertU2A(const WCHAR* src, int srcLen, char* buf, int bufSize,
                BOOL compositeCheck = FALSE, UINT codepage = CP_ACP);
 
-// prevod Unicodoveho stringu (UTF-16) na alokovany ANSI multibytovy string (volajici je
-// odpovedny za dealokaci stringu); 'src' je Unicodovy string; 'srcLen' je delka Unicodoveho
-// stringu (bez zakoncujici nuly; pri zadani -1 se delka urci podle zakoncujici nuly);
-// je-li 'compositeCheck' TRUE, pouziva flag WC_COMPOSITECHECK (viz MSDN), nesmi se pouzit
-// pro jmena souboru (NTFS rozlisuje jmena zapsana jako precomposed a composite, aneb
-// neprovadi normalizaci jmen); 'codepage' je kodova stranka ANSI stringu; vraci alokovany
-// ANSI string; pri chybe vraci NULL (detaily viz GetLastError())
+// Conversion of a Unicode string (UTF-16) to a newly allocated ANSI multibyte string (the caller is responsible for
+// freeing the result). 'src' is the Unicode string. 'srcLen' is the length of the Unicode string (without the
+// terminating null; when -1 is provided the length is determined from the terminating null). If 'compositeCheck' is
+// TRUE, the call uses the WC_COMPOSITECHECK flag (see MSDN); do not use it for file names (NTFS distinguishes names
+// written as precomposed and composite, i.e. it does not normalize names). 'codepage' is the ANSI code page. The
+// function returns the allocated ANSI string; on error it returns NULL (for details see GetLastError()).
 char* ConvertAllocU2A(const WCHAR* src, int srcLen, BOOL compositeCheck = FALSE, UINT codepage = CP_ACP);
 
-// prevod ANSI multibytoveho stringu na Unicodovy string (UTF-16); 'src' je ANSI string;
-// 'srcLen' je delka ANSI stringu (bez zakoncujici nuly; pri zadani -1 se delka urci
-// podle zakoncujici nuly); 'bufSize' (musi byt vetsi nez 0) je velikost ciloveho bufferu
-// 'buf' pro Unicodovy string; 'codepage' je kodova stranka ANSI stringu;
-// vraci pocet znaku zapsanych do 'buf' (vcetne zakoncujici nuly); pri chybe vraci nulu
-// (detaily viz GetLastError()); vzdy zajisti nulou zakonceny 'buf' (i pri chybe);
-// je-li 'buf' maly, vraci funkce nulu, ale v 'buf' je prevedena aspon cast stringu
+// Conversion of an ANSI multibyte string to a Unicode string (UTF-16). 'src' is the ANSI string.
+// 'srcLen' is the length of that string (without the terminating null; when -1 is provided the length is determined
+// from the terminating null). 'bufSize' (must be greater than 0) is the size of the target buffer 'buf' for the
+// Unicode string. 'codepage' is the ANSI code page. The function returns the number of characters written to 'buf'
+// (including the terminating null); on error it returns zero (for details see GetLastError()). It always ensures that
+// 'buf' is null-terminated (even on error). If 'buf' is too small, the function returns zero but leaves at least part
+// of the converted string in 'buf'.
 int ConvertA2U(const char* src, int srcLen, WCHAR* buf, int bufSizeInChars,
                UINT codepage = CP_ACP);
 
-// prevod ANSI multibytoveho stringu na alokovany (volajici je odpovedny za dealokaci
-// stringu) Unicodovy string (UTF-16); 'src' je ANSI string; 'srcLen' je delka ANSI
-// stringu (bez zakoncujici nuly; pri zadani -1 se delka urci podle zakoncujici nuly);
-// 'codepage' je kodova stranka ANSI stringu; vraci alokovany Unicodovy string; pri
-// chybe vraci NULL (detaily viz GetLastError())
+// Conversion of an ANSI multibyte string to a newly allocated Unicode string (UTF-16) (the caller is responsible for
+// freeing the result). 'src' is the ANSI string. 'srcLen' is the length of the ANSI string (without the terminating
+// null; when -1 is provided the length is determined from the terminating null). 'codepage' is the ANSI code page.
+// The function returns the allocated Unicode string; on error it returns NULL (for details see GetLastError()).
 WCHAR* ConvertAllocA2U(const char* src, int srcLen, UINT codepage = CP_ACP);
 
-// nakopiruje string 'txt' do nove naalokovaneho stringu, NULL = malo pameti (hrozi jen pokud
-// se nepouziva allochan.*) nebo 'txt'==NULL
+// Copies the string 'txt' into a newly allocated string; returns NULL on out-of-memory (only a risk when allochan.*
+// is not used) or when 'txt' == NULL.
 WCHAR* DupStr(const WCHAR* txt);
 
-// drzi ukazatel na alokovanou pamet, postara se o jeji uvolneni pri prepisu jinym ukazatelem na
-// alokovanou pamet a pri sve destrukci
+// Holds a pointer to allocated memory, releasing it when overwritten by another pointer to allocated memory and when
+// the wrapper itself is destroyed.
 template <class PTR_TYPE>
 class CAllocP
 {
@@ -79,6 +77,6 @@ public:
     }
 };
 
-// drzi alokovany string, postara se o uvolneni pri prepisu jinym stringem (tez alokovanym)
-// a pri sve destrukci
+// Holds an allocated string, releasing it when overwritten by another allocated string and when the wrapper itself is
+// destroyed.
 typedef CAllocP<WCHAR> CStrP;


### PR DESCRIPTION
## Summary
- restore the Unicode search comment to reference the original X:\ZUMPA\!\unicode\ch05.pdf path while keeping the English translation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e90ec0fb8883229f1db334e991accf