### PR TITLE
Refine WinLib comment translations

### DIFF
--- a/src/plugins/shared/spl_view.h
+++ b/src/plugins/shared/spl_view.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #ifdef _MSC_VER
-#pragma pack(push, enter_include_spl_view) // aby byly struktury nezavisle na nastavenem zarovnavani
+#pragma pack(push, enter_include_spl_view) // so that the structures are independent of the configured alignment
 #pragma pack(4)
 #endif // _MSC_VER
 #ifdef __BORLANDC__
@@ -29,39 +29,39 @@ struct CSalamanderPluginViewerData;
 class CPluginInterfaceForViewerAbstract
 {
 #ifdef INSIDE_SALAMANDER
-private: // ochrana proti nespravnemu primemu volani metod (viz CPluginInterfaceForViewerEncapsulation)
+private: // protection against incorrect direct calls of methods (see CPluginInterfaceForViewerEncapsulation)
     friend class CPluginInterfaceForViewerEncapsulation;
 #else  // INSIDE_SALAMANDER
 public:
 #endif // INSIDE_SALAMANDER
 
-    // funkce pro "file viewer", vola se pri pozadavku na otevreni viewru a nacteni souboru
-    // 'name', 'left'+'right'+'width'+'height'+'showCmd'+'alwaysOnTop' je doporucene umisteni
-    // okna, je-li 'returnLock' FALSE nemaji 'lock'+'lockOwner' zadny vyznam, je-li 'returnLock'
-    // TRUE, mel by viewer vratit system-event 'lock' v nonsignaled stavu, do signaled stavu 'lock'
-    // prejde v okamziku ukonceni prohlizeni souboru 'name' (soubor je v tomto okamziku odstranen
-    // z docasneho adresare), dale by mel vratit v 'lockOwner' TRUE pokud ma byt objekt 'lock' uzavren
-    // volajicim (FALSE znamena, ze si viewer 'lock' rusi sam - v tomto pripade viewer musi pro
-    // prechod 'lock' do signaled stavu pouzit metodu CSalamanderGeneralAbstract::UnlockFileInCache);
-    // pokud viewer nenastavi 'lock' (zustava NULL) je soubor 'name' platny jen do ukonceni volani teto
-    // metody ViewFile; neni-li 'viewerData' NULL, jde o predani rozsirenych parametru viewru (viz
-    // CSalamanderGeneralAbstract::ViewFileInPluginViewer); 'enumFilesSourceUID' je UID zdroje (panelu
-    // nebo Find okna), ze ktereho je viewer otviran, je-li -1, je zdroj neznamy (archivy a
-    // file_systemy nebo Alt+F11, atd.) - viz napr. CSalamanderGeneralAbstract::GetNextFileNameForViewer;
-    // 'enumFilesCurrentIndex' je index oteviraneho souboru ve zdroji (panelu nebo Find okne), je-li -1,
-    // neni zdroj nebo index znamy; vraci TRUE pri uspechu (FALSE znamena neuspech, 'lock' a
-    // 'lockOwner' v tomto pripade nemaji zadny vyznam)
+    // function for "file viewer", called when there is a request to open the viewer and load a file
+    // 'name', 'left'+'top'+'width'+'height'+'showCmd'+'alwaysOnTop' provide the recommended window placement
+    // if 'returnLock' is FALSE, 'lock'+'lockOwner' have no meaning; if 'returnLock'
+    // is TRUE, the viewer should return the system event 'lock' in the nonsignaled state; the 'lock' switches
+    // to the signaled state when viewing the file 'name' ends (the file is deleted from the temporary directory
+    // at that moment). It should also return TRUE in 'lockOwner' if the 'lock' object is to be closed by
+    // the caller (FALSE means that the viewer releases the 'lock' itself—in that case the viewer must use
+    // the method CSalamanderGeneralAbstract::UnlockFileInCache to transition 'lock' to the signaled state);
+    // if the viewer does not set 'lock' (it remains NULL) the file 'name' is valid only until this ViewFile
+    // method finishes; if 'viewerData' is not NULL, the viewer receives extended parameters (see
+    // CSalamanderGeneralAbstract::ViewFileInPluginViewer); 'enumFilesSourceUID' is the UID of the source (panel
+    // or Find window) from which the viewer is opened; if it is -1, the source is unknown (for example archives,
+    // file systems, or Alt+F11, etc.)—see for instance CSalamanderGeneralAbstract::GetNextFileNameForViewer;
+    // 'enumFilesCurrentIndex' is the index of the file being opened in that source (panel or Find window); if it is -1,
+    // the source or index is unknown; returns TRUE on success (FALSE means failure, so ignore both 'lock' and
+    // 'lockOwner' in that case)
     virtual BOOL WINAPI ViewFile(const char* name, int left, int top, int width, int height,
                                  UINT showCmd, BOOL alwaysOnTop, BOOL returnLock, HANDLE* lock,
                                  BOOL* lockOwner, CSalamanderPluginViewerData* viewerData,
                                  int enumFilesSourceUID, int enumFilesCurrentIndex) = 0;
 
-    // funkce pro "file viewer", vola se pri pozadavku na otevreni viewru a nacteni souboru
-    // 'name'; tato fuknce by nemela zobrazovat zadna okna typu "invalid file format", tato
-    // okna se zobrazi az pri volani metody ViewFile tohoto rozhrani; zjisti jestli je
-    // soubor 'name' zobrazitelny (napr. soubor ma odpovidajici signaturu) ve vieweru
-    // a pokud je, vraci TRUE; pokud vrati FALSE, zkusi Salamander pro 'name' najit jiny
-    // viewer (v prioritnim seznamu vieweru, viz konfiguracni stranka Viewers)
+    // function for "file viewer", called when there is a request to open the viewer and load the file
+    // 'name'; this function should not show any "invalid file format" windows; those windows
+    // are shown only when ViewFile of this interface is called; it checks whether
+    // the file 'name' can be displayed in the viewer (for example, whether the file has a matching signature)
+    // and if it can, it returns TRUE; if it returns FALSE, Salamander tries to find another
+    // viewer for 'name' (in the priority list of viewers, see the Viewers configuration page)
     virtual BOOL WINAPI CanViewFile(const char* name) = 0;
 };
 

