### PR TITLE
Refine English registry worker and safe file comments

### DIFF
--- a/src/regwork.cpp
+++ b/src/regwork.cpp
@@ -43,7 +43,7 @@ BOOL ClearKeyAux(HKEY key)
 
 BOOL CreateKeyAux(HWND parent, HKEY hKey, const char* name, HKEY& createdKey, BOOL quiet)
 {
-    DWORD createType; // info jestli byl klic vytvoren nebo jen otevren
+    DWORD createType; // info whether the key was created or just opened
     LONG res = HANDLES(RegCreateKeyEx(hKey, name, 0, NULL, REG_OPTION_NON_VOLATILE,
                                       KEY_READ | KEY_WRITE, NULL, &createdKey,
                                       &createType));
@@ -333,7 +333,7 @@ BOOL CRegistryWorkerThread::StartThread()
             // clean-up
             if (InUse)
                 TRACE_E("CRegistryWorkerThread::StartThread(): thread is not running and InUse is TRUE!");
-            InUse = FALSE; // jen pro sychr, na tomto miste nemuze byt TRUE
+            InUse = FALSE; // just to be safe, this cannot be TRUE at this point
             ResetEvent(WorkReady);
             ResetEvent(WorkDone);
             WorkType = rwtNone;
@@ -342,11 +342,11 @@ BOOL CRegistryWorkerThread::StartThread()
             Thread = HANDLES(CreateThread(NULL, 0, CRegistryWorkerThread::ThreadBody, (void*)this, 0, &threadID));
             if (Thread != NULL)
             {
-                OwnerTID = GetCurrentThreadId(); // povolime pouzivani pro tento thread
+                OwnerTID = GetCurrentThreadId(); // enable usage for this thread
                 StopWorkerSkipCount = 0;
                 int level = GetThreadPriority(GetCurrentThread());
                 SetThreadPriority(Thread, level);
-                ret = TRUE; // uspech!
+                ret = TRUE; // success!
             }
             else
                 TRACE_E("CRegistryWorkerThread::StartThread(): unable to start registry-worker thread!");
@@ -387,10 +387,10 @@ void CRegistryWorkerThread::StopThread()
                     Thread = NULL;
                     OwnerTID = 0; // invalid TID
                 }
-                else // nikdy by se nemelo stat
+                else // should never happen
                 {
-                    // prevence dead-locku, pokud tento thread uz ma praci v registry worker
-                    // threadu, jejiho dokonceni se zde nelze dockat
+                    // prevent a dead lock: if this thread already has work in the registry worker
+                    // thread, we cannot wait for it to finish here
                     TRACE_E("CRegistryWorkerThread::StopThread(): preventing dead lock, skipping stop signal!");
                 }
             }
