### PR TITLE
Refine archiver cache comment wording

### DIFF
--- a/src/plugins/shared/spl_arc.h
+++ b/src/plugins/shared/spl_arc.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #ifdef _MSC_VER
-#pragma pack(push, enter_include_spl_arc) // aby byly struktury nezavisle na nastavenem zarovnavani
+#pragma pack(push, enter_include_spl_arc) // so that the structures are independent of the configured alignment
 #pragma pack(4)
 #endif // _MSC_VER
 #ifdef __BORLANDC__
@@ -31,156 +31,151 @@ class CPluginDataInterfaceAbstract;
 class CPluginInterfaceForArchiverAbstract
 {
 #ifdef INSIDE_SALAMANDER
-private: // ochrana proti nespravnemu primemu volani metod (viz CPluginInterfaceForArchiverEncapsulation)
+private: // protection against incorrect direct method calls (see CPluginInterfaceForArchiverEncapsulation)
     friend class CPluginInterfaceForArchiverEncapsulation;
 #else  // INSIDE_SALAMANDER
 public:
 #endif // INSIDE_SALAMANDER
 
-    // funkce pro "panel archiver view"; vola se pro nacteni obsahu archivu 'fileName';
-    // obsah se plni do objektu 'dir'; Salamander zjisti obsah
-    // pluginem pridanych sloupcu pomoci interfacu 'pluginData' (pokud plugin sloupce
-    // nepridava, vraci 'pluginData'==NULL); vraci TRUE pri uspesnem nacteni obsahu archivu,
-    // pokud vrati FALSE, navratova hodnota 'pluginData' se ignoruje (data v 'dir' je potreba
-    // uvolnit pomoci 'dir.Clear(pluginData)', jinak se uvolni jen Salamanderovska cast dat);
-    // 'salamander' je sada uzitecnych metod vyvezenych ze Salamandera,
-    // POZOR: soubor fileName take nemusi existovat (pokud je otevren v panelu a odjinud smazan),
-    // ListArchive neni volan pro soubory nulove delky, ty maji automaticky prazdny obsah,
-    // pri pakovani do takovych souboru se soubor pred volanim PackToArchive smaze (pro
-    // kompatibilitu s externimi pakovaci)
+    // function used for the "panel archiver view"; called to load the contents of the
+    // archive 'fileName'; the content is stored in the 'dir' object; Salamander obtains
+    // the values for columns added by the plugin through the 'pluginData' interface (if the
+    // plugin does not add columns, it returns 'pluginData' == NULL); returns TRUE when the
+    // archive content is loaded successfully; if it returns FALSE, the return value of
+    // 'pluginData' is ignored (the data in 'dir' must be released with 'dir.Clear(pluginData)',
+    // otherwise only the Salamander-owned part is released);
+    // 'salamander' is a set of helper methods exported from Salamander;
+    // NOTE: the file 'fileName' may not exist (for example when it is open in the panel and
+    // removed elsewhere); ListArchive is not called for zero-length files—they automatically
+    // have empty content; when packing into such files, the file is deleted before calling
+    // PackToArchive (for compatibility with external packing tools)
     virtual BOOL WINAPI ListArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                     CSalamanderDirectoryAbstract* dir,
                                     CPluginDataInterfaceAbstract*& pluginData) = 0;
 