--- a/src/plugins/shared/winliblt.cpp
+++ b/src/plugins/shared/winliblt.cpp
@@ -16,7 +16,7 @@
 #endif // _MSC_VER
 #include <limits.h>
 #include <stdio.h>
-//#include <commctrl.h>  // potrebuju HIMAGELIST
+//#include <commctrl.h>  // I need HIMAGELIST
 #include <ostream>
 #ifdef __BORLANDC__
 #include <stdlib.h>
@@ -42,16 +42,16 @@
 #endif // _MSC_VER
 
 char CWINDOW_CLASSNAME[100] = "";
-char CWINDOW_CLASSNAME2[100] = ""; // nema CS_VREDRAW | CS_HREDRAW
+char CWINDOW_CLASSNAME2[100] = ""; // lacks CS_VREDRAW | CS_HREDRAW
 
-ATOM AtomObject = 0; // "property" okna s ukazatelem na objekt (pouzivane ve WindowsManageru)
+ATOM AtomObject = 0; // window "property" with a pointer to the object (used in WindowsManager)
 CWindowsManager WindowsManager;
 
 char WinLibStrings[WLS_COUNT][101] = {
     "Invalid number!",
     "Error"};
 
-FWinLibLTHelpCallback WinLibLTHelpCallback = NULL; // callbacku pro pripojeni na HTML help
+FWinLibLTHelpCallback WinLibLTHelpCallback = NULL; // callback for connecting to HTML Help
 
 //
 // ****************************************************************************
@@ -74,7 +74,7 @@ BOOL InitializeWinLib(const char* pluginName, HINSTANCE dllInstance)
     lstrcpyn(CWINDOW_CLASSNAME2, pluginName, 50);
     strcat(CWINDOW_CLASSNAME2, " - WinLib Universal Window2");
 
