### PR TITLE
Refine English translations in shared plugin headers

### DIFF
--- a/src/plugins/shared/spl_menu.h
+++ b/src/plugins/shared/spl_menu.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #ifdef _MSC_VER
-#pragma pack(push, enter_include_spl_menu) // aby byly struktury nezavisle na nastavenem zarovnavani
+#pragma pack(push, enter_include_spl_menu) // to keep the structures independent of the configured alignment
 #pragma pack(4)
 #endif // _MSC_VER
 #ifdef __BORLANDC__
@@ -25,32 +25,32 @@ class CSalamanderForOperationsAbstract;
 // ****************************************************************************
 // CSalamanderBuildMenuAbstract
 //
-// sada metod Salamandera pro stavbu menu pluginu
+// set of Salamander methods for building plugin menus
 //
-// jde o podmnozinu metod CSalamanderConnectAbstract, metody se stejne chovaji,
-// pouzivaji se stejne konstanty, popis viz CSalamanderConnectAbstract
+// this is a subset of CSalamanderConnectAbstract methods; they behave the same,
+// use the same constants, and are documented in CSalamanderConnectAbstract
 
 class CSalamanderBuildMenuAbstract
 {
 public:
-    // ikony se zadavaji metodou CSalamanderBuildMenuAbstract::SetIconListForMenu, zbytek
-    // popisu viz CSalamanderConnectAbstract::AddMenuItem
+    // configure icons through CSalamanderBuildMenuAbstract::SetIconListForMenu; see
+    // CSalamanderConnectAbstract::AddMenuItem for the remaining description
     virtual void WINAPI AddMenuItem(int iconIndex, const char* name, DWORD hotKey, int id, BOOL callGetState,
                                     DWORD state_or, DWORD state_and, DWORD skillLevel) = 0;
 
-    // ikony se zadavaji metodou CSalamanderBuildMenuAbstract::SetIconListForMenu, zbytek
-    // popisu viz CSalamanderConnectAbstract::AddSubmenuStart
+    // configure icons through CSalamanderBuildMenuAbstract::SetIconListForMenu; see
+    // CSalamanderConnectAbstract::AddSubmenuStart for the remaining description
     virtual void WINAPI AddSubmenuStart(int iconIndex, const char* name, int id, BOOL callGetState,
                                         DWORD state_or, DWORD state_and, DWORD skillLevel) = 0;
 
-    // popis viz CSalamanderConnectAbstract::AddSubmenuEnd
+    // description see CSalamanderConnectAbstract::AddSubmenuEnd
     virtual void WINAPI AddSubmenuEnd() = 0;
 
-    // nastavi bitmapu s ikonami pluginu pro menu; bitmapu je treba alokovat pomoci volani
-    // CSalamanderGUIAbstract::CreateIconList() a nasledne vytvorit a naplnit pomoci
-    // metod CGUIIconListAbstract interfacu; rozmery ikonek musi byt 16x16 bodu;
-    // Salamander si objekt bitmapy prebira do sve spravy, plugin ji po zavolani
-    // teto funkce nesmi destruovat; Salamander ji drzi jen v pameti, nikam se neuklada
+    // sets the bitmap with plugin icons for the menu; the bitmap must be allocated by
+    // calling CSalamanderGUIAbstract::CreateIconList() and then created and filled with the
+    // CGUIIconListAbstract interface methods; the icon dimensions must be 16x16 pixels;
+    // Salamander assumes ownership of the bitmap object, so the plugin must not destroy it
+    // after calling this function; Salamander keeps it in memory only and does not save it elsewhere
     virtual void WINAPI SetIconListForMenu(CGUIIconListAbstract* iconList) = 0;
 };
 
@@ -59,56 +59,54 @@ public:
 // CPluginInterfaceForMenuExtAbstract
 //
 