-    // funkce pro "panel archiver view", vola se pri pozadavku na rozpakovani souboru/adresaru
-    // z archivu 'fileName' do adresare 'targetDir' z cesty v archivu 'archiveRoot'; 'pluginData'
-    // je interface pro praci s informacemi o souborech/adresarich, ktere jsou specificke pluginu
-    // (napr. data z pridanych sloupcu; jde o stejny interface, ktery vraci metoda ListArchive
-    // v parametru 'pluginData' - takze muze byt i NULL); soubory/adresare jsou zadany enumeracni
-    // funkci 'next' jejimz parametrem je 'nextParam'; vraci TRUE pri uspesnem rozpakovani (nebyl
-    // pouzit Cancel, mohl byt pouzit Skip) - zdroj operace v panelu je odznacen, jinak vraci
-    // FALSE (neprovede se odznaceni); 'salamander' je sada uzitecnych metod vyvezenych ze
-    // Salamandera
+    // function for the "panel archiver view"; called when requested to unpack files/directories
+    // from archive 'fileName' to directory 'targetDir' using the archive path 'archiveRoot';
+    // 'pluginData' is the interface for working with file/directory information specific to the plugin
+    // (for example, data for added columns; it is the same interface returned by ListArchive
+    // in the 'pluginData' parameter—so it may also be NULL); the files/directories are supplied
+    // through the enumeration function 'next', whose parameter is 'nextParam'; returns TRUE when
+    // unpacking succeeds (Cancel was not used; Skip may have been) and the source items in the panel
+    // are deselected; otherwise returns FALSE (the selection remains marked);
+    // 'salamander' is a set of helper methods exported from Salamander
     virtual BOOL WINAPI UnpackArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                       CPluginDataInterfaceAbstract* pluginData, const char* targetDir,
                                       const char* archiveRoot, SalEnumSelection next,
                                       void* nextParam) = 0;
 
-    // funkce pro "panel archiver view", vola se pri pozadavku na rozpakovani jednoho souboru pro view/edit
-    // z archivu 'fileName' do adresare 'targetDir'; jmeno souboru v archivu je 'nameInArchive';
-    // 'pluginData' je interface pro praci s informacemi o souboru, ktere jsou specificke pluginu
-    // (napr. data z pridanych sloupcu; jde o stejny interface, ktery vraci metoda ListArchive
-    // v parametru 'pluginData' - takze muze byt i NULL); 'fileData' je ukazatel na strukturu CFileData
-    // vypakovavaneho souboru (strukturu sestavil plugin pri listovani archivu); 'newFileName' (neni-li
-    // NULL) je nove jmeno pro rozbalovany soubor (pouziva se pokud puvodni jmeno z archivu neni mozne
-    // vybalit na disk (napr. "aux", "prn", atd.)); do 'renamingNotSupported' (jen neni-li 'newFileName'
-    // NULL) zapsat TRUE pokud plugin nepodporuje prejmenovani pri vybalovani (standardni chybova hlaska
-    // "renaming not supported" se zobrazi ze Salamandera); vraci TRUE pri uspesnem rozpakovani souboru
-    // (soubor je na zadane ceste, nebyl pouzit Cancel ani Skip), 'salamander' je sada uzitecnych metod
-    // vyvezenych ze Salamandera
+    // function for the "panel archiver view"; called when requested to unpack a single file for viewing/editing
+    // from archive 'fileName' into directory 'targetDir'; the file name in the archive is 'nameInArchive';
+    // 'pluginData' is the interface for working with file information specific to the plugin
+    // (for example, data for added columns; it is the same interface returned by ListArchive
+    // in the 'pluginData' parameter—so it may also be NULL); 'fileData' is a pointer to the CFileData
+    // structure of the file being unpacked (the structure was built by the plugin when listing the archive);
+    // 'newFileName' (if not NULL) is a new name for the extracted file (used when the original archive name
+    // cannot be written to disk, for example "aux", "prn", etc.); set 'renamingNotSupported' to TRUE
+    // (only if 'newFileName' is not NULL) when the plugin does not support renaming during extraction
+    // (Salamander then shows the standard error message "renaming not supported");
+    // returns TRUE when the file is unpacked successfully (the file exists at the requested path and neither
+    // Cancel nor Skip was used); 'salamander' is a set of helper methods exported from Salamander
     virtual BOOL WINAPI UnpackOneFile(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                       CPluginDataInterfaceAbstract* pluginData, const char* nameInArchive,
                                       const CFileData* fileData, const char* targetDir,
                                       const char* newFileName, BOOL* renamingNotSupported) = 0;
 