-    AtomObject = GlobalAddAtom("object handle"); // vsechny pluginy budou pouzivat stejny atom, zadna kolize
+    AtomObject = GlobalAddAtom("object handle"); // all plugins share the same atom, so no collisions occur
     if (AtomObject == 0)
     {
         TRACE_E("GlobalAddAtom has failed");
@@ -104,13 +104,13 @@ void ReleaseWinLib(HINSTANCE dllInstance)
 {
     if (WindowsManager.WindowsCount != 0)
     {
-        // pruser - po unloadu pluginu muze spadnout soft, protoze se zavola window-procedura
-        //          v unloadnutem DLL (jde-li o okna zabita v ramci zabitych threadu, je to OK)
+        // serious trouble - after the plugin unload the program can crash because a window procedure
+        //                   in an unloaded DLL would be called (if the windows were destroyed within terminated threads, it is OK)
         TRACE_E("Unable to release WinLibLT - some window or dialog (count = " << WindowsManager.WindowsCount << ") is still attached to WinLibLT!");
-        // return;  // pokud slo o okno v killnutem threadu, pujde WinLibLT uvolnit, jinak unregister-funkce vrati error
+        // return;  // if the window belonged to a terminated thread, WinLibLT can be released; otherwise the unregister function returns an error
     }
 
-    // provedeme odregistrovani trid, aby pri dalsim loadu pluginu mohly byt znovu zaregistrovany
+    // unregister the classes so that they can be registered again when the plugin is loaded next time
     if (CWINDOW_CLASSNAME2[0] != 0 && CWINDOW_CLASSNAME[0] != 0)
     {
         if (!UnregisterClass(CWINDOW_CLASSNAME2, dllInstance))
@@ -127,8 +127,8 @@ void ReleaseWinLib(HINSTANCE dllInstance)
 // ****************************************************************************
 // CWindow
 //
-// lpvParam - v pripade, ze se pri CreateWindow zavola CWindow::CWindowProc
-//            (je v tride okna), musi obsahovat adresu objektu vytvareneho okna
+// lpvParam - if CreateWindow calls CWindow::CWindowProc
+//            (it is in the window class), it must contain the address of the window object being created
 
 HWND CWindow::CreateEx(DWORD dwExStyle,        // extended window style
                        LPCTSTR lpszClassName,  // address of registered class name
@@ -141,7 +141,7 @@ HWND CWindow::CreateEx(DWORD dwExStyle,        // extended window style
                        HWND hwndParent,        // handle of parent or owner window
                        HMENU hmenu,            // handle of menu or child-window identifier
                        HINSTANCE hinst,        // handle of application instance
-                       LPVOID lpvParam)        // ukazatel na objekt vytvareneho okna
+                       LPVOID lpvParam)        // pointer to the window object being created
 {
     HWND hWnd = CreateWindowEx(dwExStyle,
                                lpszClassName,
@@ -157,8 +157,8 @@ HWND CWindow::CreateEx(DWORD dwExStyle,        // extended window style
                                lpvParam);
     if (hWnd != 0)
     {
-        if (WindowsManager.GetWindowPtr(hWnd) == NULL) // pokud se jeste neni ve WindowsManageru
-            AttachToWindow(hWnd);                      // tak ho pridame -> subclassing
+        if (WindowsManager.GetWindowPtr(hWnd) == NULL) // if it is not already in WindowsManager
+            AttachToWindow(hWnd);                      // add it -> subclassing
     }
     return hWnd;
 }
@@ -173,7 +173,7 @@ HWND CWindow::Create(LPCTSTR lpszClassName,  // address of registered class name
                      HWND hwndParent,        // handle of parent or owner window
                      HMENU hmenu,            // handle of menu or child-window identifier
                      HINSTANCE hinst,        // handle of application instance
-                     LPVOID lpvParam)        // ukazatel na objekt vytvareneho okna
+                     LPVOID lpvParam)        // pointer to the window object being created
 {
     return CreateEx(0,
                     lpszClassName,
@@ -207,7 +207,7 @@ void CWindow::AttachToWindow(HWND hWnd)
     HWindow = hWnd;
     SetWindowLongPtr(HWindow, GWLP_WNDPROC, (LONG_PTR)CWindowProc);
 
-    if (DefWndProc == CWindow::CWindowProc) // to by byla rekurze
+    if (DefWndProc == CWindow::CWindowProc) // that would be recursion
     {
         TRACE_C("This should never happen.");
         DefWndProc = DefWindowProc;
@@ -252,8 +252,8 @@ CWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return TRUE;
         }
         if (GetWindowLong(HWindow, GWL_STYLE) & WS_CHILD)
-            break;   // pokud F1 nezpracujeme a pokud je to child okno, nechame F1 propadnout do parenta
-        return TRUE; // pokud to neni child, ukoncime zpracovani F1
+            break;   // if we do not handle F1 and it is a child window, let F1 pass to the parent
+        return TRUE; // if it is not a child, finish handling F1
     }
     }
     return CallWindowProc((WNDPROC)DefWndProc, HWindow, uMsg, wParam, lParam);
@@ -265,9 +265,9 @@ CWindow::CWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     CWindow* wnd;
     switch (uMsg)
     {
-    case WM_CREATE: // prvni zprava - pripojeni objektu k oknu
+    case WM_CREATE: // first message - attach the object to the window
     {
-        // osetrim MDI_CHILD_WINDOW
+        // handle MDI_CHILD_WINDOW
         if (((CREATESTRUCT*)lParam)->dwExStyle & WS_EX_MDICHILD)
             wnd = (CWindow*)((MDICREATESTRUCT*)((CREATESTRUCT*)lParam)->lpCreateParams)->lParam;
         else
@@ -280,8 +280,8 @@ CWindow::CWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         else
         {
             wnd->HWindow = hwnd;
-            //--- zarazeni okna podle hwnd do seznamu oken
-            if (!WindowsManager.AddWindow(hwnd, wnd)) // chyba
+            //--- insert the window into the list by hwnd
+            if (!WindowsManager.AddWindow(hwnd, wnd)) // error
             {
                 TRACE_E("Error during creating of window.");
                 return FALSE;
@@ -290,22 +290,21 @@ CWindow::CWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
-    case WM_DESTROY: // posledni zprava - odpojeni objektu od okna
+    case WM_DESTROY: // last message - detach the object from the window
     {
         wnd = (CWindow*)WindowsManager.GetWindowPtr(hwnd);
         if (wnd != NULL && wnd->Is(otWindow))
         {
-            // Petr: posunul jsem dolu pod wnd->WindowProc(), aby behem WM_DESTROY
-            //       jeste dochazely zpravy (potreboval Lukas)
+            // Petr: moved it below wnd->WindowProc() so that messages still arrive during WM_DESTROY (Lukas needed it)
             // WindowsManager.DetachWindow(hwnd);
 
             LRESULT res = wnd->WindowProc(uMsg, wParam, lParam);
 
-            // ted uz zase do stare procedury (kvuli subclassingu)
+            // now switch back to the original procedure (because of subclassing)
             WindowsManager.DetachWindow(hwnd);
 
-            // pokud aktualni WndProc je jina nez nase, nebudeme ji menit,
-            // protoze nekdo v rade subclasseni uz vratil puvodni WndProc
+            // if the current WndProc differs from ours, we will not change it
+            // because someone earlier in the subclassing chain has already restored the original WndProc
             WNDPROC currentWndProc = (WNDPROC)GetWindowLongPtr(wnd->HWindow, GWLP_WNDPROC);
             if (currentWndProc == CWindow::CWindowProc)
                 SetWindowLongPtr(wnd->HWindow, GWLP_WNDPROC, (LONG_PTR)wnd->DefWndProc);
@@ -313,9 +312,9 @@ CWindow::CWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (wnd->IsAllocated())
                 delete wnd;
             else
-                wnd->HWindow = NULL; // uz neni pripojeny
+                wnd->HWindow = NULL; // it is no longer attached
             if (res == 0)
-                return 0; // aplikace ji zpracovala
+                return 0; // the application handled it
             wnd = NULL;
         }
         break;
@@ -333,12 +332,12 @@ CWindow::CWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 #endif
     }
     }
-    //--- zavolani metody WindowProc(...) prislusneho objektu okna
+    //--- call the WindowProc(...) method of the corresponding window object
     if (wnd != NULL)
         return wnd->WindowProc(uMsg, wParam, lParam);
     else
         return DefWindowProc(hwnd, uMsg, wParam, lParam);
-    // chyba nebo message prisla pred WM_CREATE
+    // error or the message arrived before WM_CREATE
 }
 
 BOOL CWindow::RegisterUniversalClass(HINSTANCE dllInstance)
@@ -443,7 +442,7 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_INITDIALOG:
     {
         TransferData(ttDataToWindow);
-        return TRUE; // chci focus od DefDlgProc
+        return TRUE; // I want focus from DefDlgProc
     }
 
     case WM_HELP:
@@ -453,7 +452,7 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             WinLibLTHelpCallback(HWindow, HelpID);
         }
-        return TRUE; // F1 nenechame propadnout do parenta ani pokud nevolame WinLibLTHelpCallback()
+        return TRUE; // do not let F1 fall through to the parent even if WinLibLTHelpCallback() is not called
     }
 
     case WM_COMMAND:
@@ -497,7 +496,7 @@ CDialog::CDialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
     CDialog* dlg;
     switch (uMsg)
     {
-    case WM_INITDIALOG: // prvni zprava - pripojeni objektu k dialogu
+    case WM_INITDIALOG: // first message - attach the object to the dialog
     {
         dlg = (CDialog*)lParam;
         if (dlg == NULL)
@@ -508,25 +507,24 @@ CDialog::CDialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
         else
         {
             dlg->HWindow = hwndDlg;
-            //--- zarazeni okna podle hwndDlg do seznamu oken
-            if (!WindowsManager.AddWindow(hwndDlg, dlg)) // chyba
+            //--- insert the window into the list by hwndDlg
+            if (!WindowsManager.AddWindow(hwndDlg, dlg)) // error
             {
                 TRACE_E("Error during creating of dialog.");
                 return TRUE;
             }
-            dlg->NotifDlgJustCreated(); // zavedeno jako misto pro upravu layoutu dialogu
+            dlg->NotifDlgJustCreated(); // introduced as a place to adjust the dialog layout
         }
         break;
     }
 
-    case WM_DESTROY: // posledni zprava - odpojeni objektu od dialogu
+    case WM_DESTROY: // last message - detach the object from the dialog
     {
         dlg = (CDialog*)WindowsManager.GetWindowPtr(hwndDlg);
-        INT_PTR ret = FALSE; // pro pripad, ze ji nezpracuje
+        INT_PTR ret = FALSE; // in case it is not handled
         if (dlg != NULL && dlg->Is(otDialog))
         {
-            // Petr: posunul jsem dolu pod wnd->WindowProc(), aby behem WM_DESTROY
-            //       jeste dochazely zpravy (potreboval Lukas)
+            // Petr: moved it below wnd->WindowProc() so that messages still arrive during WM_DESTROY (Lukas needed it)
             // WindowsManager.DetachWindow(hwndDlg);
 
             ret = dlg->DialogProc(uMsg, wParam, lParam);
@@ -535,7 +533,7 @@ CDialog::CDialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (dlg->IsAllocated())
                 delete dlg;
             else
-                dlg->HWindow = NULL; // informace o odpojeni
+                dlg->HWindow = NULL; // record that it has been detached
         }
         return ret;
     }
@@ -552,11 +550,11 @@ CDialog::CDialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 #endif
     }
     }
-    //--- zavolani metody DialogProc(...) prislusneho objektu dialogu
+    //--- call the DialogProc(...) method of the corresponding dialog object
     if (dlg != NULL)
         return dlg->DialogProc(uMsg, wParam, lParam);
     else
-        return FALSE; // chyba nebo message neprisla mezi WM_INITDIALOG a WM_DESTROY
+        return FALSE; // error or the message did not arrive between WM_INITDIALOG and WM_DESTROY
 }
 
 //
@@ -596,7 +594,7 @@ void CPropSheetPage::Init(char* title, HINSTANCE modul, int resID,
     Flags = flags;
     Icon = icon;
 
-    ParentDialog = NULL; // nastavuje se z CPropertyDialog::Execute()
+    ParentDialog = NULL; // set from CPropertyDialog::Execute()
 }
 
 CPropSheetPage::~CPropSheetPage()
@@ -664,7 +662,7 @@ CPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         ParentDialog->HWindow = Parent;
         TransferData(ttDataToWindow);
-        return TRUE; // chci focus od DefDlgProc
+        return TRUE; // I want focus from DefDlgProc
     }
 
     case WM_HELP:
@@ -675,38 +673,38 @@ CPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             WinLibLTHelpCallback(HWindow, HelpID);
             return TRUE;
         }
-        break; // F1 nechame propadnout do parenta
+        break; // let F1 pass to the parent
     }
 
     case WM_NOTIFY:
     {
-        if (((NMHDR*)lParam)->code == PSN_KILLACTIVE) // deaktivace stranky
+        if (((NMHDR*)lParam)->code == PSN_KILLACTIVE) // page deactivation
         {
             if (ValidateData())
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, FALSE);
-            else // nepovolime deaktivaci stranky
+            else // do not allow the page to deactivate
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, TRUE);
             return TRUE;
         }
 
         if (((NMHDR*)lParam)->code == PSN_HELP)
-        { // stisknuto tlacitko Help
+        { // Help button pressed
             if (WinLibLTHelpCallback != NULL && HelpID != -1)
                 WinLibLTHelpCallback(HWindow, HelpID);
             return TRUE;
         }
 
-        if (((NMHDR*)lParam)->code == PSN_SETACTIVE) // aktivace stranky
+        if (((NMHDR*)lParam)->code == PSN_SETACTIVE) // page activation
         {
             if (ParentDialog != NULL && ParentDialog->LastPage != NULL)
-            { // zapamatovani posledni stranky
+            { // remember the last page
                 *ParentDialog->LastPage = ParentDialog->GetCurSel();
             }
             break;
         }
 
         if (((NMHDR*)lParam)->code == PSN_APPLY)
-        { // stisknuto tlacitko ApplyNow nebo OK
+        { // ApplyNow or OK button pressed
             if (TransferData(ttDataFromWindow))
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, PSNRET_NOERROR);
             else
@@ -715,15 +713,15 @@ CPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
 
         if (((NMHDR*)lParam)->code == PSN_WIZFINISH)
-        { // stisknuto tlacitko Finish
-            // neprislo PSN_KILLACTIVE - provedu validaci
+        { // Finish button pressed
+            // PSN_KILLACTIVE was not received - perform validation
             if (!ValidateData())
             {
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, TRUE);
                 return TRUE;
             }
 
-            // obehnu vsechny stranky pro transfer
+            // iterate through all pages for the transfer
             for (int i = 0; i < ParentDialog->Count; i++)
             {
                 if (ParentDialog->At(i)->HWindow != NULL)
@@ -751,7 +749,7 @@ CPropSheetPage::CPropSheetPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam,
     CPropSheetPage* dlg;
     switch (uMsg)
     {
-    case WM_INITDIALOG: // prvni zprava - pripojeni objektu k dialogu
+    case WM_INITDIALOG: // first message - attach the object to the dialog
     {
         dlg = (CPropSheetPage*)((PROPSHEETPAGE*)lParam)->lParam;
         if (dlg == NULL)
@@ -763,25 +761,24 @@ CPropSheetPage::CPropSheetPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam,
         {
             dlg->HWindow = hwndDlg;
             dlg->Parent = ::GetParent(hwndDlg);
-            //--- zarazeni okna podle hwndDlg do seznamu oken
-            if (!WindowsManager.AddWindow(hwndDlg, dlg)) // chyba
+            //--- insert the window into the list by hwndDlg
+            if (!WindowsManager.AddWindow(hwndDlg, dlg)) // error
             {
                 TRACE_E("Error during creating of dialog.");
                 return TRUE;
             }
-            dlg->NotifDlgJustCreated(); // zavedeno jako misto pro upravu layoutu dialogu
+            dlg->NotifDlgJustCreated(); // introduced as a place to adjust the dialog layout
         }
         break;
     }
 
-    case WM_DESTROY: // posledni zprava - odpojeni objektu od dialogu
+    case WM_DESTROY: // last message - detach the object from the dialog
     {
         dlg = (CPropSheetPage*)WindowsManager.GetWindowPtr(hwndDlg);
-        INT_PTR ret = FALSE; // pro pripad, ze ji nezpracuje
+        INT_PTR ret = FALSE; // in case it is not handled
         if (dlg != NULL && dlg->Is(otDialog))
         {
-            // Petr: posunul jsem dolu pod wnd->WindowProc(), aby behem WM_DESTROY
-            //       jeste dochazely zpravy (potreboval Lukas)
+            // Petr: moved it below wnd->WindowProc() so that messages still arrive during WM_DESTROY (Lukas needed it)
             // WindowsManager.DetachWindow(hwndDlg);
 
             ret = dlg->DialogProc(uMsg, wParam, lParam);
@@ -790,7 +787,7 @@ CPropSheetPage::CPropSheetPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam,
             if (dlg->IsAllocated())
                 delete dlg;
             else
-                dlg->HWindow = NULL; // informace o odpojeni
+                dlg->HWindow = NULL; // record that it has been detached
         }
         return ret;
     }
@@ -807,11 +804,11 @@ CPropSheetPage::CPropSheetPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam,
 #endif
     }
     }
-    //--- zavolani metody DialogProc(...) prislusneho objektu dialogu
+    //--- call the DialogProc(...) method of the corresponding dialog object
     if (dlg != NULL)
         return dlg->DialogProc(uMsg, wParam, lParam);
     else
-        return FALSE; // chyba nebo message neprisla mezi WM_INITDIALOG a WM_DESTROY
+        return FALSE; // error or the message did not arrive between WM_INITDIALOG and WM_DESTROY
 }
 
 //
@@ -915,9 +912,9 @@ CWindowsManager::GetWindowPtr(HWND hWnd)
 CWindowQueue::~CWindowQueue()
 {
     if (!Empty())
-        TRACE_E("Some window is still opened in " << QueueName << " queue!"); // nemelo by nastat...
-    // tady uz multi-threadovost nehrozi (konci plugin, thready jsou/byly ukonceny)
-    // dealokujeme aspon nejakou pamet
+        TRACE_E("Some window is still opened in " << QueueName << " queue!"); // should not happen...
+    // multi-threading is no longer a risk here (the plugin is shutting down, threads are/were terminated)
+    // free at least some memory
     CWindowQueueItem* last;
     CWindowQueueItem* item = Head;
     while (item != NULL)
@@ -949,7 +946,7 @@ void CWindowQueue::Remove(HWND hWindow)
     CWindowQueueItem* item = Head;
     while (item != NULL)
     {
-        if (item->HWindow == hWindow) // nalezeno, odstranime
+        if (item->HWindow == hWindow) // found, remove it
         {
             if (last != NULL)
                 last->Next = item->Next;
@@ -988,16 +985,16 @@ void CWindowQueue::BroadcastMessage(DWORD uMsg, WPARAM wParam, LPARAM lParam)
 
 BOOL CWindowQueue::CloseAllWindows(BOOL force, int waitTime, int forceWaitTime)
 {
-    // posleme zadost o zavreni vsech oken
+    // send a request to close all windows
     BroadcastMessage(WM_CLOSE, 0, 0);
 
-    // pockame az/jestli se zavrou
+    // wait until/if they close
     DWORD ti = GetTickCount();
     DWORD w = force ? forceWaitTime : waitTime;
     while ((w == INFINITE || w > 0) && !Empty())
     {
         DWORD t = GetTickCount() - ti;
-        if (w == INFINITE || t < w) // mame jeste cekat
+        if (w == INFINITE || t < w) // we should keep waiting
         {
             if (w == INFINITE || 50 < w - t)
                 Sleep(50);
@@ -1021,7 +1018,7 @@ BOOL CWindowQueue::CloseAllWindows(BOOL force, int waitTime, int forceWaitTime)
 BOOL CTransferInfo::GetControl(HWND& ctrlHWnd, int ctrlID, BOOL ignoreIsGood)
 {
     if (!ignoreIsGood && !IsGood())
-        return FALSE; // dalsi nema cenu zpracovavat
+        return FALSE; // no point processing anything else
     ctrlHWnd = GetDlgItem(HDialog, ctrlID);
     if (ctrlHWnd == NULL)
     {
@@ -1041,8 +1038,8 @@ void CTransferInfo::EnsureControlIsFocused(int ctrlID)
         HWND wnd = GetFocus();
         while (wnd != NULL && wnd != ctrl)
             wnd = ::GetParent(wnd);
-        if (wnd == NULL) // fokusime jen pokud neni ctrl predek GetFocusu
-        {                // jako napr. edit-line v combo-boxu
+        if (wnd == NULL) // move focus only if the control is not an ancestor of the current focus
+        {                // such as an edit line in a combo box
             SendMessage(HDialog, WM_NEXTDLGCTL, (WPARAM)ctrl, TRUE);
         }
     }
@@ -1100,8 +1097,8 @@ void CTransferInfo::EditLine(int ctrlID, double& value, char* format, BOOL selec
             BOOL decPoints = FALSE;
             BOOL expPart = FALSE;
             if (*s == '-' || *s == '+')
-                s++;        // preskok znamenka
-            while (*s != 0) // prevod carky na tecku
+                s++;        // skip the sign
+            while (*s != 0) // convert a comma to a dot
             {
                 if (!expPart && !decPoints && (*s == ',' || *s == '.'))
                 {
@@ -1114,7 +1111,7 @@ void CTransferInfo::EditLine(int ctrlID, double& value, char* format, BOOL selec
                     {
                         expPart = TRUE;
                         if (*(s + 1) == '+' || *(s + 1) == '-')
-                            s++; // preskok +- za E
+                            s++; // skip the +/- after E
                     }
                     else
                     {
@@ -1130,9 +1127,9 @@ void CTransferInfo::EditLine(int ctrlID, double& value, char* format, BOOL selec
                 s++;
             }
             if (*s == 0)
-                value = atof(buff); // jen pokud je cislo
+                value = atof(buff); // only if it is a number
             else
-                value = 0; // pri chybe dame nulu
+                value = 0; // use zero on error
             break;
         }
         }
@@ -1162,8 +1159,8 @@ void CTransferInfo::EditLine(int ctrlID, int& value, BOOL select)
 
             char* s = buff;
             if (*s == '-' || *s == '+')
-                s++;        // preskok znamenka
-            while (*s != 0) // kontrola cisla
+                s++;        // skip the sign
+            while (*s != 0) // check the number
             {
                 if (*s < '0' || *s > '9')
                 {
@@ -1176,7 +1173,7 @@ void CTransferInfo::EditLine(int ctrlID, int& value, BOOL select)
             }
 
             char* endptr;
-            value = strtoul(buff, &endptr, 10); // nahrada za atoi / _ttoi, ktere misto 4000000000 vraci 2147483647 (protoze je to SIGNED INT)
+            value = strtoul(buff, &endptr, 10); // replacement for atoi / _ttoi, which return 2147483647 instead of 4000000000 (because it is SIGNED INT)
             break;
         }
         }

--- a/src/plugins/shared/winliblt.h
+++ b/src/plugins/shared/winliblt.h
@@ -9,33 +9,32 @@
 //
 //****************************************************************************
 
-// "light" verze WinLibu
+// "light" version of WinLib
 
 #pragma once
 
-// makra pro potlaceni nepotrebnych casti WinLibLT (snazsi kompilace):
-// ENABLE_PROPERTYDIALOG - je-li definovano, je mozne pouzivat property sheet dialog (CPropertyDialog)
+// macros for suppressing unnecessary parts of WinLibLT (easier compilation):
+// ENABLE_PROPERTYDIALOG - if defined, it is possible to use the property sheet dialog (CPropertyDialog)
 
-// nastaveni vlastnich textu do WinLibu
-void SetWinLibStrings(const char* invalidNumber, // "neni cislo" (u transferbufferu cisel)
-                      const char* error);        // titulek "chyba" (u transferbufferu cisel)
+// configure custom texts for WinLib
+void SetWinLibStrings(const char* invalidNumber, // "not a number" (for numeric transfer buffers)
+                      const char* error);        // title "error" (for numeric transfer buffers)
 
-// je potreba zavolat pred pouzitim WinLibu; 'pluginName' je jmeno pluginu (napr. "DEMOPLUG"),
-// pouziva se pro odliseni jmen trid univerzalnich oken WinLibu (mezi pluginy se musi lisit,
-// jinak nastane kolize jmen trid a WinLib nemuze fungovat - bude fungovat jen prvni spusteny
-// plugin); 'dllInstance' je modul pluginu (pouziva se pri registraci univerzalnich trid WinLibu)
+// must be called before WinLib is used; 'pluginName' is the plugin name (e.g. "DEMOPLUG"),
+// used to differentiate the class names of WinLib universal windows (they must differ between plugins,
+// otherwise a class-name collision occurs and WinLib cannot work—the first plugin started would be the only one functioning);
+// 'dllInstance' is the plugin module (used when registering WinLib universal classes)
 BOOL InitializeWinLib(const char* pluginName, HINSTANCE dllInstance);
-// je potreba zavolat po pouziti WinLibu; 'dllInstance' je modul pluginu (pouziva se pri zruseni
-// registrace univerzalnich trid WinLibu)
+// must be called after WinLib is used; 'dllInstance' is the plugin module (used when unregistering WinLib universal classes)
 void ReleaseWinLib(HINSTANCE dllInstance);
 
-// typ callbacku pro pripojeni na HTML help
+// callback type for hooking into HTML help
 typedef void(WINAPI* FWinLibLTHelpCallback)(HWND hWindow, UINT helpID);
 
-// nastaveni callbacku pro pripojeni na HTML help
+// configure the callback for hooking into HTML Help
 void SetupWinLibHelp(FWinLibLTHelpCallback helpCallback);
 
-// konstanty pro stringy WinLibu (jen interni pouziti ve WinLibu)
+// constants for WinLib strings (internal use within WinLib only)
 enum CWLS
 {
     WLS_INVALID_NUMBER,
@@ -44,21 +43,21 @@ enum CWLS
     WLS_COUNT
 };
 
-extern char CWINDOW_CLASSNAME[100];  // jmeno tridy universalniho okna
-extern char CWINDOW_CLASSNAME2[100]; // jmeno tridy universalniho okna - nema CS_VREDRAW | CS_HREDRAW
+extern char CWINDOW_CLASSNAME[100];  // class name of the universal window
+extern char CWINDOW_CLASSNAME2[100]; // class name of the universal window - lacks CS_VREDRAW | CS_HREDRAW
 
 // ****************************************************************************
 
-enum CObjectOrigin // pouzito pri destrukci oken a dialogu
+enum CObjectOrigin // used when windows and dialogs are destroyed
 {
-    ooAllocated, // pri WM_DESTROY se bude dealokovat
-    ooStatic,    // pri WM_DESTROY se HWindow nastavi na NULL
-    ooStandard   // pro modalni dlg =ooStatic, pro nemodalni dlg =ooAllocated
+    ooAllocated, // will be deallocated during WM_DESTROY
+    ooStatic,    // WM_DESTROY sets HWindow to NULL
+    ooStandard   // modal dlg => ooStatic, modeless dlg => ooAllocated
 };
 
 // ****************************************************************************
 
-enum CObjectType // pro rozpoznani typu objektu
+enum CObjectType // to recognize the object type
 {
     otBase,
     otWindow,
@@ -71,7 +70,7 @@ enum CObjectType // pro rozpoznani typu objektu
 
 // ****************************************************************************
 
-class CWindowsObject // predek vsech MS-Windows objektu
+class CWindowsObject // base class of all MS Windows objects
 {
 public:
     HWND HWindow;
@@ -90,9 +89,9 @@ public:
         SetHelpID(helpID);
     }
 
-    virtual ~CWindowsObject() {} // aby se u potomku volal jejich destruktor
+    virtual ~CWindowsObject() {} // ensures descendants have their destructors invoked
 
-    virtual BOOL Is(int) { return FALSE; } // identifikace objektu
+    virtual BOOL Is(int) { return FALSE; } // object identification
     virtual int GetObjectType() { return otBase; }
 
     virtual BOOL IsAllocated() { return ObjectOrigin == ooAllocated; }
@@ -132,11 +131,11 @@ public:
     virtual BOOL Is(int type) { return type == otWindow; }
     virtual int GetObjectType() { return otWindow; }
 
-    // registruje univerzalni tridy WinLibu, vola se automaticky (registraci rusi tez automaticky)
+    // registers the WinLib universal classes, called automatically (unregistration is also automatic)
     static BOOL RegisterUniversalClass(HINSTANCE dllInstance);
 
-    // registrace vlastni univerzalni tridy; POZOR: pri unloadu pluginu je nutne zrusit registraci tridy,
-    // jinak pri opakovanem loadu pluginu dojde k chybe pri registraci (konflikt se starou tridou)
+    // registration of a custom universal class; WARNING: when the plugin unloads the class must be unregistered,
+    // otherwise loading the plugin again will fail because of a conflict with the old class
     static BOOL RegisterUniversalClass(UINT style,
                                        int cbClsExtra,
                                        int cbWndExtra,
@@ -158,7 +157,7 @@ public:
                 HWND hwndParent,        // handle of parent or owner window
                 HMENU hmenu,            // handle of menu or child-window identifier
                 HINSTANCE hinst,        // handle of application instance
-                LPVOID lpvParam);       // ukazatel na objekt vytvareneho okna
+                LPVOID lpvParam);       // pointer to the window object being created
 
     HWND CreateEx(DWORD dwExStyle,        // extended window style
                   LPCTSTR lpszClassName,  // address of registered class name
@@ -171,7 +170,7 @@ public:
                   HWND hwndParent,        // handle of parent or owner window
                   HMENU hmenu,            // handle of menu or child-window identifier
                   HINSTANCE hinst,        // handle of application instance
-                  LPVOID lpvParam);       // ukazatel na objekt vytvareneho okna
+                  LPVOID lpvParam);       // pointer to the window object being created
 
     void AttachToWindow(HWND hWnd);
     void AttachToControl(HWND dlg, int ctrlID);
@@ -190,8 +189,8 @@ protected:
 
 enum CTransferType
 {
-    ttDataToWindow,  // data jdou do okna
-    ttDataFromWindow // data jdou z okna
+    ttDataToWindow,  // data go to the window
+    ttDataFromWindow // data come from the window
 };
 
 // ****************************************************************************
@@ -199,7 +198,7 @@ enum CTransferType
 class CTransferInfo
 {
 public:
-    int FailCtrlID; // INT_MAX - vse v poradku, jinak ID controlu s chybou
+    int FailCtrlID; // INT_MAX - everything is OK, otherwise the control ID with the error
     CTransferType Type;
 
     CTransferInfo(HWND hDialog, CTransferType type)
@@ -218,15 +217,15 @@ public:
     void RadioButton(int ctrlID, int ctrlValue, int& value);
     void CheckBox(int ctrlID, int& value); // 0-unchecked, 1-checked, 2-grayed
 
-    // kontroluje double hodnotu (pokud to neni cislo, neprojde), oddelovac muze byt '.' i ',';
-    // 'format' se pouziva v sprintf pri prevodu cisla na retezec (napr. "%.2f" nebo "%g")
+    // validates a double value (if it is not a number, it fails); the separator can be '.' or ',';
+    // 'format' is used in sprintf when converting the number to a string (e.g. "%.2f" or "%g")
     void EditLine(int ctrlID, double& value, char* format, BOOL select = TRUE);
 
-    // kontroluje int hodnotu (pokud to neni cislo, neprojde)
+    // validates an int value (if it is not a number, it fails)
     void EditLine(int ctrlID, int& value, BOOL select = TRUE);
 
 protected:
-    HWND HDialog; // handle dialogu, pro ktery se provadi transfer
+    HWND HDialog; // handle of the dialog for which the transfer is executed
 };
 
 // ****************************************************************************
@@ -235,8 +234,8 @@ class CDialog : public CWindowsObject
 {
 public:
 #ifdef ENABLE_PROPERTYDIALOG
-    CWindowsObject::HWindow;         // kvuli zkompilovatelnosti CPropSheetPage
-    CWindowsObject::SetObjectOrigin; // kvuli zkompilovatelnosti CPropSheetPage
+    CWindowsObject::HWindow;         // for CPropSheetPage to compile
+    CWindowsObject::SetObjectOrigin; // for CPropSheetPage to compile
 #endif                               // ENABLE_PROPERTYDIALOG
 
     CDialog(HINSTANCE modul, int resID, HWND parent,
@@ -268,8 +267,8 @@ public:
                                         (!Modal && ObjectOrigin == ooStandard); }
 
     void SetParent(HWND parent) { Parent = parent; }
-    INT_PTR Execute(); // modalni dialog
-    HWND Create();     // nemodalni dialog
+    INT_PTR Execute(); // modal dialog
+    HWND Create();     // modeless dialog
 
     static INT_PTR CALLBACK CDialogProc(HWND hwndDlg, UINT uMsg,
                                         WPARAM wParam, LPARAM lParam);
@@ -279,7 +278,7 @@ protected:
 
     virtual void NotifDlgJustCreated() {}
 
-    BOOL Modal; // kvuli zpusobu destrukce dialogu
+    BOOL Modal; // determines how the dialog is destroyed
     HINSTANCE Modul;
     int ResID;
     HWND Parent;
@@ -294,14 +293,14 @@ class CPropertyDialog;
 class CPropSheetPage : protected CDialog
 {
 public:
-    CDialog::HWindow; // HWindow zustane pristupne
+    CDialog::HWindow; // keep HWindow accessible
 
-    CDialog::SetObjectOrigin; // zpristupneni povolenych metod predku
+    CDialog::SetObjectOrigin; // expose allowed base-class methods
     CDialog::Transfer;
 
-    // testovano s resourcem dialogu stranky se stylem:
+    // tested with a page dialog resource with the style:
     // DS_CONTROL | DS_3DLOOK | WS_CHILD | WS_CAPTION;
-    // pokud chceme pouzit primo titulek z resourcu, staci dat 'title'==NULL a
+    // if we want to use the title directly from the resource, set 'title'==NULL and
     // 'flags'==0
     CPropSheetPage(char* title, HINSTANCE modul, int resID,
                    DWORD flags /* = PSP_USETITLE*/, HICON icon,
@@ -332,7 +331,7 @@ protected:
     DWORD Flags;
     HICON Icon;
 
-    CPropertyDialog* ParentDialog; // vlastnik teto stranky
+    CPropertyDialog* ParentDialog; // owner of this page
 
     friend class CPropertyDialog;
 };
@@ -342,11 +341,11 @@ protected:
 class CPropertyDialog : public TIndirectArray<CPropSheetPage>
 {
 public:
-    // do tohoto objektu je idealni pridat objekty jednotlivych stranek
-    // a pak je jako "staticke" (defaultni volba) napridavat pres metodu Add;
-    // 'startPage' a 'lastPage' muze byt jen jedina promenna (hodnota in/odkaz out);
-    // 'flags' viz help k 'PROPSHEETHEADER', pouzitelne hlavne konstanty
-    // PSH_NOAPPLYNOW, PSH_USECALLBACK a PSH_HASHELP (jinak staci 'flags'==0)
+    // it is best to add objects of individual pages to this object
+    // and then add them as "static" (default option) through the Add method;
+    // 'startPage' and 'lastPage' can be just a single variable (value in/reference out);
+    // 'flags' see the help for 'PROPSHEETHEADER', the most useful constants are
+    // PSH_NOAPPLYNOW, PSH_USECALLBACK, and PSH_HASHELP (otherwise 'flags'==0 is enough)
     CPropertyDialog(HWND parent, HINSTANCE modul, char* caption,
                     int startPage, DWORD flags, HICON icon = NULL,
                     DWORD* lastPage = NULL, PFNPROPSHEETCALLBACK callback = NULL)
@@ -368,7 +367,7 @@ public:
     virtual int GetCurSel();
 
 protected:
-    HWND Parent; // parametry pro vytvareni dialogu
+    HWND Parent; // parameters for creating the dialog
     HWND HWindow;
     HINSTANCE Modul;
     HICON Icon;
@@ -377,7 +376,7 @@ protected:
     DWORD Flags;
     PFNPROPSHEETCALLBACK Callback;
 
-    DWORD* LastPage; // posledni zvolena stranka (muze byt NULL, pokud nezajima)
+    DWORD* LastPage; // last selected page (can be NULL if it is not needed)
 
     friend class CPropSheetPage;
 };
@@ -389,7 +388,7 @@ protected:
 class CWindowsManager
 {
 public:
-    int WindowsCount; // pocet oken obsluhovanych WinLibem (aktualni stav)
+    int WindowsCount; // number of windows handled by WinLib (current state)
 
 public:
     CWindowsManager() { WindowsCount = 0; }
@@ -416,10 +415,10 @@ struct CWindowQueueItem
 class CWindowQueue
 {
 protected:
-    const char* QueueName; // jmeno fronty (jen pro debugovaci ucely)
+    const char* QueueName; // queue name (debugging only)
     CWindowQueueItem* Head;
 
-    struct CCS // pristup z vice threadu -> nutna synchronizace
+    struct CCS // access from multiple threads -> synchronization required
     {
         CRITICAL_SECTION cs;
 
@@ -431,24 +430,24 @@ protected:
     } CS;
 
 public:
-    CWindowQueue(const char* queueName /* napr. "DemoPlug Viewers" */)
+    CWindowQueue(const char* queueName /* e.g. "DemoPlug Viewers" */)
     {
         QueueName = queueName;
         Head = NULL;
     }
     ~CWindowQueue();
 
-    BOOL Add(CWindowQueueItem* item); // prida polozku do fronty, vraci uspech
-    void Remove(HWND hWindow);        // odstrani polozku z fronty
-    BOOL Empty();                     // vraci TRUE pokud je fronta prazdna
+    BOOL Add(CWindowQueueItem* item); // add an item to the queue, returns success
+    void Remove(HWND hWindow);        // remove an item from the queue
+    BOOL Empty();                     // returns TRUE if the queue is empty
 
-    // posle (PostMessage - okna muzou byt v ruznych threadech) vsem oknum zpravu
+    // send (PostMessage - windows can be in different threads) a message to all windows
     void BroadcastMessage(DWORD uMsg, WPARAM wParam, LPARAM lParam);
 
-    // broadcastne WM_CLOSE, pak ceka na prazdnou frontu (max. cas dle 'force' bud 'forceWaitTime'
-    // nebo 'waitTime'); vraci TRUE pokud je fronta prazdna (vsechna okna se zavrela)
-    // nebo je 'force' TRUE; cas INFINITE = neomezene dlouhe cekani
-    // Poznamka: pri 'force' TRUE vraci vzdy TRUE, nema smysl na nic cekat, proto forceWaitTime = 0
+    // broadcast WM_CLOSE, then wait for an empty queue (at most the time defined by 'force' using either 'forceWaitTime'
+    // or 'waitTime'); returns TRUE if the queue is empty (all windows were closed)
+    // or if 'force' is TRUE; INFINITE means waiting without a limit
+    // Note: with 'force' TRUE it always returns TRUE, there is no point waiting, so forceWaitTime = 0
     BOOL CloseAllWindows(BOOL force, int waitTime = 1000, int forceWaitTime = 0);
 };
 


### PR DESCRIPTION
## Summary
- clarify the ViewFile contract comment in `spl_view.h` with natural English phrasing and clearer examples
- polish WinLib implementation comments to describe shared atom usage and shutdown risks more precisely
- align WinLib header comments with the updated terminology (HTML Help, class flags)

## Testing
- not run (comment-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e947ec2cb083229eaad76eae07e06d