-// flagy stavu polozek v menu (pro pluginy rozsireni menu)
-#define MENU_ITEM_STATE_ENABLED 0x01 // enablovana, bez tohoto flagu je polozka disablovana
-#define MENU_ITEM_STATE_CHECKED 0x02 // pred polozkou je "check" nebo "radio" znacka
-#define MENU_ITEM_STATE_RADIO 0x04   // bez MENU_ITEM_STATE_CHECKED se ignoruje, \
-                                     // "radio" znacka, bez tohoto flagu "check" znacka
-#define MENU_ITEM_STATE_HIDDEN 0x08  // polozka se v menu vubec nema objevit
+// state flags of menu items (for menu extension plugins)
+#define MENU_ITEM_STATE_ENABLED 0x01 // enabled, without this flag the item is disabled
+#define MENU_ITEM_STATE_CHECKED 0x02 // a "check" or "radio" mark is shown before the item
+#define MENU_ITEM_STATE_RADIO 0x04   // ignored without MENU_ITEM_STATE_CHECKED, \
+                                     // "radio" mark, without this flag a "check" mark
+#define MENU_ITEM_STATE_HIDDEN 0x08  // the item should not appear in the menu at all
 
 class CPluginInterfaceForMenuExtAbstract
 {
 #ifdef INSIDE_SALAMANDER
-private: // ochrana proti nespravnemu primemu volani metod (viz CPluginInterfaceForMenuExtEncapsulation)
+private: // protection against incorrect direct method calls (see CPluginInterfaceForMenuExtEncapsulation)
     friend class CPluginInterfaceForMenuExtEncapsulation;
 #else  // INSIDE_SALAMANDER
 public:
 #endif // INSIDE_SALAMANDER
 
-    // vraci stav polozky menu s identifikacnim cislem 'id'; navratova hodnota je kombinaci
-    // flagu (viz MENU_ITEM_STATE_XXX); 'eventMask' viz CSalamanderConnectAbstract::AddMenuItem
+    // returns the state of the menu item with identifier 'id'; the return value is a combination
+    // of flags (see MENU_ITEM_STATE_XXX); for 'eventMask' see CSalamanderConnectAbstract::AddMenuItem
     virtual DWORD WINAPI GetMenuItemState(int id, DWORD eventMask) = 0;
 
-    // spousti prikaz menu s identifikacnim cislem 'id', 'eventMask' viz
-    // CSalamanderConnectAbstract::AddMenuItem, 'salamander' je sada pouzitelnych metod
-    // Salamandera pro provadeni operaci (POZOR: muze byt NULL, viz popis metody
-    // CSalamanderGeneralAbstract::PostMenuExtCommand), 'parent' je parent messageboxu,
-    // vraci TRUE pokud ma byt v panelu zruseno oznaceni (nebyl pouzit Cancel, mohl byt
-    // pouzit Skip), jinak vraci FALSE (neprovede se odznaceni);
-    // POZOR: Pokud prikaz zpusobi zmeny na nejake ceste (diskove/FS), mel by pouzit
-    //        CSalamanderGeneralAbstract::PostChangeOnPathNotification pro informovani
-    //        panelu bez automatickeho refreshe a otevrene FS (aktivni i odpojene)
-    // POZNAMKA: pokud prikaz pracuje se soubory/adresari z cesty v aktualnim panelu nebo
-    //           i primo s touto cestou, je treba volat
-    //           CSalamanderGeneralAbstract::SetUserWorkedOnPanelPath pro aktualni panel,
-    //           jinak nebude cesta v tomto panelu vlozena do seznamu pracovnich
-    //           adresaru - List of Working Directories (Alt+F12)
+    // runs the menu command with identifier 'id'; for 'eventMask' see
+    // CSalamanderConnectAbstract::AddMenuItem; 'salamander' provides a set of usable Salamander
+    // methods for carrying out operations (WARNING: it can be NULL, see the description of
+    // CSalamanderGeneralAbstract::PostMenuExtCommand); 'parent' is the parent message box;
+    // returns TRUE if the panel selection should be cleared (Cancel was not used, Skip might have been),
+    // otherwise returns FALSE (no deselection takes place);
+    // WARNING: If the command changes anything on a path (disk/FS), it should call
+    //          CSalamanderGeneralAbstract::PostChangeOnPathNotification to inform panels
+    //          without automatic refresh and open FS (active and disconnected)
+    // NOTE: if the command works with files/directories from the active panel path, or even with
+    //       that path directly, it must call CSalamanderGeneralAbstract::SetUserWorkedOnPanelPath
+    //       for the active panel; otherwise the path will not be added to the List of Working
+    //       Directories (Alt+F12)
     virtual BOOL WINAPI ExecuteMenuItem(CSalamanderForOperationsAbstract* salamander, HWND parent,
                                         int id, DWORD eventMask) = 0;
 
-    // zobrazi napovedu pro prikaz menu s identifikacnim cislem 'id' (user stiskne Shift+F1,
-    // najde v menu Plugins menu tohoto pluginu a vybere z nej prikaz), 'parent' je parent
-    // messageboxu, vraci TRUE pokud byla zobrazena nejaka napoveda, jinak se zobrazi z helpu
-    // Salamandera kapitola "Using Plugins"
+    // shows help for the menu command with identifier 'id' (the user presses Shift+F1,
+    // finds this plugin's menu in Plugins, and selects a command from it); 'parent' is the parent
+    // message box; returns TRUE if specific help was displayed; otherwise Salamander shows the
+    // "Using Plugins" chapter from its help
     virtual BOOL WINAPI HelpForMenuItem(HWND parent, int id) = 0;
 
-    // funkce pro "dynamic menu extension", vola se jen pokud zadate FUNCTION_DYNAMICMENUEXT do
-    // SetBasicPluginData; sestavi menu pluginu pri jeho loadu, a pak vzdy znovu tesne pred
-    // jeho otevrenim v menu Plugins nebo na Plugin bare (navic i pred otevrenim okna Keyboard
-    // Shortcuts z Plugins Manageru); prikazy v novem menu by mely mit stejne ID jako ve starem,
-    // aby jim zustavaly uzivatelem pridelene hotkeys a aby pripadne fungovaly jako posledni
-    // pouzity prikaz (viz Plugins / Last Command); 'parent' je parent messageboxu, 'salamander'
-    // je sada metod pro stavbu menu
+    // function for the "dynamic menu extension", called only if you pass FUNCTION_DYNAMICMENUEXT to
+    // SetBasicPluginData; builds the plugin menu when it is loaded, and then again right before the menu
+    // is opened in the Plugins menu or on the Plugin bar (also before opening the Keyboard Shortcuts
+    // window from the Plugins Manager); commands in the new menu should keep the same IDs as the previous
+    // menu so that user-assigned hotkeys remain valid and they can still be treated as the last command used
+    // (see Plugins / Last Command); 'parent' is the parent message box; 'salamander' is the helper used to build the menu
     virtual void WINAPI BuildMenu(HWND parent, CSalamanderBuildMenuAbstract* salamander) = 0;
 };
 

