### PR TITLE
Refine English comments in auxiliary threading helpers

### DIFF
--- a/src/plugins/shared/auxtools.cpp
+++ b/src/plugins/shared/auxtools.cpp
@@ -42,11 +42,11 @@ CThreadQueue::CThreadQueue(const char* queueName)
 
 CThreadQueue::~CThreadQueue()
 {
-    ClearFinishedThreads(); // neni treba sekce, uz by mel pouzivat jen jeden thread
+    ClearFinishedThreads(); // no need for a section; only one thread should be using it now
     if (Continue != NULL)
         CloseHandle(Continue);
     if (Head != NULL)
-        TRACE_E("Some thread is still in " << QueueName << " queue!"); // po terminovani threadu, ktery ceka na (nebo zrovna terminuje) jiny thread z fronty, jinak by nemelo nastat...
+        TRACE_E("Some thread is still in " << QueueName << " queue!"); // after terminating a thread that waits for (or is terminating) another thread from the queue; otherwise it should not happen...
 }
 
 void CThreadQueue::ClearFinishedThreads()
@@ -57,7 +57,7 @@ void CThreadQueue::ClearFinishedThreads()
     {
         DWORD ec;
         if (act->Locks == 0 && (!GetExitCodeThread(act->Thread, &ec) || ec != STILL_ACTIVE))
-        { // tento thread neni zamceny + uz skoncil, vyhodime ho ze seznamu
+        { // this entry is unlocked and the thread has already finished, so remove it from the list
             if (last != NULL)
                 last->Next = act->Next;
             else
@@ -76,10 +76,10 @@ void CThreadQueue::ClearFinishedThreads()
 
 BOOL CThreadQueue::Add(CThreadQueueItem* item)
 {
-    // nejprve vyhodime thready, ktere se jiz ukoncily
+    // first discard threads that have already finished
     ClearFinishedThreads();
 
-    // pridame novy thread
+    // add a new thread
     if (item != NULL)
     {
         item->Next = Head;
@@ -93,7 +93,7 @@ BOOL CThreadQueue::FindAndLockItem(HANDLE thread)
 {
     CS.Enter();
 
-    CThreadQueueItem* act = Head; // zkusime najit otevreny handle threadu
+    CThreadQueueItem* act = Head; // look for the queue entry that owns the thread handle
     while (act != NULL)
     {
         if (act->Thread == thread)
@@ -106,7 +106,7 @@ BOOL CThreadQueue::FindAndLockItem(HANDLE thread)
 
     CS.Leave();
 
-    return act != NULL; // NULL = nenalezeno
+    return act != NULL; // NULL = not found
 }
 
 void CThreadQueue::UnlockItem(HANDLE thread, BOOL deleteIfUnlocked)
@@ -114,7 +114,7 @@ void CThreadQueue::UnlockItem(HANDLE thread, BOOL deleteIfUnlocked)
     CS.Enter();
 
     CThreadQueueItem* last = NULL;
-    CThreadQueueItem* act = Head; // zkusime najit otevreny handle threadu
+    CThreadQueueItem* act = Head; // look for the queue entry that owns the thread handle
     while (act != NULL)
     {
         if (act->Thread == thread)
@@ -122,13 +122,13 @@ void CThreadQueue::UnlockItem(HANDLE thread, BOOL deleteIfUnlocked)
         last = act;
         act = act->Next;
     }
-    if (act != NULL) // always true (bylo zamknute, neslo smazat)
+    if (act != NULL) // always true (it was locked, so it could not be deleted)
     {
         if (act->Locks <= 0)
             TRACE_E("CThreadQueue::UnlockItem(): thread has not locks!");
         else
         {
-            if (--(act->Locks) == 0 && deleteIfUnlocked) // thread uz neni zamceny a mame ho smazat
+            if (--(act->Locks) == 0 && deleteIfUnlocked) // the thread is no longer locked and the record should be removed
             {
                 if (last != NULL)
                     last->Next = act->Next;
@@ -140,7 +140,7 @@ void CThreadQueue::UnlockItem(HANDLE thread, BOOL deleteIfUnlocked)
         }
     }
     else
-        TRACE_E("CThreadQueue::UnlockItem(): unable to find thread!"); // to nebyl zamknuty, ze je smazany?
+        TRACE_E("CThreadQueue::UnlockItem(): unable to find thread!"); // wasn't it locked because it was deleted?
 
     CS.Leave();
 }
@@ -151,7 +151,7 @@ BOOL CThreadQueue::WaitForExit(HANDLE thread, int milliseconds)
     BOOL ret = TRUE;
     if (thread != NULL)
     {
-        if (FindAndLockItem(thread)) // handle threadu nalezen a uzamcen - muzeme na nej cekat, pak ho zrusime
+        if (FindAndLockItem(thread)) // thread handle found and locked — it is safe to wait and then remove it
         {
             ret = WaitForSingleObject(thread, milliseconds) != WAIT_TIMEOUT;
 
@@ -168,10 +168,10 @@ void CThreadQueue::KillThread(HANDLE thread, DWORD exitCode)
     CALL_STACK_MESSAGE2("CThreadQueue::KillThread(, %d)", exitCode);
     if (thread != NULL)
     {
-        if (FindAndLockItem(thread)) // handle threadu nalezen a uzamcen - muzeme ho terminovat, pak ho zrusime
+        if (FindAndLockItem(thread)) // thread handle found and locked — it is safe to terminate it and then remove it
         {
             TerminateThread(thread, exitCode);
-            WaitForSingleObject(thread, INFINITE); // pockame az thread skutecne skonci, nekdy mu to dost trva
+            WaitForSingleObject(thread, INFINITE); // wait until the thread really ends; sometimes it takes quite a while
 
             UnlockItem(thread, TRUE);
         }
@@ -188,7 +188,7 @@ BOOL CThreadQueue::KillAll(BOOL force, int waitTime, int forceWaitTime, DWORD ex
 
     CS.Enter();
 
-    // vykillujeme vsechny thready, ktere nehodlaji koncit sami
+    // terminate every thread that is not going to exit on its own
     CThreadQueueItem* prevItem = NULL;
     CThreadQueueItem* item = Head;
     while (item != NULL)
@@ -196,11 +196,11 @@ BOOL CThreadQueue::KillAll(BOOL force, int waitTime, int forceWaitTime, DWORD ex
         BOOL leaveCS = FALSE;
         DWORD ec;
         if (GetExitCodeThread(item->Thread, &ec) && ec == STILL_ACTIVE)
-        { // thread jeste nejspis bezi
+        { // the thread is still almost certainly running
             DWORD t = GetTickCount() - ti;
-            if (w == INFINITE || t < w) // mame jeste cekat
+            if (w == INFINITE || t < w) // we should keep waiting
             {
-                // uvolnime frontu pro dalsi thready (aby se napr. dockaly ukonceni threadu z fronty a pak se sami ukoncily)
+                // release the queue so other threads can, for example, wait for a queued worker to finish and then exit
                 CS.Leave();
 
                 if (w == INFINITE || 50 < w - t)
@@ -208,34 +208,34 @@ BOOL CThreadQueue::KillAll(BOOL force, int waitTime, int forceWaitTime, DWORD ex
                 else
                 {
                     Sleep(w - t);
-                    ti -= w; // pro priste vyradime test na cekani
+                    ti -= w; // skip the next wait-interval check
                 }
 
                 CS.Enter();
                 item = Head;
                 prevItem = NULL;
-                continue; // zacneme pekne od zacatku (podminka cyklu se otestuje)
+                continue; // restart the iteration (re-evaluates the loop condition)
             }
-            if (force) // zabijeme ho
+            if (force) // terminate the thread forcibly
             {
                 TRACE_E("Thread has not ended itself, we must terminate it (" << QueueName << " queue).");
                 TerminateThread(item->Thread, exitCode);
-                WaitForSingleObject(item->Thread, INFINITE); // pockame az thread skutecne skonci, nekdy mu to dost trva
-                // pokud nejaky thread ceka na ukonceni prave zabiteho threadu, pustime pro nej na chvilku
-                // frontu, jinak zustane zasekly v UnlockItem()
+                WaitForSingleObject(item->Thread, INFINITE); // wait until the thread really ends; sometimes it takes a while
+                // if another thread is waiting for the one we just terminated, release the queue
+                // for a moment so it does not get stuck inside UnlockItem()
                 leaveCS = item->Locks > 0;
             }
-            else // bez 'force' jen ohlasime, ze jeste neco bezi
+            else // without 'force' we merely report that something is still running
             {
                 TRACE_I("KillAll(): At least one thread is still running in " << QueueName << " queue.");
-                ClearFinishedThreads(); // jen tak pro prehlednost pri debugovani
+                ClearFinishedThreads(); // keep the debugging output tidy
                 CS.Leave();
                 return FALSE;
             }
         }
         CThreadQueueItem* delItem = item;
         item = item->Next;
-        if (delItem->Locks == 0) // handle je mozne zavrit, polozku smazat
+        if (delItem->Locks == 0) // the handle can be closed, delete the item
         {
             if (Head == delItem)
                 Head = item;
@@ -245,19 +245,19 @@ BOOL CThreadQueue::KillAll(BOOL force, int waitTime, int forceWaitTime, DWORD ex
             delete delItem;
         }
         else
-            prevItem = delItem; // handle musime nechat byt, takze i polozku
+            prevItem = delItem; // we must leave the handle alone, so the list item stays
 
         if (leaveCS)
         {
-            // uvolnime frontu pro dalsi thready (aby se napr. dockaly ukonceni threadu z fronty a pak se sami ukoncily)
+            // release the queue so other threads can, for example, wait for a queued worker to finish and then exit
             CS.Leave();
 
-            Sleep(50); // chvilka na prevzeti fronty a prip. dobeh threadu (nez ho pujdeme zabit jako vsechny ostatni)
+            Sleep(50); // give the queue a moment to be taken over and possibly let the thread finish before we terminate it like the rest
 
             CS.Enter();
             item = Head;
             prevItem = NULL;
-            continue; // zacneme pekne od zacatku (podminka cyklu se otestuje)
+            continue; // restart the iteration (re-evaluates the loop condition)
         }
     }
 
@@ -277,14 +277,14 @@ CThreadQueue::ThreadBase(void* param)
 {
     CThreadBaseData* d = (CThreadBaseData*)param;
 
-    // zaloha dat na stack ('d' prestane byt platne po 'Continue')
+    // copy the data to the stack ('d' stops being valid once Continue is signaled)
     unsigned(WINAPI * threadBody)(void*) = d->Body;
     void* threadParam = d->Param;
 
-    SetEvent(d->Continue); // pustime dal hl. thread
+    SetEvent(d->Continue); // let the main thread continue
     d = NULL;
 
-    // spustime nas thread
+    // start our thread
     return SalamanderDebug->CallWithCallStack(threadBody, threadParam);
 }
 
@@ -310,11 +310,10 @@ CThreadQueue::StartThread(unsigned(WINAPI* body)(void*), void* param, unsigned s
     data.Param = param;
     data.Continue = Continue;
 
-    // spustime thread, nepouzivame _beginthreadex(), protoze ten ma od VC2015 side-effect v podobe
-    // dalsiho loadu tohoto modulu (pluginu), ktery sice pri beznem ukonceni zase uvolni,
-    // ale kdyz pouzijeme TerminateThread(), zustane modul naloadeny az do ukonceni procesu
-    // Salamandera, pak se teprve spusti destruktory globalnich objektu a to muze vest
-    // k necekanym padum, protoze uz jsou vsechny pluginove rozhrani uvolnene (napr.
+    // start the thread; we do not call _beginthreadex(), because starting with VC2015 it loads this module (plugin) again
+    // and releases it only during a normal shutdown; when we call TerminateThread(), the module stays loaded until the
+    // Salamander process terminates, and only then are the destructors of global objects run, which can cause unexpected
+    // crashes because all plugin interfaces are already released (for example,
     // SalamanderDebug)
     DWORD tid;
     HANDLE thread = CreateThread(NULL, stack_size, CThreadQueue::ThreadBase, &data, CREATE_SUSPENDED, &tid);
@@ -328,12 +327,12 @@ CThreadQueue::StartThread(unsigned(WINAPI* body)(void*), void* param, unsigned s
     }
     else
     {
-        // pridame thread do fronty threadu tohoto pluginu
+        // add the thread to this plugin's queue
         if (!Add(new CThreadQueueItem(thread, tid)))
         {
             TRACE_E("Unable to add thread to the queue.");
-            TerminateThread(thread, 666);          // je suspended, takze nebude v zadne kriticke sekci, atd.
-            WaitForSingleObject(thread, INFINITE); // pockame az thread skutecne skonci, nekdy mu to dost trva
+            TerminateThread(thread, 666);          // it is suspended, so it will not be in any critical section, etc.
+            WaitForSingleObject(thread, INFINITE); // wait until the thread really ends; sometimes it takes quite a while
             CloseHandle(thread);
 
             CS.Leave();
@@ -341,7 +340,7 @@ CThreadQueue::StartThread(unsigned(WINAPI* body)(void*), void* param, unsigned s
             return NULL;
         }
 
-        // zapis dokud thread nebezi (zarucuje, ze uz nedobehl a jeho objekt neni dealokovany)
+        // assign while the thread is still suspended (ensures it has not finished and its queue entry has not been deleted yet)
         if (threadHandle != NULL)
             *threadHandle = thread;
         if (threadID != NULL)
@@ -350,7 +349,7 @@ CThreadQueue::StartThread(unsigned(WINAPI* body)(void*), void* param, unsigned s
         SalamanderDebug->TraceAttachThread(thread, tid);
         ResumeThread(thread);
 
-        WaitForSingleObject(Continue, INFINITE); // pockame na predani dat do CThreadQueue::ThreadBase
+        WaitForSingleObject(Continue, INFINITE); // wait until CThreadQueue::ThreadBase receives the data
 
         CS.Leave();
 
@@ -379,15 +378,15 @@ CThread::UniversalBody(void* param)
     CALL_STACK_MESSAGE2("CThread::UniversalBody(thread name = \"%s\")", thread->Name);
     SalamanderDebug->SetThreadNameInVCAndTrace(thread->Name);
 
-    unsigned ret = thread->Body(); // spusteni tela threadu
+    unsigned ret = thread->Body(); // run the actual thread body
 
-    delete thread; // likvidace objektu threadu
+    delete thread; // destroy the thread object
     return ret;
 }
 
 HANDLE
 CThread::Create(CThreadQueue& queue, unsigned stack_size, DWORD* threadID)
 {
-    // POZOR: po volani StartThread() muze byt 'this' neplatny (proto je zapis do 'Thread' uvnitr)
+    // WARNING: StartThread() may destroy 'this', so the assignment to 'Thread' happens inside that call
     return queue.StartThread(UniversalBody, this, stack_size, &Thread, threadID);
 }

--- a/src/plugins/shared/auxtools.h
+++ b/src/plugins/shared/auxtools.h
@@ -19,8 +19,8 @@
 struct CThreadQueueItem
 {
     HANDLE Thread;
-    DWORD ThreadID; // jen pro ladici ucely (nalezeni threadu v seznamu threadu v debuggeru)
-    int Locks;      // pocet zamku, je-li > 0 nesmime zavrit 'Thread'
+    DWORD ThreadID; // for debugging purposes only (finding the thread in the debugger's thread list)
+    int Locks;      // number of locks; if > 0 we must not close 'Thread'
     CThreadQueueItem* Next;
 
     CThreadQueueItem(HANDLE thread, DWORD tid)
@@ -35,11 +35,11 @@ struct CThreadQueueItem
 class CThreadQueue
 {
 protected:
-    const char* QueueName; // jmeno fronty (jen pro debugovaci ucely)
+    const char* QueueName; // queue name (for debugging purposes only)
     CThreadQueueItem* Head;
-    HANDLE Continue; // musime pockat na predani dat do startovaneho threadu
+    HANDLE Continue; // we must wait until the started thread takes the handed-off data
 
-    struct CCS // pristup z vice threadu -> nutna synchronizace
+    struct CCS // access from multiple threads -> synchronization required
     {
         CRITICAL_SECTION cs;
 
@@ -51,98 +51,92 @@ protected:
     } CS;
 
 public:
-    CThreadQueue(const char* queueName /* napr. "DemoPlug Viewers" */);
+    CThreadQueue(const char* queueName /* e.g. "DemoPlug Viewers" */);
     ~CThreadQueue();
 
-    // spusti funkci 'body' s parametrem 'param' v nove vytvorenem threadu se zasobnikem
-    // o velikosti 'stack_size' (0 = default); vraci handle threadu nebo NULL pri chybe,
-    // zaroven vysledek zapise pred spustenim threadu (resume) i do 'threadHandle'
-    // (neni-li NULL), vraceny handle threadu pouzivat jen na testy na NULL a pro volani
-    // metod CThreadQueue: WaitForExit() a KillThread(); zavreni handlu threadu zajistuje
-    // tento objekt fronty
-    // POZOR: -thread se muze spustit se zpozdenim az po navratu ze StartThread()
-    //         (je-li 'param' ukazatel na strukturu ulozenou na zasobniku, je nutne
-    //          synchronizovat predani dat z 'param' - hl. thread musi pockat
-    //          na prevzeti dat novym threadem)
-    //        -vraceny handle threadu jiz muze byt zavreny pokud thread dobehne pred
-    //         navratem ze StartThread() a z jineho threadu se vola StartThread() nebo
-    //         KillAll()
-    // mozne volat z libovolneho threadu
+    // runs 'body(param)' in a newly created thread whose stack has size 'stack_size' (0 = default);
+    // returns the thread handle or NULL on error and, before the thread resumes, stores the handle to 'threadHandle'
+    // (if it is not NULL); use the returned handle only for NULL checks and for calls to the CThreadQueue helpers
+    // WaitForExit() and KillThread(), because the queue object closes the handle
+    // WARNING: - the thread might not start until StartThread() returns
+    //          (if 'param' references stack storage, coordinate the hand-off — the main thread must wait until the worker copies it)
+    //         - the returned thread handle may already be closed if the thread finishes before
+    //           StartThread() returns and another thread calls StartThread() or KillAll()
+    // can be called from any thread
     HANDLE StartThread(unsigned(WINAPI* body)(void*), void* param, unsigned stack_size = 0,
                        HANDLE* threadHandle = NULL, DWORD* threadID = NULL);
 
-    // ceka na ukonceni threadu z teto fronty; 'thread' je handle threadu, ktery jiz muze
-    // byt i zavreny (zavira tento objekt pri volani StartThread a KillAll); pokud se
-    // docka ukonceni threadu, vyradi thread z fronty a zavre jeho handle
+    // waits for a thread from this queue to finish; 'thread' is a thread handle that may already
+    // be closed (this object closes it when StartThread or KillAll is called); if the wait
+    // succeeds, it removes the entry from the queue and closes the handle
     BOOL WaitForExit(HANDLE thread, int milliseconds = INFINITE);
 
-    // zabije thread z teto fronty (pres TerminateThread()); 'thread' je handle threadu,
-    // ktery jiz muze byt i zavreny (zavira tento objekt pri volani StartThread a KillAll);
-    // pokud thread najde, zabije ho, vyradi z fronty a zavre jeho handle (objekt threadu
-    // se nedealokuje, protoze jeho stav je neznamy, mozna nekonzistentni)
+    // kills a thread from this queue (via TerminateThread()); 'thread' is a thread handle
+    // that may already be closed (this object closes it when StartThread or KillAll is called);
+    // if it finds the thread, it terminates it, removes it from the queue, and closes its handle (the thread object
+    // is not deallocated because its state is unknown and possibly inconsistent)
     void KillThread(HANDLE thread, DWORD exitCode = 666);
 
-    // overi, ze vsechny thready skoncily; je-li 'force' TRUE a nejaky thread jeste bezi,
-    // ceka 'forceWaitTime' (v ms) na ukonceni vsech threadu, pak bezici thready zabije
-    // (jejich objekty se nedealokuji, protoze jejich stav je neznamy, mozna nekonzistentni);
-    // vraci TRUE, jsou-li vsechny thready ukoncene, pri 'force' TRUE vzdy vraci TRUE;
-    // je-li 'force' FALSE a nejaky thread jeste bezi, ceka 'waitTime' (v ms) na ukonceni
-    // vsech threadu, pokud pak jeste stale neco bezi, vraci FALSE; cas INFINITE = neomezene
-    // dlouhe cekani
-    // mozne volat z libovolneho threadu
+    // checks that all threads have finished; if 'force' is TRUE and some thread is still running,
+    // it waits 'forceWaitTime' (in ms) for them to finish, then terminates any that are still alive
+    // (their objects are not deallocated because their state is unknown and possibly inconsistent);
+    // returns TRUE if all threads end; with 'force' TRUE it always returns TRUE;
+    // if 'force' is FALSE and some thread is still running, it waits 'waitTime' (in ms) for them to finish;
+    // if something still runs afterwards, it returns FALSE; INFINITE means it waits without a limit
+    // can be called from any thread
     BOOL KillAll(BOOL force, int waitTime = 1000, int forceWaitTime = 200, DWORD exitCode = 666);
 
-protected:                                                 // vnitrni nesynchronizovane metody
-    BOOL Add(CThreadQueueItem* item);                      // prida polozku do fronty, vraci uspech
-    BOOL FindAndLockItem(HANDLE thread);                   // najde polozku pro 'thread' ve fronte a zamkne ji
-    void UnlockItem(HANDLE thread, BOOL deleteIfUnlocked); // odemkne polozku pro 'thread' ve fronte, pripadne ji smaze
-    void ClearFinishedThreads();                           // vyradi z fronty thready, ktere jiz dobehly
-    static DWORD WINAPI ThreadBase(void* param);           // univerzalni body threadu
+protected:                                                 // internal non-synchronized methods
+    BOOL Add(CThreadQueueItem* item);                      // adds an item to the queue, returns success
+    BOOL FindAndLockItem(HANDLE thread);                   // finds the item for 'thread' in the queue and locks it
+    void UnlockItem(HANDLE thread, BOOL deleteIfUnlocked); // unlocks the item for 'thread' in the queue, optionally deletes it
+    void ClearFinishedThreads();                           // removes threads that have already finished from the queue
+    static DWORD WINAPI ThreadBase(void* param);           // universal thread body
 };
 
 //
 // ****************************************************************************
 // CThread
 //
-// POZOR: musi se alokovat (neni mozne mit CThread jen na stacku); dealokuje se sam
-//        jen v pripade uspesneho vytvoreni threadu metodou Create()
+// WARNING: must be allocated (it is not possible to have CThread on the stack); it deletes itself
+//        only when the thread is successfully created by the Create() method
 
 class CThread
 {
 public:
-    // handle threadu (NULL = thread jeste nebezi/nebezel), POZOR: po ukonceni threadu se
-    // sam zavira (je neplatny), navic tento objekt uz je dealokovany
+    // thread handle (NULL if the thread has not started yet or is no longer running); WARNING: once the thread ends it
+    // closes itself (becomes invalid), and by then this object has already been deallocated
     HANDLE Thread;
 
 protected:
-    char Name[101]; // buffer pro jmeno threadu (pouziva se v TRACE a CALL-STACK pro identifikaci threadu)
-                    // POZOR: pokud budou data threadu obsahovat odkazy na stack nebo jine docasne objekty,
-                    //        je potreba zajistit, aby se s temito odkazy pracovalo jen po dobu jejich platnosti
+    char Name[101]; // buffer for the thread name (TRACE and CALL-STACK use it to identify the thread)
+                    // WARNING: if the thread data contains references to the stack or other temporary objects,
+                    //         ensure these references are used only while they remain valid
 
 public:
     CThread(const char* name = NULL);
-    virtual ~CThread() {} // aby se spravne volaly destruktory potomku
+    virtual ~CThread() {} // to ensure destructors of derived classes are called correctly
 
-    // vytvoreni (start) threadu ve fronte threadu 'queue'; 'stack_size' je velikost zasobniku
-    // noveho threadu v bytech (0 = default); vraci handle noveho threadu nebo NULL pri chybe;
-    // zavreni handlu zajistuje objekt 'queue'; pokud se podari vytvorit thread, je tento objekt
-    // dealokovan pri ukonceni threadu, pri chybe spousteni je dealokace objektu na volajicim
-    // POZOR: bez pridani synchronizace muze thread dobehnout jeste pred navratem z Create() ->
-    //        ukazatel "this" je proto po uspesnem volani Create() nutne povazovat za neplatny,
-    //        to same plati pro vraceny handle threadu (pouzivat jen na testy na NULL a pro volani
-    //        metod CThreadQueue: WaitForExit() a KillThread())
-    // mozne volat z libovolneho threadu
+    // creates (starts) a thread in the thread queue 'queue'; 'stack_size' is the stack size
+    // of the new thread in bytes (0 = default); returns the new thread handle or NULL on error;
+    // the 'queue' object closes the handle; if the thread is created, this object
+    // is deallocated when the thread finishes; if starting the thread fails, the caller must deallocate the object
+    // WARNING: without extra synchronization the thread may finish before Create() returns ->
+    //         therefore once Create() succeeds the pointer 'this' must be considered invalid,
+    //         and the same applies to the returned thread handle (use it only for NULL checks and for calling
+    //         the CThreadQueue helpers WaitForExit() and KillThread())
+    // can be called from any thread
     HANDLE Create(CThreadQueue& queue, unsigned stack_size = 0, DWORD* threadID = NULL);
 
-    // vraci 'Thread' viz vyse
+    // returns the 'Thread' member as described above
     HANDLE GetHandle() { return Thread; }
 
-    // vraci jmeno threadu
+    // returns the thread name
     const char* GetName() { return Name; }
 
-    // tato metoda obsahuje telo threadu
+    // this method implements the thread body
     virtual unsigned Body() = 0;
 
 protected:
-    static unsigned WINAPI UniversalBody(void* param); // pomocna metoda pro spousteni threadu
+    static unsigned WINAPI UniversalBody(void* param); // helper method for starting threads
 };

--- a/src/plugins/shared/dbg.cpp
+++ b/src/plugins/shared/dbg.cpp
@@ -16,8 +16,8 @@
 #include <crtdbg.h>
 #endif // _MSC_VER
 
-// potlaceni warningu C4996: This function or variable may be unsafe. Consider using strcat_s instead.
-// duvod: lstrcat a dalsi Windows rutiny prost nejsou safe, takze to nema smysl resit tady
+// suppress warning C4996: This function or variable may be unsafe. Consider using strcat_s instead.
+// reason: lstrcat and other Windows routines simply are not safe, so there is no point handling it here
 #pragma warning(push)
 #pragma warning(disable : 4996)
 
@@ -209,8 +209,8 @@ C__Trace::SetInfoW(const WCHAR* file, int line)
 
 struct C__TraceMsgBoxThreadData
 {
-    char* Msg;        // alokovany text hlasky
-    const char* File; // jen odkaz na staticky string
+    char* Msg;        // allocated message text
+    const char* File; // only a reference to a static string
     int Line;
 };
 
@@ -239,8 +239,8 @@ DWORD WINAPI __TraceMsgBoxThread(void* param)
 
 struct C__TraceMsgBoxThreadDataW
 {
-    WCHAR* Msg;        // alokovany text hlasky
-    const WCHAR* File; // jen odkaz na staticky string
+    WCHAR* Msg;        // allocated message text
+    const WCHAR* File; // only a reference to a static string
     int Line;
 };
 
@@ -265,7 +265,7 @@ DWORD WINAPI __TraceMsgBoxThreadW(void* param)
 
 void C__Trace::SendMessageToServer(BOOL information, BOOL unicode, BOOL crash)
 {
-    // flushnuti do bufferu
+    // flush the current buffer contents
     if (unicode)
         TraceStrStreamW.flush();
     else
@@ -287,19 +287,19 @@ void C__Trace::SendMessageToServer(BOOL information, BOOL unicode, BOOL crash)
                 SalamanderDebug->TraceE(File, Line, TraceStringBuf.c_str());
         }
     }
-    // jen je-li crash==TRUE:
-    // vyrobime kopii dat, start threadu pro msgbox totiz muze vyvolat dalsi TRACE
-    // hlasky (napr. v DllMain reakce na DLL_THREAD_ATTACH), pokud bysme neopustili
-    // CriticalSection, nastal by deadlock;
-    // v DllMain se nesmi pouzivat TRACE_C, jinak dojde k deadlocku:
-    //   - pokud se da do DLL_THREAD_ATTACH: chce si otevrit novy thread pro msgbox
-    //     a to je z DllMainu blokovane
-    //   - pokud se da do DLL_THREAD_DETACH: pri cekani na zavreni threadu s msgboxem
-    //     predesleho TRACE_C zachytime TRACE_C z DLL_THREAD_DETACH a nechame ho
-    //     cekat v nekonecnem cyklu, viz nize
-    // navic zavadime obranu proti mnozeni msgboxu pri vice TRACE_C zaroven, pusobilo
-    // by to jen zmatky, ted se otevre msgbox jen pro prvni a ten po uzavreni vyvola
-    // padacku, ostatni TRACE_C zustanou chyceny v nekonecne cekaci smycce, viz nize
+    // only when crash == TRUE:
+    // clone the data, because starting the message-box thread may itself trigger another TRACE
+    // message (for example, in DllMain when reacting to DLL_THREAD_ATTACH); if we stayed inside the
+    // CriticalSection we would deadlock;
+    // TRACE_C must not be used in DllMain, otherwise a deadlock occurs:
+    //   - if it is placed in DLL_THREAD_ATTACH: it wants to spawn a new thread for the message box,
+    //     which DllMain blocks
+    //   - if it is placed in DLL_THREAD_DETACH: while waiting for the message-box thread from the
+    //     previous TRACE_C to close we catch TRACE_C from DLL_THREAD_DETACH and leave it
+    //     spinning in an infinite loop, see below
+    // we also guard against spawning multiple message boxes when several TRACE_C run at once;
+    // that would only cause confusion. Now the box opens just for the first one and, once closed, it
+    // triggers the crash; the other TRACE_C stay parked in the infinite wait loop described below
     static BOOL msgBoxOpened = FALSE;
     C__TraceMsgBoxThreadData threadData;
     C__TraceMsgBoxThreadDataW threadDataW;
@@ -307,7 +307,7 @@ void C__Trace::SendMessageToServer(BOOL information, BOOL unicode, BOOL crash)
         memset(&threadDataW, 0, sizeof(threadDataW));
     else
         memset(&threadData, 0, sizeof(threadData));
-    if (crash) // break/padacka po vypisu TRACE error hlasky (TRACE_C a TRACE_MC)
+    if (crash) // breakpoint/crash after printing the TRACE error message (TRACE_C and TRACE_MC)
     {
         if (!msgBoxOpened)
         {
@@ -343,36 +343,35 @@ void C__Trace::SendMessageToServer(BOOL information, BOOL unicode, BOOL crash)
         }
     }
     if (unicode)
-        TraceStringBufW.erase(); // priprava pro dalsi trace
+        TraceStringBufW.erase(); // prepare for the next trace
     else
         TraceStringBuf.erase();
     LeaveCriticalSection(&CriticalSection);
     if (crash)
     {
-        if (unicode && threadDataW.Msg != NULL || // break/padacka po vypisu TRACE error hlasky (TRACE_C a TRACE_MC)
+        if (unicode && threadDataW.Msg != NULL || // breakpoint/crash after printing the TRACE error message (TRACE_C and TRACE_MC)
             !unicode && threadData.Msg != NULL)
         {
-            // vypiseme hlasku v jinem threadu, aby nepumpovala zpravy aktualniho threadu
+            // display the message in another thread so the current thread does not have to pump messages
             DWORD id;
             HANDLE msgBoxThread = CreateThread(NULL, 0, unicode ? __TraceMsgBoxThreadW : __TraceMsgBoxThread,
                                                unicode ? (void*)&threadDataW : (void*)&threadData, 0, &id);
             if (msgBoxThread != NULL)
             {
-                WaitForSingleObject(msgBoxThread, INFINITE); // pokud se da TRACE_C do DllMain do DLL_THREAD_ATTACH, dojde k deadlocku - silne nepravdepodobne, neresime
+                WaitForSingleObject(msgBoxThread, INFINITE); // if TRACE_C sits in DllMain's DLL_THREAD_ATTACH, it deadlocks — highly unlikely, not handled
                 CloseHandle(msgBoxThread);
             }
             msgBoxOpened = FALSE;
             GlobalFree(unicode ? (HGLOBAL)threadDataW.Msg : (HGLOBAL)threadData.Msg);
-            // pad softu vyvolame primo v kodu, kde je umisteny TRACE_C/TRACE_MC, aby
-            // bylo v bug reportu videt presne kde makra lezi; padacka tedy nasleduje
-            // po dokonceni teto metody
+            // trigger the crash in the code where TRACE_C/TRACE_MC lives so the bug report pinpoints
+            // the macro location; as a result, the crash happens only after this method returns
         }
-        else // ostatni thready s TRACE_C zablokujeme, az se zavre msgbox otevreny pro
-        {    // prvni TRACE_C, tak to tam i spadne, at v tom neni bordel
+        else // block other threads with TRACE_C until the message box opened for
+        {    // the first TRACE_C closes; then it crashes there as well to keep things tidy
             if (msgBoxOpened)
             {
                 while (1)
-                    Sleep(1000); // blokace vede na deadlock napr. kdyz je (a nema byt) TRACE_C v DLL_THREAD_DETACH
+                    Sleep(1000); // blocking causes a deadlock, for example when TRACE_C (incorrectly) runs in DLL_THREAD_DETACH
             }
         }
     }
@@ -394,11 +393,10 @@ void* _sal_safe_memcpy(void* dest, const void* src, size_t count)
 
 #endif // defined(TRACE_ENABLE) && !defined(INSIDE_SALAMANDER)
 
-// pasticka na vlastni definici techto "zakazanych" operatoru (aby fungovala kontrola
-// zakazanych kombinaci stringu WCHAR / char v TRACE makrech, nesmi byt nasledujici
-// operatory definovany v jinych modulech - jinak by linker neohlasil chybu - idea:
-// v DEBUG verzi chytame chyby linkeru, v RELEASE verzi chytame chyby vlastni definice
-// operatoru)
+// trap for custom definitions of these "forbidden" operators (to keep the check working
+// for forbidden WCHAR / char string combinations in TRACE macros, the following
+// operators must not be defined in other modules — otherwise the linker would not report an error; the idea is:
+// in the DEBUG build we catch linker errors, in the RELEASE build we catch custom operator definitions)
 #if !defined(_DEBUG) && !defined(INSIDE_SALAMANDER) && !defined(__BORLANDC__)
 
 #include <ostream>

--- a/src/plugins/shared/dbg.h
+++ b/src/plugins/shared/dbg.h
@@ -11,36 +11,35 @@
 
 #pragma once
 
-// definice maker TRACE_I, TRACE_IW, TRACE_E, TRACE_EW, TRACE_C, TRACE_CW a CALL_STACK_MESSAGEXXX pro pluginy,
-// v pluginu je treba definovat promennou SalamanderDebug (typ viz nize) a
-// v SalamanderPluginEntry tuto promennou inicializovat:
+// This header defines the macros TRACE_I, TRACE_IW, TRACE_E, TRACE_EW, TRACE_C, TRACE_CW, and CALL_STACK_MESSAGEXXX for plugins.
+// Every plugin must declare the SalamanderDebug variable (type see below) and
+// initialize the variable in SalamanderPluginEntry:
 // SalamanderDebug = salamander->GetSalamanderDebug();
 //
-// TRACE se zapina definici makra TRACE_ENABLE
-// CALL-STACK se vypina definici makra CALLSTK_DISABLE
+// enable TRACE by defining the TRACE_ENABLE macro
+// disable CALL-STACK by defining the CALLSTK_DISABLE macro
 
-// POZOR: TRACE_C se nesmi pouzivat v DllMain knihoven, ani v zadnem kodu, ktery
-//        se z DllMainu vola, jinak dojde k deadlocku, vice viz implementace
-//        C__Trace::SendMessageToServer
+// WARNING: TRACE_C must not be used in a library's DllMain, nor in any code that
+//        runs from DllMain; otherwise a deadlock occurs — see C__Trace::SendMessageToServer
+//        for the details
 
-// makro CALLSTK_MEASURETIMES - zapne mereni casu straveneho pri priprave call-stack hlaseni (meri se pomer proti
-//                              celkovemu casu behu funkci)
-//                              POZOR: nutne zapnout tez pro kazdy plugin zvlast
-// makro CALLSTK_DISABLEMEASURETIMES - potlaci mereni casu straveneho pri priprave call-stack hlaseni v DEBUG verzi
+// macro CALLSTK_MEASURETIMES - enables measuring the time spent preparing call-stack messages (records the ratio against
+//                              the total execution time of the function)
+//                              WARNING: must be enabled separately for every plugin
+// macro CALLSTK_DISABLEMEASURETIMES - suppresses the timing of call-stack message preparation in the DEBUG build
 
-// prehled typu maker: (vsechna jsou neprazdna jen pokud neni definovano CALLSTK_DISABLE)
-// CALL_STACK_MESSAGE - bezne call-stack makro
-// SLOW_CALL_STACK_MESSAGE - call-stack makro, u ktereho se ignoruje libovolne zpomaleni kodu (pouziti
-//                           na mistech, kde vime, ze vyrazne zpomaluje kod, ale presto ho na tomto
-//                           miste potrebujeme)
-// DEBUG_SLOW_CALL_STACK_MESSAGE - call-stack makro, ktere je v release verzi prazdne, v DEBUG verzi
-//                                 se chova jako SLOW_CALL_STACK_MESSAGE (pouziti na mistech, kde jsme
-//                                 ochotni ignorovat zpomaleni jen v debug verzi, release verze je rychla)
+// overview of macro types (they expand to code only when CALLSTK_DISABLE is not defined)
+// CALL_STACK_MESSAGE - regular call-stack macro
+// SLOW_CALL_STACK_MESSAGE - call-stack macro that ignores any slowdown it causes (use
+//                           where we know it slows the code noticeably but still need it)
+// DEBUG_SLOW_CALL_STACK_MESSAGE - call-stack macro that is empty in the release build and in the DEBUG build
+//                                 behaves like SLOW_CALL_STACK_MESSAGE (use where we accept the slowdown only in debug builds;
+//                                 the release build remains fast)
 
-// globalni promenna s interfacem CSalamanderDebugAbstract
+// global variable providing the CSalamanderDebugAbstract interface
 extern CSalamanderDebugAbstract* SalamanderDebug;
 
-// kopie z spl_com.h: globalni promenna s verzi Salamandera, ve kterem je tento plugin nacteny
+// copy from spl_com.h: global variable storing the version of Salamander into which this plugin is loaded
 extern int SalamanderVersion;
 
 #ifndef __WFILE__
@@ -146,7 +145,7 @@ protected:
 
             // update pointers
             setp(ptr, ptr + newsize);
-            pbump((int)oldsize); // FIXME_X64 - je pretypovani na (int) OK?
+            pbump((int)oldsize); // FIXME_X64 - is casting to (int) OK?
         }
 
         // store the character
@@ -374,7 +373,7 @@ public:
 
 #ifndef TRACE_ENABLE
 
-// aby nedochazelo k problemum se stredniky v nize nadefinovanych makrech
+// to avoid issues with semicolons in the macros defined below
 
 // Bypasses a clang-format bug in version 19.1.5 (part of Visual Studio 2022 17.14).
 // clang-format off
@@ -391,14 +390,12 @@ inline void __TraceEmptyFunction() {}
 #define TRACE_MEW(file, line, str) __TraceEmptyFunction()
 #define TRACE_E(str) __TraceEmptyFunction()
 #define TRACE_EW(str) __TraceEmptyFunction()
-// pri crashi softu pres DebugBreak() nejde vystopovat, kde lezi volani
-// TRACE_C/TRACE_MC, protoze adresa exceptiony je kdesi v ntdll.dll
-// a sekce Stack Back Trace bug reportu muze obsahovat nesmysly, pokud
-// funkce volajici TRACE_C/TRACE_MC nepouziva stary jednoduchy model
-// ukladani a prace s EBP/ESP, ovsem i v tom pripade je zde jen adresa
-// odkud byla tato funkce volana (ne primo adresa TRACE_C/TRACE_MC),
-// proto aspon prozatim pouzivame stary primitivni zpusob crashe
-// zapisem na NULL
+// when the software crashes via DebugBreak() we cannot track where the TRACE_C/TRACE_MC
+// call sits, because the exception address ends up in ntdll.dll, and the Stack Back Trace section
+// of the bug report may contain nonsense if the function calling TRACE_C/TRACE_MC does not use the old
+// simple model of saving and working with EBP/ESP; even then we only see the address
+// from which that function was called (not the direct address of TRACE_C/TRACE_MC),
+// therefore for now we rely on the old primitive crash method: writing to NULL
 //#define TRACE_MC(file, line, str) DebugBreak()
 //#define TRACE_MCW(file, line, str) DebugBreak()
 //#define TRACE_C(str) DebugBreak()
@@ -413,7 +410,7 @@ inline void __TraceEmptyFunction() {}
 
 #else // TRACE_ENABLE
 
-// info-trace, manualne zadana pozice v souboru
+// info trace, manually specified position in the file
 #define TRACE_MI(file, line, str) \
     (::EnterCriticalSection(&__Trace.CriticalSection), __Trace.OStream() << str, \
      __Trace) \
@@ -426,7 +423,7 @@ inline void __TraceEmptyFunction() {}
         .SetInfoW(file, line) \
         .SendMessageToServer(TRUE, TRUE)
 
-// info-trace
+// info trace
 #define TRACE_I(str) TRACE_MI(__FILE__, __LINE__, str)
 #define TRACE_IW(str) TRACE_MIW(__WFILE__, __LINE__, str)
 
@@ -434,7 +431,7 @@ inline void __TraceEmptyFunction() {}
 #define TRACE_W(str) TRACE_I(str)
 #define TRACE_WW(str) TRACE_IW(str)
 
-// error-trace, manualne zadana pozice v souboru
+// error trace, manually specified position in the file
 #define TRACE_ME(file, line, str) \
     (::EnterCriticalSection(&__Trace.CriticalSection), __Trace.OStream() << str, \
      __Trace) \
@@ -447,19 +444,18 @@ inline void __TraceEmptyFunction() {}
         .SetInfoW(file, line) \
         .SendMessageToServer(FALSE, TRUE)
 
-// error-trace
+// error trace
 #define TRACE_E(str) TRACE_ME(__FILE__, __LINE__, str)
 #define TRACE_EW(str) TRACE_MEW(__WFILE__, __LINE__, str)
 
-// fatal-error-trace (CRASHING TRACE), manualne zadana pozice v souboru;
-// zastavime soft v debuggeru, pro snadne odladeni problemu, ktery prave vznikl,
-// release verze spadne a problem snad bude jasny z call-stacku v bug-reportu;
-// nepouzivame DebugBreak(), protoze pri crashi softu nejde vystopovat, kde
-// lezi volani DebugBreak(), protoze adresa exceptiony je kdesi v ntdll.dll
-// a sekce Stack Back Trace bug reportu muze obsahovat nesmysly, pokud
-// funkce, ze ktere volame TRACE_C/MC, nepouziva stary jednoduchy model ukladani
-// a prace s EBP/ESP (to zalezi na kompileru a zaplych optimalizacich), proto
-// aspon prozatim pouzivame stary primitivni zpusob crashe zapisem na NULL
+// fatal error trace (CRASHING TRACE), manually specified position in the file;
+// stop the software in the debugger to debug the problem that just occurred;
+// the release build crashes and the problem should be clear from the call stack in the bug report;
+// we do not use DebugBreak(), because when the software crashes we cannot trace where the
+// DebugBreak() call resides — the exception address is somewhere in ntdll.dll — and the Stack Back Trace
+// section of the bug report may contain nonsense if the function that calls TRACE_C/MC does not use the
+// old simple stack-frame model and work with EBP/ESP (it depends on the compiler and enabled optimizations);
+// therefore, for now we use the old primitive crash method by writing to NULL
 #define TRACE_MC(file, line, str) \
     ((::EnterCriticalSection(&__Trace.CriticalSection), __Trace.OStream() << str, \
       __Trace) \
@@ -489,13 +485,13 @@ public:
     CRITICAL_SECTION CriticalSection;
 
 protected:
-    const char* File;                    // pomocne promenne pro predani jmena souboru (ANSI)
-    const WCHAR* FileW;                  // pomocne promenne pro predani jmena souboru (unicode)
-    int Line;                            // a cisla radku, odkud se vola TRACE_X()
-    C__StringStreamBuf TraceStringBuf;   // string buffer drzici data trace streamu (ANSI)
-    C__StringStreamBufW TraceStringBufW; // string buffer drzici data trace streamu (unicode)
-    C__TraceStream TraceStrStream;       // vlastni trace stream (ANSI)
-    C__TraceStreamW TraceStrStreamW;     // vlastni trace stream (unicode)
+    const char* File;                    // helper variable that carries the file name (ANSI)
+    const WCHAR* FileW;                  // helper variable that carries the file name (Unicode)
+    int Line;                            // and the line number from which TRACE_X() is called
+    C__StringStreamBuf TraceStringBuf;   // string buffer that holds trace stream data (ANSI)
+    C__StringStreamBufW TraceStringBufW; // string buffer that holds trace stream data (Unicode)
+    C__TraceStream TraceStrStream;       // actual trace stream (ANSI)
+    C__TraceStreamW TraceStrStreamW;     // actual trace stream (Unicode)
 
 public:
     C__Trace();
@@ -529,8 +525,8 @@ protected:
 
 public:
 #if (defined(_DEBUG) || defined(CALLSTK_MEASURETIMES)) && !defined(CALLSTK_DISABLEMEASURETIMES)
-    // 'doNotMeasureTimes'==TRUE = nemerit Push tohoto call-stack makra (zrejme dost zpomaluje, ale
-    // nechceme ho vyhodit, je prilis dulezite pro debugovani)
+    // 'doNotMeasureTimes' == TRUE tells the profiler not to time the Push of this call-stack macro (it apparently slows things down,
+    // but we do not want to remove it — it is too important for debugging)
 #ifdef __BORLANDC__
     CCallStackMessage(BOOL doNotMeasureTimes, const char* format, ...)
 #else  // __BORLANDC__
@@ -563,7 +559,7 @@ public:
 #define CALLSTK_TOKEN(x, y) x##y
 #define CALLSTK_TOKEN2(x, y) CALLSTK_TOKEN(x, y)
 #ifdef __BORLANDC__
-#define CALLSTK_UNIQUE(varname) CALLSTK_TOKEN2(varname, __LINE__) // __COUNTER__ je MSVC only
+#define CALLSTK_UNIQUE(varname) CALLSTK_TOKEN2(varname, __LINE__) // __COUNTER__ is MSVC only
 #else                                                             // __BORLANDC__
 #define CALLSTK_UNIQUE(varname) CALLSTK_TOKEN2(varname, __COUNTER__)
 #endif // __BORLANDC__
@@ -812,7 +808,7 @@ extern BOOL __CallStk_T; // always TRUE - just to check format string and type o
 
 #endif // _DEBUG
 
-// prazdne makro: oznamuje CheckStk, ze u teto funkce si call-stack message neprejeme
+// empty macro: informs CheckStk that we do not want a call-stack message for this function
 #define CALL_STACK_MESSAGE_NONE
 
 //
@@ -820,8 +816,8 @@ extern BOOL __CallStk_T; // always TRUE - just to check format string and type o
 // TraceAttachCurrentThread + SetThreadNameInVCAndTrace
 //
 
-// nepouzivat pokud uz se SalamanderDebug->TraceAttachThread pro tento thread volalo (primo
-// nebo napr. pri startu threadu pres CThreadQueue::StartThread)
+// do not use if SalamanderDebug->TraceAttachThread has already been called for this thread (directly
+// or for example when starting the thread via CThreadQueue::StartThread)
 inline void TraceAttachCurrentThread() { SalamanderDebug->TraceAttachThread(GetCurrentThread(), GetCurrentThreadId()); }
 
 inline void SetThreadNameInVCAndTrace(const char* name) { SalamanderDebug->SetThreadNameInVCAndTrace(name); }

--- a/src/plugins/shared/mhandles.cpp
+++ b/src/plugins/shared/mhandles.cpp
@@ -37,7 +37,7 @@ C__Handles __Handles;
 
 //*****************************************************************************
 //
-// vlozeny modul MESSAGES (zobrazovani messageboxu v aktualnim nebo vlastnim threadu)
+// embedded MESSAGES module (displaying message boxes in the current or a separate thread)
 //
 //*****************************************************************************
 
@@ -51,15 +51,15 @@ char __ErrorBuffer[__ERROR_BUFFER_SIZE] = "";
 const char* __MessagesTitle = "Message";
 HWND __MessagesParent = NULL;
 
-// zajisti aktualnimu threadu pristup k funkcim a datum modulu
+// grants the current thread access to the module's functions and data
 void EnterMessagesModul();
-// volat az aktualni thread nebude potrebovat pristup k funkcim a datum modulu
+// call once the current thread no longer needs the module's functions or data
 void LeaveMessagesModul();
 
-/// vraci ukazatel na globalni buffer, ktery naplni retezcem z sprintf
+/// returns a pointer to the global buffer filled with the string produced by sprintf
 const char* spf(const char* formatString, ...);
 
-/// vraci ukazatel na globalni buffer, ktery naplni popisem chyby
+/// returns a pointer to the global buffer filled with the error description
 const char* err(DWORD error);
 
 #define MESSAGE(parent, str, buttons) \
@@ -75,22 +75,22 @@ const char* err(DWORD error);
         .MessageBoxT(__MessagesStringBuf.c_str(), \
                      __MessagesTitle, (buttons))
 
-/** zobrazi messagebox se zadanym textem a ikonou chyby, neni v novem
-    threadu, distribuje message volajiciho threadu */
+/** displays a message box with the specified text and an error icon without creating a new
+    thread, dispatching messages on behalf of the calling thread */
 #define MESSAGE_E(parent, str, buttons) \
     MESSAGE(parent, str, MB_ICONEXCLAMATION | (buttons))
 
-/** zobrazi messagebox se zadanym textem a ikonou informaci, v novem threadu,
-    nerozdistribuje message volajiciho threadu */
+/** displays a message box with the specified text and an information icon in a new thread,
+    without dispatching the calling thread's messages */
 #define MESSAGE_TI(str, buttons) \
     MESSAGE_T(str, MB_ICONINFORMATION | (buttons))
 
-/** zobrazi messagebox se zadanym textem a ikonou chyby, v novem threadu,
-    nerozdistribuje message volajiciho threadu */
+/** displays a message box with the specified text and an error icon in a new thread,
+    without dispatching the calling thread's messages */
 #define MESSAGE_TE(str, buttons) \
     MESSAGE_T(str, MB_ICONEXCLAMATION | (buttons))
 
-// kriticka sekce pro cely modul - monitor
+// critical section guarding the entire module — the monitor
 CRITICAL_SECTION __MessagesCriticalSection;
 
 const char* __MessagesLowMemory = "Insufficient memory.";
@@ -131,15 +131,15 @@ struct C__MessageBoxData
 };
 
 int CALLBACK __MessagesMessageBoxThreadF(C__MessageBoxData* data)
-{ // nesmi cekat na odezvu volajiciho threadu, protoze ten nebude reagovat
-    // proto je parent==NULL -> zadne disablovani oken atd.
+{ // must not wait for the caller; otherwise the caller would stop dispatching messages
+    // therefore parent == NULL -> leave the owner windows enabled, etc.
     data->Return = MessageBox(NULL, data->Text, data->Caption, data->Type | MB_SETFOREGROUND);
     return 0;
 }
 
 int C__Messages::MessageBoxT(LPCTSTR lpText, LPCTSTR lpCaption, UINT uType)
 {
-    __Handles.__MessagesStrStream.flush(); // flushnuti do bufferu (v lpText)
+    __Handles.__MessagesStrStream.flush(); // flush into the buffer (lpText references that buffer)
 
     C__MessageBoxData data;
     data.Caption = lpCaption;
@@ -147,7 +147,7 @@ int C__Messages::MessageBoxT(LPCTSTR lpText, LPCTSTR lpCaption, UINT uType)
     data.Return = 0;
 
     int len = (int)strlen(lpText) + 1;
-    char* message = (char*)malloc(len); // zaloha textu
+    char* message = (char*)malloc(len); // backup of the text
     if (message != NULL)
     {
         memcpy(message, lpText, len);
@@ -155,14 +155,14 @@ int C__Messages::MessageBoxT(LPCTSTR lpText, LPCTSTR lpCaption, UINT uType)
     }
     else
         data.Text = __MessagesLowMemory;
-    LeaveMessagesModul(); // ted uz muzou zacit blbnout ostatni thready + message loopy
+    LeaveMessagesModul(); // now other threads and message loops can run
 
-    // MessageBox nahodime v novem threadu, aby nerozeslal message tohoto threadu
+    // start the MessageBox in a new thread so this thread does not have to dispatch its messages
     DWORD threadID;
     HANDLE thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)__MessagesMessageBoxThreadF, &data, 0, &threadID);
     if (thread != NULL)
     {
-        WaitForSingleObject(thread, INFINITE); // pockame az ho user odmackne
+        WaitForSingleObject(thread, INFINITE); // wait until the user dismisses it
         CloseHandle(thread);
     }
     // else TRACE_E("Unable to show MessageBox: " << data.Caption << ": " << data.Text);
@@ -170,23 +170,23 @@ int C__Messages::MessageBoxT(LPCTSTR lpText, LPCTSTR lpCaption, UINT uType)
     if (message != NULL)
         free(message);
 
-    __MessagesStringBuf.erase(); // priprava pro dalsi message
+    __MessagesStringBuf.erase(); // prepare for the next message
 
     return data.Return;
 }
 
 int C__Messages::MessageBox(HWND hWnd, LPCTSTR lpText, LPCTSTR lpCaption, UINT uType)
 {
-    __Handles.__MessagesStrStream.flush(); // flushnuti do bufferu (v lpText)
+    __Handles.__MessagesStrStream.flush(); // flush into the buffer (lpText references that buffer)
 
     int len = (int)strlen(lpText) + 1;
-    char* message = (char*)malloc(len); // zaloha textu
+    char* message = (char*)malloc(len); // backup of the text
     char* txt = message;
     if (txt != NULL)
         memcpy(txt, lpText, len);
     else
         txt = (char*)__MessagesLowMemory;
-    LeaveMessagesModul(); // ted uz muzou zacit blbnout ostatni thready + message loopy
+    LeaveMessagesModul(); // now other threads and message loops can run
 
     if (!IsWindow(hWnd))
         hWnd = NULL;
@@ -195,7 +195,7 @@ int C__Messages::MessageBox(HWND hWnd, LPCTSTR lpText, LPCTSTR lpCaption, UINT u
     if (message != NULL)
         free(message);
 
-    __MessagesStringBuf.erase(); // priprava pro dalsi message
+    __MessagesStringBuf.erase(); // prepare for the next message
 
     return ret;
 }
@@ -232,7 +232,7 @@ const char* err(DWORD error)
 
 //*****************************************************************************
 //
-// konec vlozeneho modulu MESSAGES
+// end of the embedded MESSAGES module
 //
 //*****************************************************************************
 
@@ -678,7 +678,7 @@ C__Handles::C__Handles() : __MessagesStrStream(&__MessagesStringBuf), __Messages
 
 C__Handles::~C__Handles()
 {
-    // vyrazeni handlu, ktere se uvolnuji automaticky
+    // remove handles that are released automatically
     for (int i = Handles.Count - 1; i >= 0; i--)
     {
         if (Handles[i].Handle.Origin == __hoLoadAccelerators)
@@ -688,7 +688,7 @@ C__Handles::~C__Handles()
         else if (Handles[i].Handle.Origin == __hoGetStockObject)
             Handles.Delete(i);
     }
-    // kontrola + vypis zbylych
+    // check and print the remaining ones
     if (Handles.Count != 0)
     {
         if (MESSAGE_E(NULL, "Some monitored handles remained opened.\n"
@@ -697,7 +697,7 @@ C__Handles::~C__Handles()
         {
             if (CanUseTrace)
             {
-                SalamanderDebug->TraceConnectToServer(); // v pripade, ze nebyl nahozeny server
+                SalamanderDebug->TraceConnectToServer(); // in case the server was not started
                 TRACE_I("List of opened handles:");
                 for (int i = 0; i < Handles.Count; i++)
                 {
@@ -716,7 +716,7 @@ C__Handles::~C__Handles()
         {
             if (CanUseTrace)
             {
-                SalamanderDebug->TraceConnectToServer(); // v pripade, ze nebyl nahozeny server
+                SalamanderDebug->TraceConnectToServer(); // in case the server was not started
                 TRACE_I(__HandlesMessageNumberOpened << Handles.Count);
             }
         }
@@ -735,7 +735,7 @@ C__Handles::SetInfo(const char* file, int line, C__HandlesOutputType outputType)
     ::EnterCriticalSection(&CriticalSection);
     if (CriticalSection.RecursionCount > 1)
     {
-        DebugBreak(); // rekurzivni volani handles !!! zase nejaka maskovana message-loopa - viz call-stack
+        DebugBreak(); // recursive call to the handles helpers — likely a hidden message loop; inspect the call stack
     }
     OutputType = outputType;
     TemporaryHandle.File = file;
@@ -838,7 +838,7 @@ BOOL C__Handles::DeleteHandle(C__HandlesType& type, HANDLE handle,
             {
                 C__HandlesOrigin org = Handles[i].Handle.Origin;
                 if (org != __hoLoadAccelerators && org != __hoLoadIcon &&
-                    org != __hoGetStockObject) // nejde o handle, ktery nemusi byt uvolneny (prioritne uvolnujeme handly, ktere se musi uvolnit)
+                    org != __hoGetStockObject) // this handle is not one of the automatically released ones (prefer releasing the ones that must be freed first)
                 {
                     if (origin != NULL)
                         *origin = org;
@@ -853,7 +853,7 @@ BOOL C__Handles::DeleteHandle(C__HandlesType& type, HANDLE handle,
             }
         }
     }
-    if (foundTypeOK != -1) // nalezen jen handle, ktery nemusi byt uvolneny
+    if (foundTypeOK != -1) // only a handle that does not need to be released was found
     {
         type = Handles[foundTypeOK].Handle.Type;
         if (origin != NULL)
@@ -861,7 +861,7 @@ BOOL C__Handles::DeleteHandle(C__HandlesType& type, HANDLE handle,
         Handles.Delete(foundTypeOK);
         return TRUE;
     }
-    if (found != -1) // nalezen jen handle se shodnym cislem
+    if (found != -1) // only a handle with the same value was found
     {
 #if defined(_DEBUG) || defined(__HANDLES_DEBUG)
         if (CanUseTrace)
@@ -1101,7 +1101,7 @@ HDC C__Handles::BeginPaint(HWND hwnd, LPPAINTSTRUCT lpPaint)
     C__HandlesData tmpTemporaryHandle = TemporaryHandle;
     ::LeaveCriticalSection(&CriticalSection);
 
-    HDC ret = ::BeginPaint(hwnd, lpPaint); // obsahuje message-loopu
+    HDC ret = ::BeginPaint(hwnd, lpPaint); // runs an internal message loop
 
     ::EnterCriticalSection(&CriticalSection);
     OutputType = tmpOutputType;
@@ -1931,8 +1931,8 @@ BOOL C__Handles::DuplicateHandle(HANDLE hSourceProcessHandle, HANDLE hSourceHand
                        MB_OK);
         }
 
-        // GetCurrentProcess vraci jakysi pseudohandle, takze tahle konstrukce
-        // neni spravna, meli by se porovnat ID procesu a ne jejich handly ...
+        // GetCurrentProcess returns a sort of pseudo-handle, so this construct
+        // is not correct; we should compare process IDs rather than their handles...
 
         if ((dwOptions & DUPLICATE_CLOSE_SOURCE) &&
             hSourceProcessHandle == GetCurrentProcess())
@@ -2135,7 +2135,7 @@ BOOL C__Handles::FreeLibrary(HMODULE hLibModule)
     C__HandlesData tmpTemporaryHandle = TemporaryHandle;
     ::LeaveCriticalSection(&CriticalSection);
 
-    BOOL ret = ::FreeLibrary(hLibModule); // obsahuje volani destruktoru globalek DLLka, muze obsahovat message-loopu
+    BOOL ret = ::FreeLibrary(hLibModule); // calls DLL global destructors and may run an internal message loop
 
     ::EnterCriticalSection(&CriticalSection);
     OutputType = tmpOutputType;
@@ -2151,7 +2151,7 @@ VOID C__Handles::FreeLibraryAndExitThread(HMODULE hLibModule, DWORD dwExitCode)
     C__HandlesData tmpTemporaryHandle = TemporaryHandle;
     ::LeaveCriticalSection(&CriticalSection);
 
-    ::FreeLibraryAndExitThread(hLibModule, dwExitCode); // obsahuje volani destruktoru globalek DLLka, muze obsahovat message-loopu
+    ::FreeLibraryAndExitThread(hLibModule, dwExitCode); // calls DLL global destructors and may run an internal message loop
 
     ::EnterCriticalSection(&CriticalSection);
     OutputType = tmpOutputType;
@@ -2231,7 +2231,7 @@ BOOL C__Handles::FindCloseChangeNotification(HANDLE hChangeHandle)
     C__HandlesData tmpTemporaryHandle = TemporaryHandle;
     ::LeaveCriticalSection(&CriticalSection);
 
-    BOOL ret = ::FindCloseChangeNotification(hChangeHandle); // muze se kousnout i na dost dlouho
+    BOOL ret = ::FindCloseChangeNotification(hChangeHandle); // can get stuck for quite a long time
 
     ::EnterCriticalSection(&CriticalSection);
     OutputType = tmpOutputType;
@@ -2386,7 +2386,7 @@ HDWP C__Handles::DeferWindowPos(HDWP hWinPosInfo, HWND hWnd, HWND hWndInsertAfte
 {
     HDWP ret = ::DeferWindowPos(hWinPosInfo, hWnd, hWndInsertAfter, x, y, cx, cy, uFlags);
 
-    if (ret != hWinPosInfo) // doslo k realokaci struktury - musime zmenit hodnotu hlidaneho handlu
+    if (ret != hWinPosInfo) // the structure was reallocated - we must update the value of the monitored handle
     {
         CheckClose(TRUE, (HANDLE)hWinPosInfo, __htDeferWindowPos, __GetHandlesOrigin(__hoDeferWindowPos), ERROR_SUCCESS, FALSE);
         CheckCreate(ret != NULL, __htDeferWindowPos, __hoDeferWindowPos, (HANDLE)ret, GetLastError());
@@ -2404,7 +2404,7 @@ BOOL C__Handles::EndDeferWindowPos(HDWP hWinPosInfo)
     C__HandlesData tmpTemporaryHandle = TemporaryHandle;
     ::LeaveCriticalSection(&CriticalSection);
 
-    BOOL ret = ::EndDeferWindowPos(hWinPosInfo); // obsahuje message-loopu
+    BOOL ret = ::EndDeferWindowPos(hWinPosInfo); // runs an internal message loop
 
     ::EnterCriticalSection(&CriticalSection);
     OutputType = tmpOutputType;

--- a/src/plugins/shared/mhandles.h
+++ b/src/plugins/shared/mhandles.h
@@ -11,19 +11,19 @@
 
 #pragma once
 
-// makro MHANDLES_ENABLE - zapina monitorovani handlu
-// POZOR: volat HANDLES_CAN_USE_TRACE() tesne po inicializaci "dbg.h" modulu
-//        (po inicializaci SalamanderDebug a SalamanderVersion)
-// POZOR: MHANDLES se inicializuji/rusi na urovni "lib", pokud tedy plugin
-//        uroven "lib" (nebo "compiler") pouziva, musi si sam zajistit, ze na
-//        techto urovnich nebude pouzivat MHANDLES (viz #pragma init_seg (lib))
-// POZNAMKA: pro snazsi rozmisteni maker HANDLES() a HANDLES_Q() pouzijte program CheckHnd.exe
+// macro MHANDLES_ENABLE - enables handle monitoring
+// WARNING: call HANDLES_CAN_USE_TRACE() right after initializing the "dbg.h" module
+//        (after SalamanderDebug and SalamanderVersion are initialized)
+// WARNING: MHANDLES are initialized/destroyed at the "lib" level; if the plugin
+//        uses the "lib" (or "compiler") level, it must make sure on its own that
+//        MHANDLES are not used at those levels (see #pragma init_seg (lib))
+// NOTE: for easier placement of HANDLES() and HANDLES_Q() macros use the CheckHnd.exe tool
 
 #define NOHANDLES(function) function
 
 #ifndef MHANDLES_ENABLE
 
-// aby nedochazelo k problemum se stredniky v nize nadefinovanych makrech
+// to avoid issues with semicolons in the macros defined below
 inline void __HandlesEmptyFunction() {}
 
 #define HANDLES_CAN_USE_TRACE() __HandlesEmptyFunction()
@@ -54,8 +54,8 @@ enum C__HandlesOutputType
 
 enum C__HandlesType
 {
-    __htHandle_comp_with_CloseHandle,  // handle kompatibilni s CloseHandle() a DuplicateHandle()
-    __htHandle_comp_with_DeleteObject, // handle kompatibilni s DeleteObject() a GetStockObject()
+    __htHandle_comp_with_CloseHandle,  // handle compatible with CloseHandle() and DuplicateHandle()
+    __htHandle_comp_with_DeleteObject, // handle compatible with DeleteObject() and GetStockObject()
     __htKey,
     __htIcon,
     __htGlobal,
@@ -220,7 +220,7 @@ struct C__HandlesHandle
 {
     C__HandlesType Type;
     C__HandlesOrigin Origin;
-    HANDLE Handle; // univerzalni, pro vsechny druhy handlu
+    HANDLE Handle; // universal, for all kinds of handles
 
     C__HandlesHandle() {}
 
@@ -284,16 +284,16 @@ typedef unsigned int uintptr_t;
 class C__Handles
 {
 public:
-    // objekty pro praci s messageboxy, zde je jen pro zaruceni poradi konstrukce/destrukce
+    // objects for working with message boxes; present only to ensure construction/destruction order
     std::ostream __MessagesStrStream;
     C__Messages __Messages;
 
 protected:
-    C_HandlesDataArray Handles;       // vsechny kontrolovane handly
-    C__HandlesData TemporaryHandle;   // pri vkladani nastaven z SetInfo()
-    C__HandlesOutputType OutputType;  // typ vystupu hlasek
-    CRITICAL_SECTION CriticalSection; // pro synchronizaci multi-threadu
-    BOOL CanUseTrace;                 // TRUE az po inicializaci "dbg.h" modulu, az bude mozne pouzivat TRACE_ makra
+    C_HandlesDataArray Handles;       // all monitored handles
+    C__HandlesData TemporaryHandle;   // set by SetInfo() when adding
+    C__HandlesOutputType OutputType;  // type of message output
+    CRITICAL_SECTION CriticalSection; // for multi-thread synchronization
+    BOOL CanUseTrace;                 // TRUE only after the "dbg.h" module is initialized and TRACE_ macros can be used
 
 public:
     C__Handles();
@@ -677,9 +677,9 @@ public:
     BOOL OpenProcessToken(HANDLE ProcessHandle, DWORD DesiredAccess, PHANDLE TokenHandle);
 
 protected:
-    void AddHandle(C__HandlesHandle handle); // prida TemporaryHandle
+    void AddHandle(C__HandlesHandle handle); // adds TemporaryHandle
 
-    // vyjme handle, pri uspechu vraci TRUE
+    // removes the handle; returns TRUE on success
     BOOL DeleteHandle(C__HandlesType& type, HANDLE handle,
                       C__HandlesOrigin* origin,
                       C__HandlesType expType);


### PR DESCRIPTION
## Summary
- clarify the queue bookkeeping remarks in `CThreadQueue` to better explain locking, retries, and forced termination
- smooth the StartThread/Create documentation so hand-off and handle lifetime expectations read naturally
- improve the message-box helper notes around background threads, recursion detection, and API calls that spin their own message loops

## Testing
- not run (comment-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e92e2590a88322b064add6cdc7c34d