-    // funkce pro "panel archiver edit" a "custom archiver pack", vola se pri pozadavku na zapakovani
-    // souboru/adresaru do archivu 'fileName' na cestu 'archiveRoot', soubory/adresare jsou zadany
-    // zdrojovou cestou 'sourcePath' a enumeracni funkci 'next' s parametrem 'nextParam',
-    // je-li 'move' TRUE, zapakovane soubory/adresare by mely byt odstranene z disku, vraci TRUE
-    // pokud se podari zapakovat/odstranit vsechny soubory/adresare (nebyl pouzit Cancel, mohl byt
-    // pouzit Skip) - zdroj operace v panelu je odznacen, jinak vraci FALSE (neprovede se odznaceni),
-    // 'salamander' je sada uzitecnych metod vyvezenych ze Salamandera
+    // function for "panel archiver edit" and "custom archiver pack"; called when requested to pack
+    // files/directories into archive 'fileName' at path 'archiveRoot'; the files/directories are provided by
+    // the source path 'sourcePath' and the enumeration function 'next' with parameter 'nextParam';
+    // if 'move' is TRUE, the packed files/directories should be removed from disk; returns TRUE
+    // when it succeeds in packing/removing all files/directories (Cancel was not used; Skip may have been)
+    // and the source items in the panel are deselected; otherwise it returns FALSE (the selection remains);
+    // 'salamander' is a set of helper methods exported from Salamander
     virtual BOOL WINAPI PackToArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                       const char* archiveRoot, BOOL move, const char* sourcePath,
                                       SalEnumSelection2 next, void* nextParam) = 0;
 
-    // funkce pro "panel archiver edit", vola se pri pozadavku na smazani souboru/adresaru z archivu
-    // 'fileName'; soubory/adresare jsou zadany cestou 'archiveRoot' a enumeracni funkci 'next'
-    // s parametrem 'nextParam'; 'pluginData' je interface pro praci s informacemi o souborech/adresarich,
-    // ktere jsou specificke pluginu (napr. data z pridanych sloupcu; jde o stejny interface, ktery vraci
-    // metoda ListArchive v parametru 'pluginData' - takze muze byt i NULL); vraci TRUE pokud se
-    // podari smazat vsechny soubory/adresare (nebyl pouzit Cancel, mohl byt pouzit Skip) - zdroj
-    // operace v panelu je odznacen, jinak vraci FALSE (neprovede se odznaceni); 'salamander' je sada
-    // uzitecnych metod vyvezenych ze Salamandera
+    // function for "panel archiver edit"; called when requested to delete files/directories from archive
+    // 'fileName'; the files/directories are provided by the path 'archiveRoot' and the enumeration function
+    // 'next' with parameter 'nextParam'; 'pluginData' is the interface for working with file/directory
+    // information specific to the plugin (for example, data for added columns; it is the same interface
+    // returned by ListArchive in the 'pluginData' parameter—so it may also be NULL); returns TRUE when it
+    // succeeds in deleting all files/directories (Cancel was not used; Skip may have been) and the source
+    // items in the panel are deselected; otherwise it returns FALSE (the selection remains);
+    // 'salamander' is a set of helper methods exported from Salamander
     virtual BOOL WINAPI DeleteFromArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                           CPluginDataInterfaceAbstract* pluginData, const char* archiveRoot,
                                           SalEnumSelection next, void* nextParam) = 0;
 
