### PR TITLE
translated regexp.cpp and regexp.h

### DIFF
--- a/src/common/regexp.cpp
+++ b/src/common/regexp.cpp
@@ -39,14 +39,14 @@
 
 #pragma warning(3 : 4706) // warning C4706: assignment within conditional expression
 
-//#include "trace.h" aby to slo pripojit i k pluginum, stejne tu zatim zadny TRACE neni
+//#include "trace.h" so it can also be attached to plugins, there is no TRACE here yet anyway
 #include "str.h"
 #include "regexp.h"
 
 //*****************************************************************************
 //*****************************************************************************
 //
-// moje cast regexp.cpp
+// my part of regexp.cpp
 //
 //*****************************************************************************
 //*****************************************************************************
@@ -65,7 +65,7 @@ public:
 
 C__RegExpSection __RegExpSection;
 
-/*    - moznost definice svych vlastnich hlasek, jinak staci nakopirovat do kodu
+/*    - option to define your own messages, otherwise just copy into the code
 
 const char *RegExpErrorText(CRegExpErrors err)
 {
@@ -159,7 +159,7 @@ BOOL CRegularExpression::SetFlags(WORD flags)
     Expression = regcomp(pattern, LastErrorText);
 
     if (Expression != NULL && (Flags & sfForward) == 0)
-    { // vyraz je syntakticky o.k. + backward search
+    { // expression is syntactically OK + backward search
         if (Expression != NULL)
             free(Expression);
         Expression = NULL;
@@ -263,16 +263,16 @@ BOOL CRegularExpression::ExpandVariables(char* pattern, char* buffer, int bufSiz
 {
     char* sour = pattern;
     char* dest = buffer;
-    bufSize--; //rezervujeme si misto pro NULL
+    bufSize--; // reserve space for NULL
     while (*sour)
     {
         if (!bufSize)
-            return FALSE; //dosel nam buffer
+            return FALSE; // we ran out of buffer
         if (*sour == '\\')
         {
             sour++;
             if (!*sour)
-                break; // tady bych asi mnel hodit chybu takovato sekvence neni definovana
+                break; // I should probably throw an error here; such a sequence is not defined
             if (*sour >= '1' && *sour <= '9')
             {
                 int n = *sour - '0';
@@ -308,9 +308,9 @@ int CRegularExpression::ReplaceForward(int start, char* pattern, BOOL global,
     char* output = buffer;
     int len;
     while (start <= LineLength && regexec(Expression, Line, start) == 1 &&
-           Expression->endp[0] - Expression->startp[0] > 0 /*zero sized match neberem*/)
+           Expression->endp[0] - Expression->startp[0] > 0 /* do not accept zero-sized matches */)
     {
-        //zkopirujeme nezmeny text, ktery predchazi match
+        // copy the unchanged text that precedes the match
         len = (int)((Expression->startp[0] - Line) - start);
         if (len + 1 > bufSize)
         {
@@ -319,7 +319,7 @@ int CRegularExpression::ReplaceForward(int start, char* pattern, BOOL global,
         memcpy(output, OrigLineStart + start, len);
         output += len;
         bufSize -= len;
-        //nahradime co jsme nasli
+        // replace what we found
         if (!ExpandVariables(pattern, output, bufSize, &len))
         {
             return FALSE;
@@ -334,7 +334,7 @@ int CRegularExpression::ReplaceForward(int start, char* pattern, BOOL global,
 
     if (ret && start < LineLength)
     {
-        //dokopirujeme text nasledujici match
+        // append the text following the match
         if (LineLength - start + 1 > bufSize)
         {
             return FALSE;
@@ -350,9 +350,9 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
 
     while (s < srcExpEnd)
     {
-        //---  hledani konce atomu - pro zopakovani '*', '+' a '?'
-        char* ss;    // ukazuje za atom
-        BOOL addPar; // paruji zavorky? (ma se pridat zavorka do paru)
+        //---  search for the end of an atom when handling repetitions '*', '+' and '?'
+        char* ss;    // points past the atom
+        BOOL addPar; // do the parentheses form a pair? (should we add a matching parenthesis)
         switch (*s)
         {
         case '\\':
@@ -362,8 +362,8 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
         case '(':
         case '[':
         {
-            int parNum = (*s == '(') ? 1 : 0; // pocty zavorek
-            int braNum = (*s == '[') ? 1 : 0; // pocty zavorek
+            int parNum = (*s == '(') ? 1 : 0; // parenthesis count
+            int braNum = (*s == '[') ? 1 : 0; // bracket count
             char* lastBra = (*s == '[') ? s : NULL;
             ss = s + 1;
             while (*ss != 0 && (parNum != 0 || braNum != 0))
@@ -373,10 +373,10 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
                 case '(':
                     if (braNum == 0)
                         parNum++;
-                    break; // [..(..] je povoleno
+                    break; // [..(..] is allowed
                 case '[':
                 {
-                    if (braNum == 0) // [..[..] je povoleno
+                    if (braNum == 0) // [..[..] is allowed
                     {
                         braNum++;
                         lastBra = ss - 1;
@@ -387,13 +387,13 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
                 case ')':
                     if (braNum == 0 && parNum > 0)
                         parNum--;
-                    break; // [..)..] je povoleno
+                    break; // [..)..] is allowed
                 case ']':
                 {
-                    if (braNum != 0) // ..].. je povoleno
+                    if (braNum != 0) // ..].. is allowed
                     {
-                        if (ss - 2 != lastBra &&                     // []..] je povoleno
-                            (ss - 3 != lastBra || *(ss - 2) != '^')) // [^]..] je take povoleno
+                        if (ss - 2 != lastBra &&                     // []..] is allowed
+                            (ss - 3 != lastBra || *(ss - 2) != '^')) // [^]..] is also allowed
                         {
                             braNum--;
                         }
@@ -405,7 +405,7 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
                 {
                     if (*ss != 0)
                         ss++;
-                    break; // znak za '\\' nemuze byt brany jako zavorka
+                    break; // the character after '\\' cannot be treated as a bracket
                 }
                 }
             }
@@ -422,12 +422,12 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
             break;
         }
 
-        //---  nakopirovani vsech '*', '+' a '?' obsazenych za atomem
+        //---  copy all '*', '+' and '?' that follow the atom
         char* oldSS = ss;
         while (*ss == '*' || *ss == '?' || *ss == '+')
             *--dstExpEnd = *ss++;
 
-        //--- nakopirovani obraceneho atomu
+        //--- copy the reversed atom
         switch (*s)
         {
         case '\\':
@@ -446,13 +446,13 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
             else
                 *--dstExpEnd = (*s == '(') ? ')' : ']';
 
-            if (oldSS - s >= 2) // pokud vyraz nekonci otevrenou zavorkou
+            if (oldSS - s >= 2) // if the expression does not end with an opening bracket
             {
                 if (*s == '(')
-                { // kopie reversovaneho vyrazu - ohraniceni
+                { // copy the reversed expression to handle the boundaries
                     ReverseRegExp(dstExpEnd, s + 1, oldSS - 1);
                 }
-                else // prosta kopie vnitrku - mnozina
+                else // simply copy the contents - character class
                 {
                     dstExpEnd -= (oldSS - 1) - (s + 1);
                     memcpy(dstExpEnd, s + 1, (oldSS - 1) - (s + 1));
@@ -476,7 +476,7 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
             break;
         }
 
-        //---  prechod na dalsi atom
+        //---  proceed to the next atom
         s = ss;
     }
 }
@@ -484,7 +484,7 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
 //*****************************************************************************
 //*****************************************************************************
 //
-// puvodni regexp.cpp
+// original regexp.cpp
 //
 //*****************************************************************************
 //*****************************************************************************
@@ -745,7 +745,7 @@ regexp* regcomp(char* exp, const char*& lastErrorText)
         }
     }
 
-    lastErrorText = NULL; // uspesny navrat
+    lastErrorText = NULL; // successful return
     __RegExpSection.Leave();
     return (r);
 }

--- a/src/common/regexp.h
+++ b/src/common/regexp.h
@@ -6,7 +6,7 @@
 //*****************************************************************************
 //*****************************************************************************
 //
-// puvodni regexp.h
+// original regexp.h
 //
 //*****************************************************************************
 //*****************************************************************************
@@ -36,12 +36,12 @@ void regerror(const char* error);
 //*****************************************************************************
 //*****************************************************************************
 //
-// moje cast regexp.h
+// my part of regexp.h
 //
 //*****************************************************************************
 //*****************************************************************************
 
-// chyby, ktere mohou nastat pri compilaci a hledani reg. expr.
+// errors that can occur while compiling and searching regular expressions
 enum CRegExpErrors
 {
     reeNoError,
@@ -59,7 +59,7 @@ enum CRegExpErrors
     reeInternalDisaster,
 };
 
-// funkce, ktera vraci text nastale chyby
+// function that returns the text of the error that occurred
 const char* RegExpErrorText(CRegExpErrors err);
 
 // search flags
@@ -74,18 +74,18 @@ const char* RegExpErrorText(CRegExpErrors err);
 class CRegularExpression
 {
 public:
-    static const char* LastError; // text posledni chyby
+    static const char* LastError; // text of the last error
 
 protected:
     const char* LastErrorText;
     char* OriginalPattern;
-    regexp* Expression; // nakompilovany regularni vyraz
+    regexp* Expression; // compiled regular expression
     WORD Flags;
 
-    char* Line;                // buffer pro radek
-    const char* OrigLineStart; // pointer na zacatek puvodniho textu (predaneho do SetLine() jako 'start')
-    int Allocated;             // kolik bytu je alokovano
-    int LineLength;            // aktualni delka radky
+    char* Line;                // buffer for the line
+    const char* OrigLineStart; // pointer to the beginning of the original text (passed to SetLine() as 'start')
+    int Allocated;             // how many bytes are allocated
+    int LineLength;            // current line length
 
 public:
     CRegularExpression()
@@ -114,33 +114,33 @@ public:
     const char* GetPattern() const { return OriginalPattern; }
 
     const char* GetLastErrorText() const { return LastErrorText; }
-    BOOL Set(const char* pattern, WORD flags); // vraci FALSE pri chybe (volat metodu GetLastErrorText)
-    BOOL SetFlags(WORD flags);                 // vraci FALSE pri chybe (volat metodu GetLastErrorText)
+    BOOL Set(const char* pattern, WORD flags); // returns FALSE on error (call the GetLastErrorText method)
+    BOOL SetFlags(WORD flags);                 // returns FALSE on error (call the GetLastErrorText method)
 
-    BOOL SetLine(const char* start, const char* end); // radek textu, ve kterem vyhledava, vraci FALSE pri chybe (volat metodu GetLastErrorText)
+    BOOL SetLine(const char* start, const char* end); // line of text in which it searches, returns FALSE on error (call the GetLastErrorText method)
 
     int SearchForward(int start, int& foundLen);
     int SearchBackward(int length, int& foundLen);
 
-    // nahradi promnene \1 ... \9 textem zachycenym odpovidajicima zavorkama
-    // 'pattern' je vzor kterym se nahrazuje nalezeny match, 'buffer' buffer
-    // pro vystup, 'bufSize' maximalni velikost textu vcetne ukoncovaciho NULL
-    // znaku, v promnene 'count' vraci pocet znaku zkopirovanych do bufferu
-    // vraci TRUE pokud se vyraz vesel cely do bufferu
+    // replaces variables \1 ... \9 with the text captured by the corresponding parentheses
+    // 'pattern' is the template that replaces the found match, 'buffer' is the buffer
+    // for output, 'bufSize' is the maximum text length including the terminating NULL
+    // character, in the 'count' variable it returns the number of characters copied into the buffer
+    // returns TRUE if the expression fit entirely into the buffer
     BOOL ExpandVariables(char* pattern, char* buffer,
                          int bufSize, int* count);
 
-    // navratove hodnoty
+    // return values
     //
-    // 0 hledany text nebyl nalezen, do 'buffer' se nic nekopirovalo
-    // 1 text byl uspesne nahrazen
-    // 2 'buffer' je prilis maly
+    // 0 the searched text was not found, nothing was copied into 'buffer'
+    // 1 the text was successfully replaced
+    // 2 'buffer' is too small
     int ReplaceForward(int start, char* pattern, BOOL global,
                        char* buffer, int bufSize);
 
 protected:
-    // Obraci regularni vyraz - pro hledani od zadu
-    // VYRAZ MUSI BYT SYNTAKTICKY SPRAVNY ! JINAK NEFUNGUJE SPRAVNE !
-    // napr. "a)b(d)(" -> "((d)b)a" coz je chybne
+    // Reverses a regular expression - for searching backwards
+    // THE EXPRESSION MUST BE SYNTACTICALLY CORRECT! OTHERWISE IT DOES NOT WORK PROPERLY!
+    // e.g. "a)b(d)(" -> "((d)b)a" which is incorrect
     void ReverseRegExp(char*& dstExpEnd, char* srcExp, char* srcExpEnd);
 };


### PR DESCRIPTION
## Summary
- refine the ReverseRegExp comment translations so the grammar reads naturally in English
- clarify the phrasing around handling parentheses, brackets, and repetition operators while reversing expressions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e916bb8eec832297d3af4c4b4a6175