### PR TITLE
Translate Czech comments in DIB utilities

### DIFF
--- a/src/common/dib.cpp
+++ b/src/common/dib.cpp
@@ -7,7 +7,7 @@
 #include <crtdbg.h>
 #include <ostream>
 #include <limits.h>
-#include <commctrl.h> // potrebuju LPCOLORMAP
+#include <commctrl.h> // need LPCOLORMAP
 
 #if defined(_DEBUG) && defined(_MSC_VER) // without passing file+line to 'new' operator, list of memory leaks shows only 'crtdbg.h(552)'
 #define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
@@ -21,8 +21,8 @@
 
 #include "dib.h"
 
-// opatreni proti runtime check failure v debug verzi: puvodni verze makra pretypovava rgb na WORD,
-// takze hlasi ztratu dat (RED slozky)
+// workaround for runtime check failure in the debug build: the original macro casts rgb to WORD,
+// so it reports data loss (RED component)
 #undef GetGValue
 #define GetGValue(rgb) ((BYTE)(((rgb) >> 8) & 0xFF))
 
@@ -311,7 +311,7 @@ HBITMAP DIBToBitmap(HANDLE hDIB, HPALETTE hPal)
 //
 // Function:   MapColor(RGB fromColor, RGB toColor)
 //
-//             vsechny barvy fromColor premapuje na barvu toColor
+//             remaps all colors fromColor to the color toColor
 //
 //---------------------------------------------------------------------
 

--- a/src/plugins/zip/sfxmake/crc32.h
+++ b/src/plugins/zip/sfxmake/crc32.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-// definice pro uziti v SFXMake
+// definitions for use in SFXMake
 #define __UINT32 unsigned long
 #define __UINT8 unsigned char
 #define STATIC_CRC_TAB


### PR DESCRIPTION
## Summary
- translate the debug macro and color mapping comments in `dib.cpp` to English
- translate the SFXMake helper comment in `crc32.h` to English

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e918f9fb288322ad4cdddf144b13ff