--- a/src/plugins/shared/spl_thum.h
+++ b/src/plugins/shared/spl_thum.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #ifdef _MSC_VER
-#pragma pack(push, enter_include_spl_thum) // aby byly struktury nezavisle na nastavenem zarovnavani
+#pragma pack(push, enter_include_spl_thum) // to keep the structures independent of the configured alignment
 #pragma pack(4)
 #endif // _MSC_VER
 #ifdef __BORLANDC__
@@ -24,72 +24,63 @@
 // CSalamanderThumbnailMakerAbstract
 //
 
-// informace o obrazku, ze ktereho generujeme thumbnail, tyto flagy se pouzivaji
-// v CSalamanderThumbnailMakerAbstract::SetParameters():
-#define SSTHUMB_MIRROR_HOR 1                                            // obrazek je potreba horizontalne zrcadlit
-#define SSTHUMB_MIRROR_VERT 2                                           // obrazek je potreba vertikalne zrcadlit
-#define SSTHUMB_ROTATE_90CW 4                                           // obrazek je potreba otocit o 90 stupnu ve smeru hodinovych rucicek
-#define SSTHUMB_ROTATE_180 (SSTHUMB_MIRROR_VERT | SSTHUMB_MIRROR_HOR)   // obrazek je potreba otocit o 180 stupnu
-#define SSTHUMB_ROTATE_90CCW (SSTHUMB_ROTATE_90CW | SSTHUMB_ROTATE_180) // obrazek je potreba otocit o 90 stupnu proti smeru hodinovych rucicek
-// obrazek je v horsi kvalite nebo mensi nez je potreba, Salamander po dokonceni prvniho kola
-// ziskavani "rychlych" thumbnailu zkusi pro tento obrazek ziskat "kvalitni" thumbnail
+// information about the image from which the thumbnail is generated; these flags are used
+// in CSalamanderThumbnailMakerAbstract::SetParameters():
+#define SSTHUMB_MIRROR_HOR 1                                            // the image needs to be mirrored horizontally
+#define SSTHUMB_MIRROR_VERT 2                                           // the image needs to be mirrored vertically
+#define SSTHUMB_ROTATE_90CW 4                                           // the image needs to be rotated 90 degrees clockwise
+#define SSTHUMB_ROTATE_180 (SSTHUMB_MIRROR_VERT | SSTHUMB_MIRROR_HOR)   // the image needs to be rotated 180 degrees
+#define SSTHUMB_ROTATE_90CCW (SSTHUMB_ROTATE_90CW | SSTHUMB_ROTATE_180) // the image needs to be rotated 90 degrees counterclockwise
+// the image is lower quality or smaller than required; after Salamander finishes the first round
+// of "quick" thumbnails it tries to obtain a "quality" thumbnail for this image
 #define SSTHUMB_ONLY_PREVIEW 8
 
 class CSalamanderThumbnailMakerAbstract
 {
 public:
-    // nastaveni parametru zpracovani obrazku pri tvorbe thumbnailu; nutne volat
-    // jako prvni metodu tohoto rozhrani; 'picWidth' a 'picHeight' jsou rozmery
-    // zpracovavaneho obrazku (v bodech); 'flags' je kombinace flagu SSTHUMB_XXX,
-    // ktera udava informace o obrazku predavanem v parametru 'buffer' v metode
-    // ProcessBuffer; vraci TRUE, pokud se podarilo alokovat buffery pro zmensovani
-    // a je mozne nasledne volat ProcessBuffer; pokud vrati FALSE, doslo k chybe
-    // a je treba ukoncit nacitani thumbnailu
+    // sets the image-processing parameters used to create a thumbnail; must be the first method called
+    // on this interface; 'picWidth' and 'picHeight' are the dimensions of the processed image (in pixels);
+    // 'flags' is a combination of SSTHUMB_XXX values describing the image passed in the 'buffer' parameter
+    // to ProcessBuffer; returns TRUE if the downscaling buffers were allocated successfully and
+    // ProcessBuffer may be called; if it returns FALSE an error occurred and thumbnail loading must stop
     virtual BOOL WINAPI SetParameters(int picWidth, int picHeight, DWORD flags) = 0;
 
-    // zpracuje cast obrazku v bufferu 'buffer' (zpracovavana cast obrazku je ulozena
-    // po radcich shora dolu, body na radcich jsou ulozeny zleva doprava, kazdy bod
-    // reprezentuje 32-bitova hodnota, ktera je slozena z tri bytu s barvami R+G+B a
-    // ctvrteho bytu, ktery se ignoruje); rozlisujeme dva typy zpracovani: kopie
-    // obrazku do vysledneho thumbnailu (nepresahuje-li velikost zpracovavaneho obrazku
-    // velikost thumbnailu) a zmenseni obrazku do thumbnailu (obrazek vetsi nez
-    // thumbnail); 'buffer' je pouzit pouze pro cteni; 'rowsCount' urcuje kolik radku
-    // obrazku je v bufferu;
-    // je-li'buffer' NULL, berou se data z vlastniho bufferu (plugin ziska pres GetBuffer);
-    // vraci TRUE pokud ma plugin pokracovat s nacitanim obrazku, vraci-li FALSE,
-    // tvorba thumbnailu je hotova (byl zpracovan cely obrazek) nebo se ma co
-    // nejdrive prerusit (napr. uzivatel zmenil cestu v panelu, thumbnail tedy jiz
-    // neni potreba)
+    // processes a portion of the image supplied in 'buffer' (the processed part of the image is stored row by
+    // row from top to bottom, with pixels in each row stored left to right; each pixel is represented by a
+    // 32-bit value composed of three bytes with the R+G+B colors and a fourth byte that is ignored);
+    // two processing modes are supported: copying the image to the resulting thumbnail (when the processed
+    // image does not exceed the thumbnail size) and shrinking the image down to the thumbnail (when the
+    // image is larger); 'buffer' is read-only; 'rowsCount' tells how many rows of the image are present;
+    // if 'buffer' is NULL, the data are taken from the internal buffer (the plugin obtains it via GetBuffer);
+    // returns TRUE if the plugin should keep reading the image; if it returns FALSE the thumbnail is complete
+    // (all data were processed) or processing should stop as soon as possible (for example, the user changed the
+    // panel path so the thumbnail is no longer needed)
     //
-    // POZOR: pokud je spustena metoda CPluginInterfaceForThumbLoader::LoadThumbnail,
-    // je blokovana zmena cesty v panelu. Z toho duvodu je treba predavat a hlavne
-    // nacitat vetsi obrazky po castech a testovatovanim navratove hodnoty
-    // metody ProcessBuffer overovat, zda se nacitani nema prerusit.
-    // Pokud je treba provest casove narocnejsi operace pred volanim metody SetParameters
-    // nebo pred volanim ProcessBuffer, je behem teto doby nutne obcas volat GetCancelProcessing.
+    // WARNING: while CPluginInterfaceForThumbLoader::LoadThumbnail is running, changing the panel path is
+    // blocked. Therefore large images must be provided in chunks, checking the return value of ProcessBuffer to
+    // find out whether loading should stop. If time-consuming work needs to happen before SetParameters or before
+    // ProcessBuffer, call GetCancelProcessing occasionally during that period.
     virtual BOOL WINAPI ProcessBuffer(void* buffer, int rowsCount) = 0;
 
-    // vraci vlastni buffer o velikosti potrebne k ulozeni 'rowsCount' radku obrazku
-    // (4 * 'rowsCount' * 'picWidth' bytu); je-li objekt v chybovem stavu (po volani
-    // SetError), vraci NULL;
-    // plugin nesmi dealokovat ziskany buffer (dealokuje se v Salamanderovi automaticky)
+    // returns an internal buffer large enough to store 'rowsCount' rows of the image
+    // (4 * 'rowsCount' * 'picWidth' bytes); if the object is in an error state (after calling SetError),
+    // it returns NULL;
+    // the plugin must not deallocate the provided buffer (Salamander releases it automatically)
     virtual void* WINAPI GetBuffer(int rowsCount) = 0;
 
-    // oznameni chyby pri ziskavani obrazku (thumbnail je povazovan za vadny
-    // a nepouzije se), ostatni metody tohoto rozhrani budou od chvile volani
-    // SetError uz jen vracet chyby (GetBuffer a SetParameters) nebo preruseni
-    // prace (ProcessBuffer)
+    // reports an error while obtaining the image (the thumbnail is considered faulty and will not be used);
+    // after SetError is called, the other methods in this interface only return errors (GetBuffer and
+    // SetParameters) or stop processing (ProcessBuffer)
     virtual void WINAPI SetError() = 0;
 
-    // vraci TRUE, pokud ma plugin preprusit nacitani thumbnailu
-    // vraci FALSE, pokud ma plugin pokracovat s nacitanim obrazku
+    // returns TRUE if the plugin should interrupt loading the thumbnail
+    // returns FALSE if the plugin should continue reading the image
     //
-    // metodu lze volat pred i po volani metody SetParameters
+    // the method can be called before and after SetParameters
     //
-    // slouzi k detekci pozadavku na preruseni v pripadech, kdy plugin
-    // potrebuje vykonat casove narocne operace jeste pred volanim SetParameters
-    // nebo v pripade, kdy plugin potrebuje obrazek predrenderovat, tedy po volani
-    // SetParameters, ale pred volanim ProcessBuffer
+    // used to detect a cancellation request in cases where the plugin
+    // needs to perform time-consuming operations before calling SetParameters,
+    // or when it must pre-render the image after SetParameters but before ProcessBuffer
     virtual BOOL WINAPI GetCancelProcessing() = 0;
 };
 