@@ -411,7 +411,7 @@ void CRegistryWorkerThread::WaitForWorkDoneWithMessageLoop()
     {
         DWORD waitRes = MsgWaitForMultipleObjects(1, &WorkDone, FALSE, INFINITE, QS_ALLINPUT);
         if (waitRes == WAIT_OBJECT_0)
-            break; // prace je hotova, pokracujeme...
+            break; // work is finished, continue...
         else
         {
             if (waitRes == WAIT_OBJECT_0 + 1) // new input
@@ -644,7 +644,7 @@ CRegistryWorkerThread::Body()
                 TRACE_I("End");
                 WorkType = rwtNone;
                 SetEvent(WorkDone);
-                return 0; // ukoncime thread
+                return 0; // terminate the thread
             }
 
             case rwtClearKey:
@@ -700,7 +700,7 @@ CRegistryWorkerThread::ThreadBodyFEH(void* param)
     {
         TRACE_I("CRegistryWorkerThread::ThreadBodyFEH: calling ExitProcess(1).");
         //    ExitProcess(1);
-        TerminateProcess(GetCurrentProcess(), 1); // tvrdsi exit (tenhle jeste neco vola)
+        TerminateProcess(GetCurrentProcess(), 1); // forceful exit (this still triggers some shutdown handling)
     }
     return 0;
 #endif // CALLSTK_DISABLE
@@ -725,14 +725,14 @@ CRegistryWorkerThread::CInUseHandler::~CInUseHandler()
 BOOL CRegistryWorkerThread::CInUseHandler::CanUseThread(CRegistryWorkerThread* t)
 {
     if (t->Thread != NULL && t->OwnerTID == GetCurrentThreadId())
-    { // prace ve workerovi se tyka jen threadu, ktery ho nastartoval
+    { // work in the worker concerns only the thread that started it
         BOOL ret = !t->InUse;
-        if (ret) // prace se muze spustit v threadu registry workera
+        if (ret) // work can run in the registry worker thread
         {
             t->InUse = TRUE;
-            T = t; // v destruktoru se da T->InUse = FALSE
+            T = t; // destructor will set T->InUse = FALSE
         }
-        // else  // rekurzivni volani (diky message-loope a tim distribuci zprav) = praci v threadu odmitneme
+        // otherwise, this is a recursive call (due to the message loop and message dispatch) so reject running the work there
         return ret;
     }
     return FALSE;

--- a/src/regwork.h
+++ b/src/regwork.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-// funkce pro pohodlnou praci s Registry + zadne hlasky o LOAD a SAVE konfigurace pri chybach
+// helper functions for convenient work with the Registry that avoid LOAD/SAVE configuration messages on errors
 BOOL OpenKeyAux(HWND parent, HKEY hKey, const char* name, HKEY& openedKey, BOOL quiet = TRUE);
 BOOL CreateKeyAux(HWND parent, HKEY hKey, const char* name, HKEY& createdKey, BOOL quiet = TRUE);
 BOOL GetValueAux(HWND parent, HKEY hKey, const char* name, DWORD type, void* buffer,
@@ -14,13 +14,13 @@ BOOL DeleteValueAux(HKEY hKey, const char* name);
 BOOL ClearKeyAux(HKEY key);
 void CloseKeyAux(HKEY hKey);
 BOOL DeleteKeyAux(HKEY hKey, const char* name);
-// neprovede kontrolu typu, takze nacte REG_DWORD stejne jako 4-byte REG_BINARY
+// does not check the type, so it reads REG_DWORD the same as a 4-byte REG_BINARY
 BOOL GetValueDontCheckTypeAux(HKEY hKey, const char* name, void* buffer, DWORD bufferSize);
 
 enum CRegistryWorkType
 {
     rwtNone,
-    rwtStopWorker, // servisni prace: ukonceni threadu
+    rwtStopWorker, // maintenance task: terminate the thread
     rwtClearKey,
     rwtCreateKey,
     rwtOpenKey,
@@ -48,13 +48,13 @@ protected:
         void ResetT() { T = NULL; }
     };
 
-    HANDLE Thread;           // thread registry-workera
-    DWORD OwnerTID;          // TID threadu, ktery spustil worker thread (nikdo jiny ho nemuze ukoncit)
-    BOOL InUse;              // TRUE = jiz nejakou praci provadi, dalsi prace se spusti bez threadu (resi rekurzi, pouziti z vice threadu se odmita, viz OwnerTID)
-    int StopWorkerSkipCount; // kolik volani StopThread() v threadu OwnerTID ignorovat (pocet rekurzivnich volani StartThread())
+    HANDLE Thread;           // registry worker thread
+    DWORD OwnerTID;          // TID of the thread that started the worker thread (no one else can stop it)
+    BOOL InUse;              // TRUE = already performing some work; further work runs without the thread (handles recursion, use from other threads is rejected, see OwnerTID)
+    int StopWorkerSkipCount; // how many StopThread() calls in the OwnerTID thread to ignore (number of recursive StartThread() calls)
 
-    HANDLE WorkReady; // signaled: thread ma pripravena data ke zpracovani (hlavni thread ceka na dokonceni + provadi message-loopu)
-    HANDLE WorkDone;  // signaled: thread dokoncil praci (hlavni thread muze pokracovat)
+    HANDLE WorkReady; // signaled: the thread has data ready for processing (the main thread waits for completion + runs the message loop)
+    HANDLE WorkDone;  // signaled: the thread finished the work (the main thread may continue)
 
     CRegistryWorkType WorkType;
     BOOL LastWorkSuccess;
@@ -73,55 +73,55 @@ public:
     CRegistryWorkerThread();
     ~CRegistryWorkerThread();
 
-    // start threadu registry-workera, vraci uspech
+    // start the registry worker thread; returns TRUE on success
     BOOL StartThread();
 
-    // ukonceni threadu registry-workera
+    // terminate the registry worker thread
     void StopThread();
 
-    // vycisti klic 'key' od vsech podklicu a hodnot, vraci uspech
+    // clear key 'key' of all subkeys and values; returns TRUE on success
     BOOL ClearKey(HKEY key);
 
-    // vytvori nebo otevre existujici podklic 'name' klice 'key', vraci 'createdKey' a uspech;
-    // ziskany klic ('createdKey') je nutne zavrit volanim CloseKey
+    // create or open the existing subkey 'name' of key 'key'; returns the handle in 'createdKey'
+    // and TRUE on success. The returned key must be closed with CloseKey.
     BOOL CreateKey(HKEY key, const char* name, HKEY& createdKey);
 
-    // otevre existujici podklic 'name' klice 'key', vraci 'openedKey' a uspech
-    // ziskany klic ('openedKey') je nutne zavrit volanim CloseKey
+    // open the existing subkey 'name' of key 'key'; returns the handle in 'openedKey'
+    // and TRUE on success. The returned key must be closed with CloseKey.
     BOOL OpenKey(HKEY key, const char* name, HKEY& openedKey);
 
-    // zavre klic otevreny pres OpenKey nebo CreateKey
+    // close a key previously obtained via OpenKey or CreateKey
     void CloseKey(HKEY key);
 
-    // smaze podklic 'name' klice 'key', vraci uspech
+    // delete subkey 'name' of key 'key'; returns TRUE on success
     BOOL DeleteKey(HKEY key, const char* name);
 
-    // nacte hodnotu 'name'+'type'+'buffer'+'bufferSize' z klice 'key', vraci uspech
+    // load value 'name' of type 'type' into 'buffer' (size 'bufferSize') from key 'key'; returns TRUE on success
     BOOL GetValue(HKEY key, const char* name, DWORD type, void* buffer, DWORD bufferSize);
 
-    // nacte hodnotu 'name'+'type1 || type2' do 'returnedType'+'buffer'+'bufferSize' z klice 'key', vraci uspech
+    // load value 'name' of type 'type1' or 'type2' into 'buffer' (size 'bufferSize') from key 'key';
+    // stores the actual type in 'returnedType' and returns TRUE on success
     BOOL GetValue2(HKEY hKey, const char* name, DWORD type1, DWORD type2, DWORD* returnedType, void* buffer, DWORD bufferSize);
 
-    // ulozi hodnotu 'name'+'type'+'data'+'dataSize' do klice 'key', pro retezce je mozne
-    // zadat 'dataSize' == -1 -> vypocet delky retezce pomoci funkce strlen,
-    // vraci uspech
+    // store value 'name' of type 'type' from 'data' (size 'dataSize') into key 'key'.
+    // For strings you can pass 'dataSize' == -1 to derive the size from strlen(). Returns TRUE on success.
     BOOL SetValue(HKEY key, const char* name, DWORD type, const void* data, DWORD dataSize);
 
-    // smaze hodnotu 'name' klice 'key', vraci uspech
+    // delete value 'name' from key 'key'; returns TRUE on success
     BOOL DeleteValue(HKEY key, const char* name);
 
-    // vytahne do 'bufferSize' protrebnou velikost pro hodnotu 'name'+'type' z klice 'key', vraci uspech
+    // retrieve into 'bufferSize' the required size for value 'name' of type 'type' from key 'key'; returns TRUE on success
     BOOL GetSize(HKEY key, const char* name, DWORD type, DWORD& bufferSize);
 
 protected:
-    // ceka na dokonceni prace + provadi message-loopu
+    // waits for the work to finish + runs the message loop
     void WaitForWorkDoneWithMessageLoop();
 
-    // telo threadu - zde se odehrava vsechna prace
+    // thread body - all work takes place here
     unsigned Body();
 
-    static DWORD WINAPI ThreadBody(void* param); // pomocna funkce pro telo threadu
-    static unsigned ThreadBodyFEH(void* param);  // pomocna funkce pro telo threadu
+    static DWORD WINAPI ThreadBody(void* param); // helper function for the thread body
+    static unsigned ThreadBodyFEH(void* param);  // helper function for the thread body
 };
 
 extern CRegistryWorkerThread RegistryWorkerThread;

--- a/src/safefile.cpp
+++ b/src/safefile.cpp
@@ -34,7 +34,7 @@ BOOL CSalamanderSafeFile::SafeFileOpen(SAFE_FILE* file,
                         fileName, dwDesiredAccess, dwShareMode, dwCreationDisposition,
                         dwFlagsAndAttributes, flags);
 
-    // pro chyby jako LOW_MEMORY si prejeme uplny konec operace
+    // for errors such as LOW_MEMORY we want the operation to abort entirely
     if (pressedButton != NULL)
         *pressedButton = DIALOG_CANCEL;
 
@@ -72,7 +72,7 @@ BOOL CSalamanderSafeFile::SafeFileOpen(SAFE_FILE* file,
         }
     } while (hFile == INVALID_HANDLE_VALUE);
 
-    // vse je OK - naplnime kontext
+    // everything is OK - populate the context structure
     file->FileName = DupStr(fileName);
     if (file->FileName == NULL)
     {
@@ -117,7 +117,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
     if (skipPath != NULL && skipPathMax > 0)
         *skipPath = 0;
     BOOL wholeFileAllocated = FALSE;
-    BOOL needWholeAllocTest = FALSE; // mame overit, ze se dari nastavit ukazovatko a data se nepripoji na konec souboru
+    BOOL needWholeAllocTest = FALSE; // we must verify that the pointer can be set and the data are not appended to the end of the file
     if (allocateWholeFile != NULL &&
         *allocateWholeFile >= CQuadWord(0, 0x80000000))
     {
@@ -125,7 +125,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
         needWholeAllocTest = TRUE;
     }
 
-    // zjistime, zda jiz existuje
+    // check whether the target already exists
     DWORD attrs;
     HANDLE hFile;
     int fileNameLen = (int)strlen(fileName);
@@ -135,7 +135,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
         if (attrs == 0xFFFFFFFF)
             break;
 
-        // uz existuje, zkusime jestli to neni jen kolize s dosovym nazvem (plne jmeno existujiciho souboru/adresare je jine)
+        // it already exists; check whether the conflict is only with the DOS name (the full name differs)
         if (!isDir)
         {
             WIN32_FIND_DATA data;
@@ -144,10 +144,10 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
             {
                 HANDLES(FindClose(find));
                 const char* tgtName = SalPathFindFileName(fileName);
-                if (StrICmp(tgtName, data.cAlternateFileName) == 0 && // shoda jen pro dos name
-                    StrICmp(tgtName, data.cFileName) != 0)            // (plne jmeno je jine)
+                if (StrICmp(tgtName, data.cAlternateFileName) == 0 && // match only for the DOS name
+                    StrICmp(tgtName, data.cFileName) != 0)            // (the full name is different)
                 {
-                    // prejmenujeme ("uklidime") soubor/adresar s konfliktnim dos name do docasneho nazvu 8.3 (nepotrebuje extra dos name)
+                    // rename ("clean up") the conflicting file/directory to a temporary 8.3 name (so it no longer needs a DOS alias)
                     char tmpName[MAX_PATH + 20];
                     char origFullName[MAX_PATH];
                     lstrcpyn(tmpName, fileName, MAX_PATH);
@@ -170,20 +170,20 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                                 break;
                             }
                         }
-                        if (tmpName[0] != 0) // pokud se podarilo "uklidit" konfliktni soubor/adresar, zkusime vytvoreni ciloveho
-                        {                    // souboru/adresare, pak vratime "uklizenemu" souboru/adresari jeho puvodni jmeno
+                        if (tmpName[0] != 0) // if we managed to "clean up" the conflicting file/directory, try creating the target
+                        {                    // file/directory and then restore the original name to the "cleaned" file/directory
                             hFile = INVALID_HANDLE_VALUE;
-                            //              if (!isDir)   // soubor
-                            //              {       // do handles pridame handle na zaver pouze pokud se plni struktura SAFE_FILE
+                            //              if (!isDir)   // file
+                            //              {       // add the handle to HANDLES only at the end if the SAFE_FILE structure is being filled
                             hFile = NOHANDLES(CreateFile(fileName, dwDesiredAccess, dwShareMode, NULL,
                                                          CREATE_NEW, dwFlagsAndAttributes, NULL));
                             //              }
-                            //              else   // adresar
+                            //              else   // directory
                             //              {
-                            //                if (CreateDirectory(fileName, NULL)) out = (void *)1;  // pri uspechu musime vratit neco jineho nez INVALID_HANDLE_VALUE
+                            //                if (CreateDirectory(fileName, NULL)) out = (void *)1;  // on success we must return something other than INVALID_HANDLE_VALUE
                             //              }
                             if (!::SalMoveFile(tmpName, origFullName))
-                            { // toto se zjevne muze stat, nepochopitelne, ale Windows vytvori misto 'fileName' (dos name) soubor se jmenem origFullName
+                            { // this can apparently happen; inexplicably, Windows creates a file named origFullName instead of 'fileName' (the DOS name)
                                 TRACE_I("Unexpected situation in CSalamanderGeneral::SafeCreateFile(): unable to rename file from tmp-name to original long file name! " << origFullName);
 
                                 if (hFile != INVALID_HANDLE_VALUE)
@@ -199,30 +199,30 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                                 }
                             }
                             if (hFile != INVALID_HANDLE_VALUE)
-                                goto SUCCESS; // navrat jen pri uspechu, chyby se resi dale (ignorujeme konflikt dos-jmena)
+                                goto SUCCESS; // return only on success; errors are handled later (ignore the DOS-name conflict)
                         }
                     }
                 }
             }
         }
 
-        // uz existuje, ale co to je ?
+        // it already exists, but what is it?
         if (attrs & FILE_ATTRIBUTE_DIRECTORY)
         {
             int ret;
-            // je to adresar
+            // it is a directory
             if (isDir)
             {
-                // pokud jsme chteli adresar, pak je to v poradku
-                // a vratime cokoli ruzneho od INVALID_HANDLE_VALUE
+                // if we wanted a directory, that is fine
+                // and return anything other than INVALID_HANDLE_VALUE
                 return (void*)1;
             }
-            // jinak hlasime chybu
+            // otherwise report an error
             if (silentMask != NULL && (*silentMask & SILENT_SKIP_FILE_NAMEUSED) && allowSkip)
                 ret = DIALOG_SKIP;
             else
             {
-                // ERROR: filename+error, tlacitka retry/skip/skip all/cancel
+                // ERROR: filename+error, buttons retry/skip/skip all/cancel
                 ret = DialogError(hParent, allowSkip ? BUTTONS_RETRYSKIPCANCEL : BUTTONS_RETRYCANCEL,
                                   fileName, LoadStr(IDS_NAMEALREADYUSEDFORDIR), LoadStr(IDS_ERRORCREATINGFILE));
             }
@@ -244,15 +244,15 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
         else
         {
             int ret;
-            // je to soubor, zjistime, zda ho muzeme prepsat
+            // it is a file, check whether it can be overwritten
             if (isDir)
             {
-                // snazime se vytvorit adresar, ale v miste uz je soubor se stejnym nazvem -- vyhlasime chybu
+                // we are trying to create a directory, but there is already a file with the same name in place -- report an error
                 if (silentMask != NULL && (*silentMask & SILENT_SKIP_DIR_NAMEUSED) && allowSkip)
                     ret = DIALOG_SKIP;
                 else
                 {
-                    // ERROR: filename+error, tlacitka retry/skip/skip all/cancel
+                    // ERROR: filename+error, buttons retry/skip/skip all/cancel
                     ret = DialogError(hParent, allowSkip ? BUTTONS_RETRYSKIPCANCEL : BUTTONS_RETRYCANCEL,
                                       fileName, LoadStr(IDS_NAMEALREADYUSED), LoadStr(IDS_ERRORCREATINGDIR));
                 }
@@ -266,7 +266,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                     if (skipped != NULL)
                         *skipped = TRUE;
                     if (skipPath != NULL)
-                        lstrcpyn(skipPath, fileName, skipPathMax); // uzivatel chce vratit skipnutou cestu
+                        lstrcpyn(skipPath, fileName, skipPathMax); // the user wants to retrieve the skipped path
                     return INVALID_HANDLE_VALUE;
                 case DIALOG_CANCEL:
                 case DIALOG_FAIL:
@@ -276,7 +276,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
             }
             else
             {
-                // doptame se na prepis
+                // ask whether to overwrite
                 if ((srcFileName != NULL && !Configuration.CnfrmFileOver) || (silentMask != NULL && (*silentMask & SILENT_OVERWRITE_FILE_EXIST)))
                     ret = DIALOG_YES;
                 else if (silentMask != NULL && (*silentMask & SILENT_SKIP_FILE_EXIST) && allowSkip)
@@ -295,13 +295,13 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                         strcpy(fibuffer, LoadStr(IDS_ERR_FILEOPEN));
                     if (srcFileName != NULL)
                     {
-                        // CONFIRM FILE OVERWRITE: filename1+filedata1+filename2+filedata2, tlacitka yes/all/skip/skip all/cancel
+                        // CONFIRM FILE OVERWRITE: filename1+filedata1+filename2+filedata2, buttons yes/all/skip/skip all/cancel
                         ret = DialogOverwrite(hParent, allowSkip ? BUTTONS_YESALLSKIPCANCEL : BUTTONS_YESALLCANCEL,
                                               fileName, fibuffer, srcFileName, srcFileInfo);
                     }
                     else
                     {
-                        // CONFIRM FILE OVERWRITE: filename1+filedata1+a newly created file, tlacitka yes/all/skip/skip all/cancel
+                        // CONFIRM FILE OVERWRITE: filename1+filedata1+a newly created file, buttons yes/all/skip/skip all/cancel
                         ret = DialogQuestion(hParent, allowSkip ? BUTTONS_YESALLSKIPCANCEL : BUTTONS_YESNOCANCEL,
                                              fileName, LoadStr(IDS_NEWLYCREATEDFILE), LoadStr(IDS_CONFIRMFILEOVERWRITING));
                     }
@@ -328,12 +328,12 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                 }
                 if (ret == DIALOG_YES)
                 {
-                    // budeme prepisovat - zrusime atributy
+                    // we will overwrite - clear the attributes
                     if (attrs & FILE_ATTRIBUTE_HIDDEN ||
                         attrs & FILE_ATTRIBUTE_SYSTEM ||
                         attrs & FILE_ATTRIBUTE_READONLY)
                     {
-                        // pro soubory bez hidden a system attr. se druha (hidden+system) confirmation nevypisuje
+                        // for files without hidden and system attributes, the second (hidden+system) confirmation is not shown
                         if (srcFileName == NULL || !Configuration.CnfrmSHFileOver ||
                             (silentMask != NULL && (*silentMask & SILENT_OVERWRITE_FILE_SYSHID)) ||
                             ((attrs & FILE_ATTRIBUTE_HIDDEN) == 0 && (attrs & FILE_ATTRIBUTE_SYSTEM) == 0))
@@ -341,7 +341,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                         else if (silentMask != NULL && (*silentMask & SILENT_SKIP_FILE_SYSHID) && allowSkip)
                             ret = DIALOG_SKIP;
                         else
-                            // QUESTION: filename+question, tlacitka yes/all/skip/skip all/cancel
+                            // QUESTION: filename+question, buttons yes/all/skip/skip all/cancel
                             ret = DialogQuestion(hParent, allowSkip ? BUTTONS_YESALLSKIPCANCEL : BUTTONS_YESALLCANCEL,
                                                  fileName, LoadStr(IDS_WANTOVERWRITESHFILE), LoadStr(IDS_CONFIRMFILEOVERWRITING));
                         switch (ret)
@@ -380,13 +380,13 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
     {
         if (fileNameLen > MAX_PATH - 1)
         {
-            // Prilis dlouhe jmeno -- nabidneme Skip / Skip All / Cancel
+            // Name too long -- offer Skip / Skip All / Cancel
             int ret;
             if (silentMask != NULL && (*silentMask & (isDir ? SILENT_SKIP_DIR_CREATE : SILENT_SKIP_FILE_CREATE)) && allowSkip)
                 ret = DIALOG_SKIP;
             else
             {
-                // ERROR: filename+error, skip/skip all/cancel
+                // ERROR: filename+error, buttons skip/skip all/cancel
                 ret = DialogError(hParent, allowSkip ? BUTTONS_SKIPCANCEL : BUTTONS_OK, fileName, ::GetErrorText(ERROR_FILENAME_EXCED_RANGE),
                                   LoadStr(isDir ? IDS_ERRORCREATINGDIR : IDS_ERRORCREATINGFILE));
             }
@@ -401,7 +401,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                 if (skipped != NULL)
                     *skipped = TRUE;
                 if (isDir && skipPath != NULL)
-                    lstrcpyn(skipPath, fileName, skipPathMax); // uzivatel chce vratit skipnutou cestu
+                    lstrcpyn(skipPath, fileName, skipPathMax); // the user wants to retrieve the skipped path
             }
             }
             return INVALID_HANDLE_VALUE;
@@ -409,31 +409,31 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
 
         char namecopy[MAX_PATH];
         strcpy(namecopy, fileName);
-        // pokud je to soubor, ziskame jmeno adresare
+        // if it is a file, obtain the directory name
         if (!isDir)
         {
             char* ptr = strrchr(namecopy, '\\');
-            // existuje cesta, kterou bychom mohli tvorit ?
+            // does a path exist that we could create?
             if (ptr == NULL)
                 goto CREATE_FILE;
-            // pokud ano, nechame jen cestu
+            // if so, keep only the path
             *ptr = '\0';
-            // existuje uz cesta ?
+            // does the path already exist?
             while (1)
             {
                 attrs = SalGetFileAttributes(namecopy);
                 if (attrs != 0xFFFFFFFF)
                 {
-                    // ano - jdeme delat soubor
+                    // yes - proceed to create the file
                     if (attrs & FILE_ATTRIBUTE_DIRECTORY)
                         goto CREATE_FILE;
-                    // ne - je to soubor se stejnym nazvem - hazime chybu
+                    // no - there is a file with the same name - report an error
                     int ret;
                     if (silentMask != NULL && (*silentMask & SILENT_SKIP_DIR_NAMEUSED) && allowSkip)
                         ret = DIALOG_SKIP;
                     else
                     {
-                        // ERROR: filename+error, tlacitka retry/skip/skip all/cancel
+                        // ERROR: filename+error, buttons retry/skip/skip all/cancel
                         ret = DialogError(hParent, allowSkip ? BUTTONS_RETRYSKIPCANCEL : BUTTONS_RETRYCANCEL, namecopy,
                                           LoadStr(IDS_NAMEALREADYUSED), LoadStr(IDS_ERRORCREATINGDIR));
                     }
@@ -447,7 +447,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                         if (skipped != NULL)
                             *skipped = TRUE;
                         if (skipPath != NULL)
-                            lstrcpyn(skipPath, namecopy, skipPathMax); // uzivatel chce vratit skipnutou cestu
+                            lstrcpyn(skipPath, namecopy, skipPathMax); // the user wants to retrieve the skipped path
                         return INVALID_HANDLE_VALUE;
                     case DIALOG_CANCEL:
                     case DIALOG_FAIL:
@@ -459,13 +459,13 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                     break;
             }
         }
-        // vytvorime adresarovou cestu
+        // create the directory path
         char root[MAX_PATH];
         GetRootPath(root, namecopy);
-        // pokud je dir root adresar, je tu nejaky problem
+        // if the directory is the root directory, there is a problem
         if (strlen(namecopy) <= strlen(root))
         {
-            // root adresar -> chyba
+            // root directory -> error
             int ret;
             if (silentMask != NULL && (*silentMask & SILENT_SKIP_DIR_CREATE) && allowSkip)
                 ret = DIALOG_SKIP;
@@ -482,20 +482,20 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                 if (skipped != NULL)
                     *skipped = TRUE;
                 if (skipPath != NULL)
-                    lstrcpyn(skipPath, namecopy, skipPathMax); // uzivatel chce vratit skipnutou cestu
+                    lstrcpyn(skipPath, namecopy, skipPathMax); // the user wants to retrieve the skipped path
             }
             return INVALID_HANDLE_VALUE;
         }
         char* ptr;
         char namecpy2[MAX_PATH];
         strcpy(namecpy2, namecopy);
-        // najdeme prvni existujici adresar
+        // find the first existing directory
         while (1)
         {
             ptr = strrchr(namecpy2, '\\');
             if (ptr == NULL)
             {
-                // root adresar -> chyba
+                // root directory -> error
                 int ret;
                 if (silentMask != NULL && (*silentMask & SILENT_SKIP_DIR_CREATE) && allowSkip)
                     ret = DIALOG_SKIP;
@@ -512,12 +512,12 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                     if (skipped != NULL)
                         *skipped = TRUE;
                     if (skipPath != NULL)
-                        lstrcpyn(skipPath, namecpy2, skipPathMax); // uzivatel chce vratit skipnutou cestu
+                        lstrcpyn(skipPath, namecpy2, skipPathMax); // the user wants to retrieve the skipped path
                 }
                 return INVALID_HANDLE_VALUE;
             }
             *ptr = '\0';
-            // jsme uz na root-adresari ?
+            // are we already at the root directory?
             if (ptr <= namecpy2 + strlen(root))
                 break;
             while (1)
@@ -525,7 +525,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                 attrs = SalGetFileAttributes(namecpy2);
                 if (attrs != 0xFFFFFFFF)
                 {
-                    // mame adresar nebo soubor ?
+                    // do we have a directory or a file?
                     if (attrs & FILE_ATTRIBUTE_DIRECTORY)
                         break;
                     else
@@ -535,7 +535,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                             ret = DIALOG_SKIP;
                         else
                         {
-                            // ERROR: filename+error, tlacitka retry/skip/skip all/cancel
+                            // ERROR: filename+error, buttons retry/skip/skip all/cancel
                             ret = DialogError(hParent, allowSkip ? BUTTONS_RETRYSKIPCANCEL : BUTTONS_RETRYCANCEL,
                                               namecpy2, LoadStr(IDS_NAMEALREADYUSED), LoadStr(IDS_ERRORCREATINGDIR));
                         }
@@ -549,7 +549,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                             if (skipped != NULL)
                                 *skipped = TRUE;
                             if (skipPath != NULL)
-                                lstrcpyn(skipPath, namecpy2, skipPathMax); // uzivatel chce vratit skipnutou cestu
+                                lstrcpyn(skipPath, namecpy2, skipPathMax); // the user wants to retrieve the skipped path
                             return INVALID_HANDLE_VALUE;
                         case DIALOG_CANCEL:
                         case DIALOG_FAIL:
@@ -564,32 +564,32 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
             if (attrs != 0xFFFFFFFF && attrs & FILE_ATTRIBUTE_DIRECTORY)
                 break;
         }
-        // mame prvni funkcni adresar v namecopy
+        // we have the first working directory in namecopy
         ptr = namecpy2 + strlen(namecpy2) - 1;
         if (*ptr != '\\')
         {
             *++ptr = '\\';
             *++ptr = '\0';
         }
-        // pridame dalsi
+        // add another
         const char* src = namecopy + strlen(namecpy2);
         while (*src == '\\')
             src++;
         int len = (int)strlen(namecpy2);
-        // a uz je vyrabime jeden za druhym
+        // and now create them one after another
         while (*src != 0)
         {
-            BOOL invalidPath = FALSE; // *src != 0 && *src <= ' '; // mezera na zacatku jmena adresare je povolena, pri rucni vyrobe adresare ji ale nedovolujeme, je to matouci
+            BOOL invalidPath = FALSE; // *src != 0 && *src <= ' '; // a leading space in a directory name is allowed, but when creating directories manually we do not allow it because it is confusing
             const char* slash = strchr(src, '\\');
             if (slash == NULL)
                 slash = src + strlen(src);
             memcpy(namecpy2 + len, src, slash - src);
             namecpy2[len += (int)(slash - src)] = '\0';
             if (namecpy2[len - 1] <= ' ' || namecpy2[len - 1] == '.')
-                invalidPath = TRUE; // mezery a tecky na konci jmena vytvareneho adresare jsou nezadouci
+                invalidPath = TRUE; // spaces and dots at the end of the directory name being created are undesirable
             while (invalidPath || !CreateDirectory(namecpy2, NULL))
             {
-                // nepodarilo se vytvorit adresar, zobrazime chybu
+                // failed to create the directory, display an error
                 int ret;
                 if (silentMask != NULL && (*silentMask & SILENT_SKIP_DIR_CREATE) && allowSkip)
                     ret = DIALOG_SKIP;
@@ -598,7 +598,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                     DWORD err = GetLastError();
                     if (invalidPath)
                         err = ERROR_INVALID_NAME;
-                    // ERROR: filename+error, tlacitka retry/skip/skip all/cancel
+                    // ERROR: filename+error, buttons retry/skip/skip all/cancel
                     ret = DialogError(hParent, allowSkip ? BUTTONS_RETRYSKIPCANCEL : BUTTONS_RETRYCANCEL,
                                       namecpy2, ::GetErrorText(err), LoadStr(IDS_ERRORCREATINGDIR));
                 }
@@ -612,7 +612,7 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
                     if (skipped != NULL)
                         *skipped = TRUE;
                     if (skipPath != NULL)
-                        lstrcpyn(skipPath, namecpy2, skipPathMax); // uzivatel chce vratit skipnutou cestu
+                        lstrcpyn(skipPath, namecpy2, skipPathMax); // the user wants to retrieve the skipped path
                     return INVALID_HANDLE_VALUE;
 
                 case DIALOG_CANCEL:
@@ -629,22 +629,22 @@ CSalamanderSafeFile::SafeFileCreate(const char* fileName,
     }
 
 CREATE_FILE:
-    // je-li to soubor, vytvorime ho
+    // if it is a file, create it
     if (!isDir)
-    { // do handles pridame handle na zaver pouze pokud se plni struktura SAFE_FILE
+    { // add the handle to HANDLES only at the end if the SAFE_FILE structure is being filled
         while ((hFile = NOHANDLES(CreateFile(fileName, dwDesiredAccess, dwShareMode, NULL,
                                              CREATE_ALWAYS, dwFlagsAndAttributes, NULL))) == INVALID_HANDLE_VALUE)
         {
             DWORD err = GetLastError();
-            // resi situaci, kdy je potreba prepsat soubor na Sambe:
-            // soubor ma 440+jinyho_vlastnika a je v adresari, kam ma akt. user zapis
-            // (smazat lze, ale primo prepsat ne (nelze otevrit pro zapis) - obchazime:
-            //  smazeme+vytvorime soubor znovu)
-            // (na Sambe lze povolit mazani read-only, coz umozni delete read-only souboru,
-            //  jinak nelze smazat, protoze Windows neumi smazat read-only soubor a zaroven
-            //  u toho souboru nelze shodit "read-only" atribut, protoze akt. user neni vlastnik)
-            if (DeleteFile(fileName)) // je-li read-only, pujde smazat jedine na Sambe s povolenym "delete readonly"
-            {                         // do handles pridame handle na zaver pouze pokud se plni struktura SAFE_FILE
+            // handles the situation when a file needs to be overwritten on Samba:
+            // the file has permissions 440+different_owner and is in a directory the current user can write to
+            // (it can be deleted, but not overwritten directly (cannot be opened for writing) - we work around it:
+            //  delete and create the file again)
+            // (on Samba it is possible to allow deleting read-only files, which allows deleting a read-only file,
+            //  otherwise it cannot be deleted because Windows cannot delete a read-only file and at the same time
+            //  the "read-only" attribute cannot be cleared on that file because the current user is not the owner)
+            if (DeleteFile(fileName)) // if it is read-only, it can be deleted only on Samba with "delete readonly" allowed
+            {                         // add the handle to HANDLES only at the end if the SAFE_FILE structure is being filled
                 hFile = NOHANDLES(CreateFile(fileName, dwDesiredAccess, dwShareMode, NULL,
                                              CREATE_ALWAYS, dwFlagsAndAttributes, NULL));
                 if (hFile != INVALID_HANDLE_VALUE)
@@ -657,7 +657,7 @@ CREATE_FILE:
                 ret = DIALOG_SKIP;
             else
             {
-                // ERROR: filename+error, tlacitka retry/skip/skip all/cancel
+                // ERROR: filename+error, buttons retry/skip/skip all/cancel
                 ret = DialogError(hParent, allowSkip ? BUTTONS_RETRYSKIPCANCEL : BUTTONS_RETRYCANCEL, fileName,
                                   ::GetErrorText(err), LoadStr(IDS_ERRORCREATINGFILE));
             }
@@ -679,9 +679,9 @@ CREATE_FILE:
         }
 
     SUCCESS:
-        // *************** Zde zacina anti-fragmentovaci kod
+        // *************** Anti-fragmentation code begins here
 
-        // pokud je to mozne, provedeme alokaci potrebneho mista pro soubor (nedochazi pak k fragmentaci disku + hladsi zapis na diskety)
+        // if possible, allocate the necessary space for the file (prevents disk fragmentation + smoother writes to floppies)
         if (allocateWholeFile != NULL)
         {
             BOOL fatal = TRUE;
@@ -703,14 +703,14 @@ CREATE_FILE:
                             DWORD wr;
                             if (WriteFile(hFile, "x", 1, &wr, NULL) && wr == 1)
                             {
-                                if (SetEndOfFile(hFile)) // zkusime zkraceni souboru na jeden byte
+                                if (SetEndOfFile(hFile)) // try truncating the file to one byte
                                 {
                                     CQuadWord size;
                                     size.LoDWord = GetFileSize(hFile, &size.HiDWord);
                                     if (size == CQuadWord(1, 0))
-                                    { // kontrola, jestli nedoslo k pridani zapisovaneho bytu na konec souboru + jestli umime soubor zkratit
+                                    { // check whether the written byte was appended to the end of the file and whether we can truncate the file
                                         needWholeAllocTest = FALSE;
-                                        goto SET_SIZE_AGAIN; // musime znovu nastavit kompletni velikost souboru
+                                        goto SET_SIZE_AGAIN; // we have to set the full file size again
                                     }
                                 }
                             }
@@ -718,14 +718,14 @@ CREATE_FILE:
                         else
                         {
                             fatal = FALSE;
-                            wholeFileAllocated = TRUE; // vse je OK, soubor je natazeny
+                            wholeFileAllocated = TRUE; // everything is OK, the file is stretched
                         }
                     }
                 }
                 else
                 {
                     if (GetLastError() == ERROR_DISK_FULL)
-                        ignoreErr = TRUE; // malo mista na disku
+                        ignoreErr = TRUE; // low disk space
                 }
             }
             if (fatal)
@@ -734,29 +734,29 @@ CREATE_FILE:
                 {
                     DWORD err = GetLastError();
                     TRACE_E("SafeFileCreate(): unable to allocate whole file size before copy operation, please report under what conditions this occurs! GetLastError(): " << GetErrorText(err));
-                    *allocateWholeFile = CQuadWord(-1, 0); // dalsi pokusy na tomhle cilovem disku si odpustime
+                    *allocateWholeFile = CQuadWord(-1, 0); // skip further attempts on this target disk
                 }
                 else
-                    *allocateWholeFile = CQuadWord(0, 0); // soubor se nezdarilo nastavit, ale priste to zkusime znovu
+                    *allocateWholeFile = CQuadWord(0, 0); // the file could not be prepared, but we will try again next time
 
-                // zkusime jeste soubor zkratit na nulu, aby nedoslo pri zavreni souboru k nejakemu zbytecnemu zapisu
+                // also try truncating the file to zero to avoid unnecessary writing when closing the file
                 SetFilePointer(hFile, 0, NULL, FILE_BEGIN);
                 SetEndOfFile(hFile);
 
                 CloseHandle(hFile);
-                ClearReadOnlyAttr(fileName); // kdyby vznikl jako read-only, tak abychom si s nim poradili
+                ClearReadOnlyAttr(fileName); // in case it ended up read-only so we can handle it
                 DeleteFile(fileName);
 
-                allocateWholeFile = NULL; // v pristi kole uz se o nafukovani nebudeme pokouset
+                allocateWholeFile = NULL; // next time we will no longer try to preallocate
                 goto CREATE_FILE;
             }
         }
-        // *************** Zde konci anti-fragmentovaci kod
+        // *************** Anti-fragmentation code ends here
     }
-    // vratime result - pokud jsme dosli az sem, vracime uspech
+    // return the result - if we got this far, we return success
     if (isDir)
-        return (void*)1; // pro adresar proste neco jineho, nez INVALID_HANDLE_VALUE
-    if (file != NULL)    // mame za ukol inicializovat strukturu SAFE_FILE
+        return (void*)1; // for a directory just return anything other than INVALID_HANDLE_VALUE
+    if (file != NULL)    // our task is to initialize the SAFE_FILE structure
     {
         file->FileName = DupStr(fileName);
         if (file->FileName == NULL)
@@ -772,7 +772,7 @@ CREATE_FILE:
         file->dwCreationDisposition = CREATE_ALWAYS;
         file->dwFlagsAndAttributes = dwFlagsAndAttributes;
         file->WholeFileAllocated = wholeFileAllocated;
-        HANDLES_ADD(__htFile, __hoCreateFile, hFile); // handle hFile pridame do HANDLES
+        HANDLES_ADD(__htFile, __hoCreateFile, hFile); // add handle hFile to HANDLES
     }
     return hFile;
 }
@@ -782,7 +782,7 @@ void CSalamanderSafeFile::SafeFileClose(SAFE_FILE* file)
     if (file->HFile != NULL && file->HFile != INVALID_HANDLE_VALUE)
     {
         if (file->WholeFileAllocated)
-            SetEndOfFile(file->HFile); // jinak by se zapisoval zbytek souboru
+            SetEndOfFile(file->HFile); // otherwise the rest of the file would be written
         HANDLES(CloseHandle(file->HFile));
     }
     if (file->FileName != NULL)
@@ -837,7 +837,7 @@ SEEK_AGAIN:
     {
         DWORD dlgRet;
         DWORD skip = seekForRead ? SILENT_SKIP_FILE_READ : SILENT_SKIP_FILE_WRITE;
-        if (silentMask != NULL && (*silentMask & skip) && ButtonsContainsSkip(flags)) // pokud nemame hlasku ignorovat, zobrazime ji
+        if (silentMask != NULL && (*silentMask & skip) && ButtonsContainsSkip(flags)) // if we are not supposed to ignore the message, show it
             dlgRet = DIALOG_SKIP;
         else
         {
@@ -848,14 +848,14 @@ SEEK_AGAIN:
         switch (dlgRet)
         {
         case DIALOG_RETRY:
-            goto SEEK_AGAIN; // zkusime znovu
+            goto SEEK_AGAIN; // try again
         case DIALOG_SKIPALL:
             if (silentMask != NULL)
                 *silentMask |= skip;
         default:
         {
             if (pressedButton != NULL)
-                *pressedButton = dlgRet; // vratim tlacitko, na ktere user kliknul
+                *pressedButton = dlgRet; // return the button the user clicked
             return FALSE;
         }
         }
@@ -884,11 +884,11 @@ BOOL CSalamanderSafeFile::SafeFileRead(SAFE_FILE* file, LPVOID lpBuffer,
         TRACE_E("CSalamanderSafeFile::SafeFileRead() HFile==NULL");
         return FALSE;
     }
-    // ziskame aktualni seek v souboru
+    // obtain the current seek position in the file
     long currentSeekHi = 0;
     DWORD currentSeekLo = SetFilePointer(file->HFile, 0, &currentSeekHi, FILE_CURRENT);
     if (currentSeekLo == 0xFFFFFFFF && GetLastError() != NO_ERROR)
-        goto READ_ERROR; // nelze nastavit offset, zkusime to znovu
+        goto READ_ERROR; // cannot set the offset, try again
 
     while (TRUE)
     {
@@ -896,7 +896,7 @@ BOOL CSalamanderSafeFile::SafeFileRead(SAFE_FILE* file, LPVOID lpBuffer,
         {
             if ((flags & SAFE_FILE_CHECK_SIZE) && nNumberOfBytesToRead != *lpNumberOfBytesRead)
             {
-                // volajici vyzaduje nacteni presne tolika bajtu, o kolik si pozadal
+                // the caller requires reading exactly as many bytes as requested
                 DWORD dlgRet;
                 if (silentMask != NULL && (*silentMask & SILENT_SKIP_FILE_READ) && ButtonsContainsSkip(flags))
                     dlgRet = DIALOG_SKIP;
@@ -915,7 +915,7 @@ BOOL CSalamanderSafeFile::SafeFileRead(SAFE_FILE* file, LPVOID lpBuffer,
                 default:
                 {
                     if (pressedButton != NULL)
-                        *pressedButton = dlgRet; // vratim tlacitko, na ktere user kliknul
+                        *pressedButton = dlgRet; // return the button the user clicked
                     return FALSE;
                 }
                 }
@@ -942,27 +942,27 @@ BOOL CSalamanderSafeFile::SafeFileRead(SAFE_FILE* file, LPVOID lpBuffer,
                 if (file->HFile != NULL)
                 {
                     if (file->WholeFileAllocated)
-                        SetEndOfFile(file->HFile);     // jinak by se zapisoval zbytek souboru
-                    HANDLES(CloseHandle(file->HFile)); // zavreme invalidni handle, protoze uz by z nej stejne neslo cist
+                        SetEndOfFile(file->HFile);     // otherwise the rest of the file would be written
+                    HANDLES(CloseHandle(file->HFile)); // close the invalid handle because we could not read from it anyway
                 }
 
                 file->HFile = HANDLES_Q(CreateFile(file->FileName, file->dwDesiredAccess, file->dwShareMode, NULL,
                                                    file->dwCreationDisposition, file->dwFlagsAndAttributes, NULL));
-                if (file->HFile != INVALID_HANDLE_VALUE) // otevreno, jeste nastavime offset
+                if (file->HFile != INVALID_HANDLE_VALUE) // opened; now set the offset
                 {
                 SEEK:
                     LONG lo = currentSeekLo;
                     LONG hi = currentSeekHi;
                     lo = SetFilePointer(file->HFile, lo, &hi, FILE_BEGIN);
                     if (lo == 0xFFFFFFFF && GetLastError() != NO_ERROR)
-                        goto READ_ERROR; // nelze nastavit offset, zkusime to znovu
+                        goto READ_ERROR; // cannot set the offset, try again
                     if (lo != (long)currentSeekLo || hi != currentSeekHi)
                     {
                         SetLastError(ERROR_SEEK_ON_DEVICE);
-                        goto READ_ERROR; // nelze nastavit offset (soubor uz muze byt mensi), zkusime to znovu
+                        goto READ_ERROR; // cannot set the offset (the file may already be smaller), try again
                     }
                 }
-                else // nejde otevrit, problem trva ...
+                else // cannot open it, the problem persists...
                 {
                     file->HFile = NULL;
                     goto READ_ERROR;
@@ -976,7 +976,7 @@ BOOL CSalamanderSafeFile::SafeFileRead(SAFE_FILE* file, LPVOID lpBuffer,
             default:
             {
                 if (pressedButton != NULL)
-                    *pressedButton = dlgRet; // vratim tlacitko, na ktere user kliknul
+                    *pressedButton = dlgRet; // return the button the user clicked
                 return FALSE;
             }
             }
@@ -994,11 +994,11 @@ BOOL CSalamanderSafeFile::SafeFileWrite(SAFE_FILE* file, LPVOID lpBuffer,
         TRACE_E("CSalamanderSafeFile::SafeFileWrite() HFile==NULL");
         return FALSE;
     }
-    // ziskame aktualni seek v souboru
+    // obtain the current seek position in the file
     long currentSeekHi = 0;
     DWORD currentSeekLo = SetFilePointer(file->HFile, 0, &currentSeekHi, FILE_CURRENT);
     if (currentSeekLo == 0xFFFFFFFF && GetLastError() != NO_ERROR)
-        goto WRITE_ERROR; // nelze nastavit offset, zkusime to znovu
+        goto WRITE_ERROR; // cannot set the offset, try again
 
     while (TRUE)
     {
@@ -1026,27 +1026,27 @@ BOOL CSalamanderSafeFile::SafeFileWrite(SAFE_FILE* file, LPVOID lpBuffer,
                 if (file->HFile != NULL)
                 {
                     if (file->WholeFileAllocated)
-                        SetEndOfFile(file->HFile);     // jinak by se zapisoval zbytek souboru
-                    HANDLES(CloseHandle(file->HFile)); // zavreme invalidni handle, protoze uz by z nej stejne neslo cist
+                        SetEndOfFile(file->HFile);     // otherwise the rest of the file would be written
+                    HANDLES(CloseHandle(file->HFile)); // close the invalid handle because we could not read from it anyway
                 }
 
                 file->HFile = HANDLES_Q(CreateFile(file->FileName, file->dwDesiredAccess, file->dwShareMode, NULL,
                                                    file->dwCreationDisposition, file->dwFlagsAndAttributes, NULL));
-                if (file->HFile != INVALID_HANDLE_VALUE) // otevreno, jeste nastavime offset
+                if (file->HFile != INVALID_HANDLE_VALUE) // opened; now set the offset
                 {
                     //SEEK:
                     LONG lo = currentSeekLo;
                     LONG hi = currentSeekHi;
                     lo = SetFilePointer(file->HFile, lo, &hi, FILE_BEGIN);
                     if (lo == 0xFFFFFFFF && GetLastError() != NO_ERROR)
-                        goto WRITE_ERROR; // nelze nastavit offset, zkusime to znovu
+                        goto WRITE_ERROR; // cannot set the offset, try again
                     if (lo != (long)currentSeekLo || hi != currentSeekHi)
                     {
                         SetLastError(ERROR_SEEK_ON_DEVICE);
-                        goto WRITE_ERROR; // nelze nastavit offset (soubor uz muze byt mensi), zkusime to znovu
+                        goto WRITE_ERROR; // cannot set the offset (the file may already be smaller), try again
                     }
                 }
-                else // nejde otevrit, problem trva ...
+                else // cannot open it, the problem persists...
                 {
                     file->HFile = NULL;
                     goto WRITE_ERROR;
@@ -1060,7 +1060,7 @@ BOOL CSalamanderSafeFile::SafeFileWrite(SAFE_FILE* file, LPVOID lpBuffer,
             default:
             {
                 if (pressedButton != NULL)
-                    *pressedButton = dlgRet; // vratim tlacitko, na ktere user kliknul
+                    *pressedButton = dlgRet; // return the button the user clicked
                 return FALSE;
             }
             }


### PR DESCRIPTION
## Summary
- clarify forceful termination handling and recursion guard notes in the registry worker implementation
- improve registry worker header documentation wording for each helper method
- polish safe file helper comments to read naturally in English while keeping intent intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e95354215883229f6db039046fe18a