-    // funkce pro "custom archiver unpack"; vola se pri pozadavku na rozbaleni souboru/adresaru z archivu
-    // 'fileName' do adresare 'targetDir'; soubory/adresare jsou zadany maskou 'mask'; vraci TRUE pokud
-    // se podari rozbalit vsechny soubory/adresare (nebyl pouzit Cancel, mohl byt pouzit Skip);
-    // je-li 'delArchiveWhenDone' TRUE, je potreba napridavat do 'archiveVolumes' vsechny svazky archivu
-    // (vcetne null-terminatoru; neni-li vicesvazkovy, bude tam jen 'fileName'), vrati-li se z teto funkce
-    // TRUE (uspesne rozbaleni), dojde nasledne ke smazani vsech souboru z 'archiveVolumes';
-    // 'salamander' je sada uzitecnych metod vyvezenych ze Salamandera
+    // function for "custom archiver unpack"; called when requested to extract files/directories from
+    // archive 'fileName' into directory 'targetDir'; the files/directories are specified by the mask 'mask';
+    // returns TRUE when it succeeds in extracting all files/directories (Cancel was not used; Skip may have been);
+    // if 'delArchiveWhenDone' is TRUE, add all archive volumes to 'archiveVolumes' (including the terminating
+    // null; if the archive is not multi-volume, only 'fileName' is added); if the function returns TRUE
+    // (extraction succeeded), every file listed in 'archiveVolumes' is deleted afterwards;
+    // 'salamander' is a set of helper methods exported from Salamander
     virtual BOOL WINAPI UnpackWholeArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                            const char* mask, const char* targetDir, BOOL delArchiveWhenDone,
                                            CDynamicString* archiveVolumes) = 0;
 
-    // funkce pro "panel archiver view/edit", vola se pred zavrenim panelu s archivem
-    // POZOR: pokud se nepodari otevrit novou cestu, archiv muze v panelu zustat (nezavisle na tom,
-    //        co vrati CanCloseArchive); metodu tedy nelze pouzit pro destrukci kontextu;
-    //        je urcena napriklad pro optimalizaci operace Delete z archivu, kdy muze pri
-    //        jeho opousteni nabidnou "setreseni" archivu
-    //        pro destrukci kontextu lze pouzit metodu CPluginInterfaceAbstract::ReleasePluginDataInterface,
-    //        viz dokument archivatory.txt
-    // 'fileName' je jmeno archivu; 'salamander' je sada uzitecnych metod vyvezenych ze Salamandera;
-    // 'panel' oznacuje panel, ve kterem je archiv otevreny (PANEL_LEFT nebo PANEL_RIGHT);
-    // vraci TRUE pokud je zavreni mozne, je-li 'force' TRUE, vraci TRUE vzdy; pokud probiha
-    // critical shutdown (vice viz CSalamanderGeneralAbstract::IsCriticalShutdown), nema
-    // smysl se usera na cokoliv ptat
+    // function for "panel archiver view/edit"; called before closing the panel with the archive
+    // NOTE: if a new path cannot be opened, the archive may remain displayed in the panel (regardless of
+    //        what CanCloseArchive returns); therefore the method cannot be used to destroy the context;
+    //        it is meant, for example, to optimize the Delete operation from the archive, where it can
+    //        offer to "compact" the archive when leaving it;
+    //        to destroy the context, use the method CPluginInterfaceAbstract::ReleasePluginDataInterface—
+    //        see the document archivatory.txt
+    // 'fileName' is the archive name; 'salamander' is a set of helper methods exported from Salamander;
+    // 'panel' denotes the panel where the archive is open (PANEL_LEFT or PANEL_RIGHT);
+    // returns TRUE if closing is possible; if 'force' is TRUE, it always returns TRUE; when a critical shutdown
+    // is in progress (see more in CSalamanderGeneralAbstract::IsCriticalShutdown), it makes no sense
+    // to ask the user anything
     virtual BOOL WINAPI CanCloseArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                         BOOL force, int panel) = 0;
 