@@ -101,38 +92,36 @@ public:
 class CPluginInterfaceForThumbLoaderAbstract
 {
 #ifdef INSIDE_SALAMANDER
-private: // ochrana proti nespravnemu primemu volani metod (viz CPluginInterfaceForThumbLoaderEncapsulation)
+private: // protection against incorrect direct method calls (see CPluginInterfaceForThumbLoaderEncapsulation)
     friend class CPluginInterfaceForThumbLoaderEncapsulation;
 #else  // INSIDE_SALAMANDER
 public:
 #endif // INSIDE_SALAMANDER
 
-    // nacte thumbnail pro soubor 'filename'; 'thumbWidth' a 'thumbHeight' jsou
-    // rozmery pozadovaneho thumbnailu; 'thumbMaker' je rozhrani algoritmu pro
-    // tvorbu thumbnailu (umi prijmout hotovy thumbnail nebo ho vyrobit zmensenim
-    // obrazku); vraci TRUE pokud je format souboru 'filename' znamy, pokud vrati
-    // FALSE, Salamander zkusi nacist thumbnail pomoci jineho pluginu; chybu pri
-    // ziskavani thumbnailu (napr. chybu cteni souboru) plugin hlasi pomoci
-    // rozhrani 'thumbMaker' - viz metoda SetError; 'fastThumbnail' je TRUE v prvnim
-    // kole cteni thumbnailu - cilem je vratit thumbnail co nejrychleji (klidne
-    // v horsi kvalite nebo mensi nez je potreba), v druhem kole cteni thumbnailu
-    // (jen pokud se v prvnim kole nastavi flag SSTHUMB_ONLY_PREVIEW) je
-    // 'fastThumbnail' FALSE - cilem je vratit kvalitni thumbnail
-    // omezeni: jelikoz se vola z threadu pro nacitani ikon (neni to hlavni thread), lze z
-    // CSalamanderGeneralAbstract pouzivat jen metody, ktere lze volat z libovolneho threadu
+    // loads a thumbnail for the file given by 'filename'; 'thumbWidth' and 'thumbHeight' are the requested
+    // thumbnail dimensions; 'thumbMaker' is the interface of the algorithm that creates thumbnails (it can
+    // accept a finished thumbnail or build one by resizing the image); returns TRUE if the format of 'filename'
+    // is known; if it returns FALSE, Salamander attempts to load the thumbnail using another plugin; any error
+    // while obtaining the thumbnail (for example, a file read error) is reported through 'thumbMaker'—see
+    // SetError; 'fastThumbnail' is TRUE during the first pass, where the goal is to return a thumbnail as
+    // quickly as possible (even if it is lower quality or smaller than requested); during the second pass
+    // (only if SSTHUMB_ONLY_PREVIEW was set in the first pass) 'fastThumbnail' is FALSE so the goal is to
+    // return a quality thumbnail;
+    // limitation: because the method is called from the icon-loading thread (not the main thread), only
+    // CSalamanderGeneralAbstract methods that may be called from any thread can be used
     //
-    // Doporucene schema implementace:
-    //   - pokusit se otevrit obrazek
-    //   - pokud se nepodari, vratit FALSE
-    //   - extrahovat rozmery obrazku
-    //   - predat je do Salamandera pres thumbMaker->SetParameters
-    //   - pokud vrati FALSE, uklid a odchod (nepovedlo se alokovat buffery)
-    //   - SMYCKA
-    //     - nacist cast dat z obrazku
-    //     - poslat je do Salamandera pres thumbMaker->ProcessBuffer
-    //     - pokud vrati FALSE, uklid a odchod (preruseni z duvodu zmeny cesty)
-    //     - pokracovat ve SMYCCE, dokud nebude cely obrazek predan
-    //   - uklid a odchod
+    // Recommended implementation outline:
+    //   - try to open the image
+    //   - if opening fails, return FALSE
+    //   - extract the image dimensions
+    //   - pass them to Salamander via thumbMaker->SetParameters
+    //   - if it returns FALSE, clean up and exit (buffer allocation failed)
+    //   - LOOP
+    //     - read part of the data from the image
+    //     - send it to Salamander via thumbMaker->ProcessBuffer
+    //     - if it returns FALSE, clean up and exit (interrupted because the path changed)
+    //     - continue in the LOOP until the entire image has been passed
+    //   - clean up and exit
     virtual BOOL WINAPI LoadThumbnail(const char* filename, int thumbWidth, int thumbHeight,
                                       CSalamanderThumbnailMakerAbstract* thumbMaker,
                                       BOOL fastThumbnail) = 0;

--- a/src/plugins/shared/spl_vers.h
+++ b/src/plugins/shared/spl_vers.h
@@ -25,7 +25,7 @@
 #define VERSINFO_SALAMANDER_MINORA 0
 #define VERSINFO_SALAMANDER_MINORB 0
 
-#if (VERSINFO_SALAMANDER_MINORB == 0) // nulu na setinach nepiseme 2.50 -> 2.5
+#if (VERSINFO_SALAMANDER_MINORB == 0) // we do not write zero in the hundredths 2.50 -> 2.5
 #define VERSINFO_SALAMANDER_VERSION VERSINFO_xstr(VERSINFO_SALAMANDER_MAJOR) "." VERSINFO_xstr(VERSINFO_SALAMANDER_MINORA) VERSINFO_BETAVERSION_TXT
 #define VERSINFO_SAL_SHORT_VERSION VERSINFO_xstr(VERSINFO_SALAMANDER_MAJOR) VERSINFO_xstr(VERSINFO_SALAMANDER_MINORA) VERSINFO_BETAVERSIONSHORT_TXT
 #else
@@ -33,8 +33,8 @@
 #define VERSINFO_SAL_SHORT_VERSION VERSINFO_xstr(VERSINFO_SALAMANDER_MAJOR) VERSINFO_xstr(VERSINFO_SALAMANDER_MINORA) VERSINFO_xstr(VERSINFO_SALAMANDER_MINORB) VERSINFO_BETAVERSIONSHORT_TXT
 #endif
 
-#ifdef VERSINFO_MAJOR      // je definovane jen pokud se pouziva z pluginu
-#if (VERSINFO_MINORB == 0) // nulu na setinach nepiseme 2.50 -> 2.5
+#ifdef VERSINFO_MAJOR      // defined only when it is used from a plugin
+#if (VERSINFO_MINORB == 0) // we do not write zero in the hundredths 2.50 -> 2.5
 #define VERSINFO_VERSION VERSINFO_xstr(VERSINFO_MAJOR) "." VERSINFO_xstr(VERSINFO_MINORA) VERSINFO_BETAVERSION_TXT
 #define VERSINFO_VERSION_NO_PLATFORM VERSINFO_xstr(VERSINFO_MAJOR) "." VERSINFO_xstr(VERSINFO_MINORA) VERSINFO_BETAVERSION_TXT_NO_PLATFORM
 #else
@@ -51,14 +51,13 @@
 
 // VERSINFO_BUILDNUMBER:
 //
-// Slouzi ke snadnemu odliseni verzi vsech modulu mezi jednotlivymi verzemi
-// Salamandera (jde o posledni komponentu cisla verze vsech pluginu a
-// Salamandera). Zvysovat s kazdou verzi (IB, DB, PB, beta, release nebo i
-// jen testovaci verze poslana jednomu uzivateli). Prehled ruznych typu verzi
-// je v souboru doc\versions.txt. Vzdy zavest komentar s popisem, ke ktere
-// verzi Salamandera patri nove pouzite cislo buildu.
+// Used to easily distinguish the versions of all modules between individual Salamander
+// releases (this is the last component of the version number of all plugins and Salamander).
+// Increase it with every release (IB, DB, PB, beta, final, or even a test build sent to a
+// single user). An overview of the version categories is in doc\versions.txt. Always add a
+// comment that states which Salamander version the newly used build number belongs to.
 //
-// Prehled pouzitych hodnot VERSINFO_BUILDNUMBER:
+// Overview of used VERSINFO_BUILDNUMBER values:
 // 9 - 2.5 beta 9
 // 10 - 2.5 beta 10
 // 11 - 2.5 beta 11
@@ -97,52 +96,52 @@
 // 182 - 4.0 (CB182)
 // 183 - 5.0
 
-// ! DULEZITE: nova cisla buildu je nutne zapsat do vetve "default", a pak
-//             teprve do vedlejsi vetve (kompletni seznam je jen v "default" vetvi)
+// ! IMPORTANT: new build numbers must be recorded in the "default" branch, and then
+//             only then into the side branch (the complete list exists only in the "default" branch)
 #define VERSINFO_BUILDNUMBER 183
 
 // VERSINFO_BETAVERSION_TXT:
 //
-// Meni se s kazdym buildem, v pripade release verze bude VERSINFO_BETAVERSION_TXT="".
-// Pokud vydavame specialni opravne beta verze typu 2.5 beta 9a, zvysime
-// VERSINFO_BUILDNUMBER o jedna a dame VERSINFO_BETAVERSION_TXT==" beta 9a".
+// Changes with every build; for a release version VERSINFO_BETAVERSION_TXT will be "".
+// If we publish corrective beta versions such as 2.5 beta 9a, we increase
+// VERSINFO_BUILDNUMBER by one and set VERSINFO_BETAVERSION_TXT == " beta 9a".
 //
-// VERSINFO_BETAVERSIONSHORT_TXT slouzi pro pojmenovani bug reportu, jde o co nejkratsi zapis
+// VERSINFO_BETAVERSIONSHORT_TXT is used for naming bug reports; it should be as short as possible
 
-// priklady ("x86" je pro 32-bit verzi, "x64" pro 64-bit verzi, v nasledujicich prikladech jsou
-// x86/x64 zamenne): " (x86)" (pro release verze), " beta 2 (x64)", " beta 2 (SDK x86)",
+// examples ("x86" is for the 32-bit version, "x64" for the 64-bit version; in the following examples they are
+// interchangeable as x86/x64): " (x86)" (for release versions), " beta 2 (x64)", " beta 2 (SDK x86)",
 // " RC1 (x64)", " beta 2 (IB21 x86)", " beta 2 (DB21 x64)", " beta 2 (PB21 x86)"
 #define VERSINFO_BETAVERSION_TXT " (" SAL_VER_PLATFORM ")"
-#define VERSINFO_BETAVERSION_TXT_NO_PLATFORM "" // kopie radku vyse + smazat SAL_VER_PLATFORM + je-li zavorka prazdna, smazat ji + smazat nadbytecne mezery
+#define VERSINFO_BETAVERSION_TXT_NO_PLATFORM "" // copy the line above + remove SAL_VER_PLATFORM + if the parentheses are empty, remove them + delete extra spaces
 
-// priklady (x86/x64 viz predchozi odstavec): "x86" (pro release verze), "B2x64", "B2SDKx86",
+// examples (x86/x64 see the previous paragraph): "x86" (for release versions), "B2x64", "B2SDKx86",
 // "RC1x64", "B2IB21x86", "B2DB21x64", "B2PB21x86"
 #define VERSINFO_BETAVERSIONSHORT_TXT SAL_VER_PLATFORM
 
 // LAST_VERSION_OF_SALAMANDER:
 //
-// Podpora pro kontrolu aktualnosti verze Salamandera, kterou interni pluginy
-// (distribuovane v jednom balicku se Salamanderem) provadi behem entry-pointu
-// (SalamanderPluginEntry) viz metoda CSalamanderPluginEntryAbstract::GetVersion()
-// (v spl_base.h). Slouzi hlavne pro jednoduchost: interni plugin muze volat
-// jakoukoliv metodu z rozhrani Salamandera, protoze po kontrole na posledni
-// verzi Salamandera ma jistotu, ze ji Salamander obsahuje (hrozi mu jen load
-// do novejsi verze Salamandera, ktery tyto metody musi tez obsahovat).
+// Support for checking whether the Salamander version is current, which internal plugins
+// (distributed in a single package with Salamander) perform during their entry point
+// (SalamanderPluginEntry); see the CSalamanderPluginEntryAbstract::GetVersion() method
+// (in spl_base.h). It serves mainly for convenience: an internal plugin can call any method
+// from the Salamander interface because, once it verifies that Salamander is up to date,
+// it is certain those methods exist (the only risk is loading into a newer Salamander
+// version, which must also contain these methods).
 //
-// Pouziva se i opacne: aby mel interni plugin jistotu, ze mu Salamander bude
-// volat vsechny metody (vcetne nejnovejsich), vraci tuto verzi, jako verzi,
-// pro kterou byl plugin postaven (viz export pluginu SalamanderPluginGetReqVer).
+// It is also used the other way around: for an internal plugin to be sure that Salamander will
+// call all methods (including the newest ones), it returns this version as the one it was built
+// against (see the SalamanderPluginGetReqVer plugin export).
 //
-// Pokud nektery plugin vraci z SalamanderPluginGetReqVer nizsi verzi nez
-// LAST_VERSION_OF_SALAMANDER (pro zpetnou kompatibilitu se starsimi verzemi
-// Salamandera), mel by pridat export SalamanderPluginGetSDKVer a vracet z nej
-// LAST_VERSION_OF_SALAMANDER (verze SDK pouzita pro stavbu pluginu), aby mohl
-// Salamander (napr. aktualni nebo novejsi) pouzivat i metody pluginu, ktere
-// ve verzi vracene z SalamanderPluginGetReqVer jeste nebyly.
+// If a plugin returns from SalamanderPluginGetReqVer a lower version than
+// LAST_VERSION_OF_SALAMANDER (for backward compatibility with older Salamander versions),
+// it should add the SalamanderPluginGetSDKVer export and have it return LAST_VERSION_OF_SALAMANDER
+// (the SDK version used to build the plugin). That lets Salamander (for example the current version
+// or a newer one) use plugin methods that were not yet available in the older version returned
+// from SalamanderPluginGetReqVer.
 //
-// Pri zmenach v rozhrani je potreba dodrzet postup uvedeny v doc\how_to_change.txt.
+// When changing the interface you must follow the procedure described in doc\how_to_change.txt.
 //
-// Prehled pouzitych hodnot LAST_VERSION_OF_SALAMANDER:
+// Overview of used LAST_VERSION_OF_SALAMANDER values:
 //   1  - 1.6 beta 4 + 5
 //   2  - 1.6 beta 6
 //   3  - 1.6 beta 7
@@ -159,13 +158,13 @@
 //   14 - 2.5 beta 10
 //   15 - 2.5 beta 10a
 //   16 - 2.5 beta 11
-//   17 - 2.5 beta 12 (jen interni, pustili jsme misto ni RC1)
+//   17 - 2.5 beta 12 (internal only, we released RC1 instead)
 //   18 - 2.5 RC1
 //   19 - 2.5 RC2
 //   20 - 2.5 RC3
 //   21 - 2.5
 //   22 - 2.51
-//   23 - 2.52 beta 1 (POZOR: nekompatibilni SDK s predchozimi a dalsimi verzemi)
+//   23 - 2.52 beta 1 (WARNING: SDK incompatible with previous and subsequent versions)
 //   29 - 2.52 beta 2
 //   31 - 2.52
 //   39 - 2.53 beta 1 + 2.53 beta 1a
@@ -185,9 +184,9 @@
 //   76 - 3.06
 //   79 - 3.07
 //   81 - 3.08
-// ! DULEZITE: vsechny verze z VC2008 musi byt < 100, vsechny verze z VC2019 musi byt >= 100,
-//             nova cisla verzi je nutne zapsat do vetve "default", a pak
-//             teprve do vedlejsi vetve (kompletni seznam je jen v "default" vetvi)
+// ! IMPORTANT: all versions from VC2008 must be < 100, all versions from VC2019 must be >= 100,
+//             new version numbers must be recorded in the "default" branch, and then
+//             only then into the side branch (the complete list exists only in the "default" branch)
 //   101 - 4.0 beta 1 (DB177)
 //   102 - 4.0
 //   103 - 5.0


### PR DESCRIPTION
## Summary
- polish the English phrasing in `spl_menu.h` so the menu extension API guidance reads naturally
- clarify the thumbnail loader documentation in `spl_thum.h`, especially around buffering and cancellation
- refine the versioning notes in `spl_vers.h` for clearer instructions on build numbers and compatibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e947dd0a60832287abae6357c147bf