-    // zjisti pozadovane nastaveni disk-cache (disk-cache se pouziva pro docasne kopie
-    // souboru pri otevirani souboru z archivu ve viewerech, editorech a pres systemove
-    // asociace); normalne (podari-li se po volani naalokovat kopii 'tempPath') se vola
-    // jen jednou a to pred prvnim pouzitim disk-cache (napr. pred prvnim otevrenim
-    // souboru z archivu ve vieweru/editoru); pokud vraci FALSE, pouziva
-    // se standardni nastaveni (soubory v TEMP adresari, kopie se mazou pomoci Win32
-    // API funkce DeleteFile() az pri prekroceni limitni velikosti cache nebo pri zavreni archivu)
-    // a vsechny ostatni navratove hodnoty se ignoruji; vraci-li TRUE, pouzivaji se nasledujici
-    // navratove hodnoty: neni-li 'tempPath' (buffer o velikosti MAX_PATH) prazdny retezec, budou
-    // se vsechny docasne kopie vypakovane pluginem z archivu ukladat do podadresaru teto cesty
-    // (tyto podadresare zrusi disk-cache pri ukonceni Salamandera, ale pluginu nic nebrani
-    // v jejich smazani drive, napr. pri svem unloadu; zaroven je vhodne pri loadu prvni instance
-    // pluginu (nejen v ramci jednoho spusteneho Salamandera) promazat podadresare "SAL*.tmp" na teto
-    // ceste - resi problemy vznikle zamknutymi soubory a pady softu) + je-li 'ownDelete' TRUE,
-    // bude se pro mazani kopii volat metoda DeleteTmpCopy a PrematureDeleteTmpCopy + je-li
-    // 'cacheCopies' FALSE, budou se kopie mazat hned jakmile se uvolni (napr. jakmile se zavre
-    // viewer), je-li 'cacheCopies' TRUE, budou se kopie mazat az pri prekroceni limitni velikosti
-    // cache nebo pri zavreni archivu
+    // determines the required disk-cache settings (the disk cache is used for temporary copies of files
+    // when opening archive files in viewers, editors, and through system associations); normally
+    // (if it succeeds in allocating the copy 'tempPath' after the call) it is called only once, specifically before
+    // the first use of the disk cache (for example before the first archive file is opened in the viewer/editor);
+    // if it returns FALSE, the standard settings are used (files in the TEMP directory; copies are deleted via the
+    // Win32 API function DeleteFile() only after exceeding the cache size limit or when the archive is closed)
+    // and all other return values are ignored; if it returns TRUE, the following return values are used:
+    // if 'tempPath' (a buffer of size MAX_PATH) is not an empty string, all temporary copies extracted by the
+    // plugin from the archive are stored in subdirectories of this path (these subdirectories are removed by the
+    // disk cache when Salamander exits, but nothing prevents the plugin from deleting them earlier, for example
+    // during unload; it is also advisable, when loading the first instance of the plugin—not only within a single
+    // running Salamander—to clean the "SAL*.tmp" subdirectories on this path; this solves problems caused by
+    // locked files and crashes) + if 'ownDelete' is TRUE, the methods DeleteTmpCopy and PrematureDeleteTmpCopy
+    // will be called to delete the copies + if 'cacheCopies' is FALSE, the copies are deleted as soon as they are
+    // released (for example when the viewer closes); if 'cacheCopies' is TRUE, the copies are deleted only after
+    // the cache size limit is exceeded or when the archive is closed
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) = 0;
 
-    // pouziva se jen pokud metoda GetCacheInfo vraci v parametru 'ownDelete' TRUE:
-    // smaze docasnou kopii vypakovanou z tohoto archivu (pozor na read-only soubory,
-    // u nich je treba nejprve zmenit atributy, a pak jdou teprve smazat), pokud mozno
-    // by nemelo zobrazovat zadna okna (uzivatel cinnost primo nevyvolal, muze ho rusit
-    // v jine cinnosti), pri delsich akcich se hodi vyuziti wait-okenka (viz
-    // CSalamanderGeneralAbstract::CreateSafeWaitWindow); 'fileName' je jmeno souboru
-    // s kopii; pokud se maze vic souboru najednou (muze nastat napr. po zavreni
-    // editovaneho archivu), je 'firstFile' TRUE pro prvni soubor a FALSE pro ostatni
-    // soubory (pouziva se ke korektnimu zobrazeni wait-okenka - viz DEMOPLUG)
+    // used only if GetCacheInfo returns TRUE in the parameter 'ownDelete':
+    // deletes a temporary copy extracted from this archive (watch out for read-only files; their attributes
+    // must be changed first and only then can they be deleted); if possible, it should not display any windows
+    // (the user did not invoke the action directly and it could distract them from other tasks); for longer
+    // actions it is useful to display a wait window (see CSalamanderGeneralAbstract::CreateSafeWaitWindow);
+    // 'fileName' is the name of the file with the copy; if several files are deleted at once (for example after
+    // closing the edited archive), 'firstFile' is TRUE for the first file and FALSE for the others
+    // (used to display the wait window correctly—see DEMOPLUG)
     //
-    // POZOR: vola se v hl. threadu na zaklade doruceni zpravy z disk-cache hl. oknu - posila se
-    // zprava o potrebe uvolnit docasnou kopii (typicky v okamziku zavreni vieweru nebo
-    // "rozeditovaneho" archivu v panelu), tedy muze dojit k opakovanemu vstupu do pluginu
-    // (pokud zpravu distribuuje message-loopa uvnitr pluginu), dalsi vstup do DeleteTmpCopy
-    // je vylouceny, protoze do ukonceni volani DeleteTmpCopy disk-cache zadne dalsi zpravy
-    // neposila
+    // WARNING: called in the main thread after the disk cache delivers a message to the main window—a message
+    // about the need to release a temporary copy (typically when the viewer or the "edited" archive in the panel
+    // closes), so re-entry into the plugin may occur (if the message is dispatched by the plugin's internal
+    // message loop); another entry into DeleteTmpCopy is excluded, because until the DeleteTmpCopy call finishes
+    // the disk cache does not send any further messages
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) = 0;
 
-    // pouziva se jen pokud metoda GetCacheInfo vraci v parametru 'ownDelete' TRUE:
-    // pri unloadu pluginu zjisti, jestli se ma volat DeleteTmpCopy pro kopie, ktere jsou
-    // jeste pouzivane (napr. otevrene ve vieweru) - vola se jen pokud takove kopie
-    // existuji; 'parent' je parent pripadneho messageboxu s dotazem uzivateli (pripadne
-    // doporuceni, aby user zavrel vsechny soubory z archivu, aby je plugin mohl smazat);
-    // 'copiesCount' je pocet pouzivanych kopii souboru z archivu; vraci TRUE pokud se
-    // ma volat DeleteTmpCopy, pokud vrati FALSE, kopie zustanou na disku; pokud probiha
-    // critical shutdown (vice viz CSalamanderGeneralAbstract::IsCriticalShutdown), nema
-    // smysl se usera na cokoliv ptat a provadet zdlouhave akce (napr. shredovani souboru)
-    // POZNAMKA: behem provadeni PrematureDeleteTmpCopy je zajisteno, ze nedojde
-    // k volani DeleteTmpCopy
+    // used only if GetCacheInfo returns TRUE in the parameter 'ownDelete':
+    // during plugin unload, determines whether DeleteTmpCopy should be called for copies that are still in use
+    // (for example open in the viewer)—called only if such copies exist; 'parent' is the parent window of a
+    // possible message box shown to the user (or a recommendation that the user close all files from the archive
+    // so the plugin can delete them); 'copiesCount' is the number of in-use copies of files from the archive;
+    // returns TRUE when DeleteTmpCopy should be called; if it returns FALSE, the copies remain on disk; when a
+    // critical shutdown is in progress (see more in CSalamanderGeneralAbstract::IsCriticalShutdown), it makes no
+    // sense to ask the user anything or to perform lengthy actions (for example file shredding)
+    // NOTE: during the execution of PrematureDeleteTmpCopy it is guaranteed that DeleteTmpCopy will not be called
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) = 0;
 };
 


### PR DESCRIPTION
## Summary
- clarify the disk-cache configuration comment in `spl_arc.h` by replacing the problematic wording

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e92e6c16b483228ca0f22baade0d96