### PR TITLE
Refine password manager comment translations

### DIFF
--- a/src/pwdmngr.cpp
+++ b/src/pwdmngr.cpp
@@ -27,7 +27,7 @@ CSalamanderCryptAbstract* GetSalamanderCrypt();
 
    The following macros assume that the mode value is correct.
 */
-#define PASSWORD_MANAGER_AES_MODE 3 // NEMENIT, napriklad CMasterPasswordVerifier je deklarovana "natvrdo"
+#define PASSWORD_MANAGER_AES_MODE 3 // DO NOT CHANGE; for example, CMasterPasswordVerifier is declared "hardcoded"
 
 //****************************************************************************
 //
@@ -36,7 +36,7 @@ CSalamanderCryptAbstract* GetSalamanderCrypt();
 
 void FillBufferWithRandomData(BYTE* buf, int len)
 {
-    static unsigned calls = 0; //ensure different random header each time
+    static unsigned calls = 0; // ensure a different random header each time
 
     if (++calls == 1)
         srand((unsigned)time(NULL) ^ (unsigned)_getpid());
@@ -49,8 +49,8 @@ void FillBufferWithRandomData(BYTE* buf, int len)
 //
 // ScramblePassword / UnscramblePassword
 //
-// Prevzato z FTP pluginu. Slouzi pro pripad, ze uzivatel nenastavi master
-// password a nepouziva se tedy silne AES sifrovani.
+// Taken from the FTP plugin. Used in case the user does not set the master
+// password and strong AES encryption is therefore not used.
 //
 
 unsigned char ScrambleTable[256] =
@@ -76,11 +76,11 @@ BOOL InitUnscrambleTable = TRUE;
 BOOL InitSRand = TRUE;
 unsigned char UnscrambleTable[256];
 
-#define SCRAMBLE_LENGTH_EXTENSION 50 // pocet znaku o ktere musime rozsirit buffer, aby se vesel scramble
+#define SCRAMBLE_LENGTH_EXTENSION 50 // number of characters by which we must extend the buffer to fit the scramble
 
 void ScramblePassword(char* password)
 {
-    // padding + jednotky delky + desitky delky + stovky delky + password
+    // padding + length ones digit + length tens digit + length hundreds digit + password
     int len = (int)strlen(password);
     char* buf = (char*)malloc(len + SCRAMBLE_LENGTH_EXTENSION);
     if (InitSRand)
@@ -110,7 +110,7 @@ void ScramblePassword(char* password)
         s++;
     }
     strcpy(password, buf);
-    memset(buf, 0, len + SCRAMBLE_LENGTH_EXTENSION); // cisteni pameti obsahujici password
+    memset(buf, 0, len + SCRAMBLE_LENGTH_EXTENSION); // wipe the memory that contained the password
     free(buf);
 }
 
@@ -126,7 +126,7 @@ BOOL UnscramblePassword(char* password)
         InitUnscrambleTable = FALSE;
     }
 
-    char* backup = DupStr(password); // zaloha pro TRACE_E
+    char* backup = DupStr(password); // backup for TRACE_E
 
     char* s = password;
     int last = 31;
@@ -142,7 +142,7 @@ BOOL UnscramblePassword(char* password)
 
     s = password;
     while (*s != 0 && (*s < '0' || *s > '9'))
-        s++; // najdeme si delku passwordu
+        s++; // find the length of the password
     BOOL ok = FALSE;
     if (strlen(s) >= 3)
     {
@@ -157,10 +157,10 @@ BOOL UnscramblePassword(char* password)
     }
     if (!ok)
     {
-        password[0] = 0; // nejaka chyba, zrusime password
+        password[0] = 0; // encountered an error; clear the password
         TRACE_E("Unable to unscramble password! scrambled=" << backup);
     }
-    memset(backup, 0, lstrlen(backup)); // cisteni pameti obsahujici password
+    memset(backup, 0, lstrlen(backup)); // wipe the memory that contained the password
     free(backup);
     return ok;
 }
@@ -181,7 +181,7 @@ void CChangeMasterPassword::Validate(CTransferInfo& ti)
     CALL_STACK_MESSAGE1("CChangeMasterPassword::Validate()");
     HWND hWnd;
 
-    // pokud je zapnuto pouzivani master password, musime overit, ze ho uzivatel zadal spravne
+    // if master password usage is enabled, we must verify that the user entered it correctly
     if (PwdManager->IsUsingMasterPassword() && ti.GetControl(hWnd, IDC_CHMP_CURRENTPWD))
     {
         char curPwd[SAL_AES_MAX_PWD_LENGTH + 1];
@@ -215,14 +215,14 @@ void CChangeMasterPassword::Transfer(CTransferInfo& ti)
 {
     if (ti.Type == ttDataToWindow)
     {
-        // limitujeme delku hesla, viz omezeni AES knihovny
+        // limit the password length; see the AES library limitations
         SendDlgItemMessage(HWindow, IDC_CHMP_CURRENTPWD, EM_LIMITTEXT, SAL_AES_MAX_PWD_LENGTH, 0);
         SendDlgItemMessage(HWindow, IDC_CHMP_NEWPWD, EM_LIMITTEXT, SAL_AES_MAX_PWD_LENGTH, 0);
         SendDlgItemMessage(HWindow, IDC_CHMP_RETYPEPWD, EM_LIMITTEXT, SAL_AES_MAX_PWD_LENGTH, 0);
 
         if (!PwdManager->IsUsingMasterPassword())
         {
-            // sestrelim z current pwd ES_PASSWORD styl, abychom mohli zobrazit text (not set)
+            // remove the ES_PASSWORD style from the current field so we can display the "not set" text
             HWND hEdit = GetDlgItem(HWindow, IDC_CHMP_CURRENTPWD);
             SendMessage(hEdit, EM_SETPASSWORDCHAR, 0, 0);
             SetWindowText(hEdit, LoadStr(IDS_MASTERPASSWORD_NOTSET));
@@ -237,7 +237,7 @@ void CChangeMasterPassword::Transfer(CTransferInfo& ti)
         {
             char oldPwd[SAL_AES_MAX_PWD_LENGTH + 1];
             GetDlgItemText(HWindow, IDC_CHMP_CURRENTPWD, oldPwd, SAL_AES_MAX_PWD_LENGTH);
-            PwdManager->EnterMasterPassword(oldPwd); // prosla validace, tak uz toto projde take
+            PwdManager->EnterMasterPassword(oldPwd); // validation passed, so this will succeed as well
         }
 
         char newPwd[SAL_AES_MAX_PWD_LENGTH + 1];
@@ -248,13 +248,13 @@ void CChangeMasterPassword::Transfer(CTransferInfo& ti)
 
 void CChangeMasterPassword::EnableControls()
 {
-    // nove (a kontrolni) heslo museji byt shodne, jinak zakazeme OK tlacitko
+    // disable the OK button unless the new password matches its confirmation
     char newPwd[SAL_AES_MAX_PWD_LENGTH + 1];
     char retypedPwd[SAL_AES_MAX_PWD_LENGTH + 1];
     GetDlgItemText(HWindow, IDC_CHMP_NEWPWD, newPwd, SAL_AES_MAX_PWD_LENGTH);
     GetDlgItemText(HWindow, IDC_CHMP_RETYPEPWD, retypedPwd, SAL_AES_MAX_PWD_LENGTH);
     BOOL enableOK = (stricmp(newPwd, retypedPwd) == 0);
-    if (enableOK && !PwdManager->IsUsingMasterPassword() && newPwd[0] == 0) // OK nesmime dovolit, pokud neni zadan MP a zaroven jsou obe hesla prazdna
+    if (enableOK && !PwdManager->IsUsingMasterPassword() && newPwd[0] == 0) // block OK when master password usage is disabled and both fields are empty
         enableOK = FALSE;
     EnableWindow(GetDlgItem(HWindow, IDOK), enableOK);
 }
@@ -269,7 +269,7 @@ CChangeMasterPassword::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (HIWORD(wParam) == EN_CHANGE && (LOWORD(wParam) == IDC_CHMP_NEWPWD || LOWORD(wParam) == IDC_CHMP_RETYPEPWD))
         {
-            // nove (a kontrolni) heslo museji byt shodne, jinak zakazeme OK tlacitko
+            // disable the OK button unless the new password matches its confirmation
             EnableControls();
         }
         break;
@@ -314,7 +314,7 @@ void CEnterMasterPassword::Transfer(CTransferInfo& ti)
     {
         char plainMasterPassword[SAL_AES_MAX_PWD_LENGTH + 1];
         GetDlgItemText(HWindow, IDC_MPR_PASSWORD, plainMasterPassword, SAL_AES_MAX_PWD_LENGTH);
-        PwdManager->EnterMasterPassword(plainMasterPassword); // prosla validace, tak uz toto projde take
+        PwdManager->EnterMasterPassword(plainMasterPassword); // validation passed, so this will succeed as well
     }
 }
 
@@ -361,8 +361,8 @@ void CRemoveMasterPassword::Transfer(CTransferInfo& ti)
     {
         char plainMasterPassword[SAL_AES_MAX_PWD_LENGTH + 1];
         GetDlgItemText(HWindow, IDC_RMP_CURRENTPWD, plainMasterPassword, SAL_AES_MAX_PWD_LENGTH);
-        // heslo musime predat password manageru, bude potreba pro event zasilany pluginum
-        PwdManager->EnterMasterPassword(plainMasterPassword); // prosla validace, tak uz toto projde take
+        // pass the password to the password manager; plugins need it for the pending event
+        PwdManager->EnterMasterPassword(plainMasterPassword); // validation passed, so this will succeed as well
     }
 }
 
@@ -401,7 +401,7 @@ CCfgPageSecurity::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
     {
-        // obejdu Transfer(), jde o specialni ovladani checkboxu
+        // bypass Transfer(); the checkbox needs special handling
         CheckDlgButton(HWindow, IDC_SEC_ENABLE_MASTERPWD, PasswordManager.IsUsingMasterPassword() ? BST_CHECKED : BST_UNCHECKED);
 
         EnableControls();
@@ -412,14 +412,14 @@ CCfgPageSecurity::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (HIWORD(wParam) == BN_CLICKED && LOWORD(wParam) == IDC_SEC_ENABLE_MASTERPWD)
         {
-            // kliknuti na checkbox
+            // checkbox was clicked
             EnableControls();
 
-            // pokud uzivatel zaskrtnul volbu "Pouzivat Master Password", zobrazime dialog pro zmenu hesla
+            // if the user checked the "Use Master Password" option, display the change password dialog
             BOOL useMasterPwd = IsDlgButtonChecked(HWindow, IDC_SEC_ENABLE_MASTERPWD);
             if (useMasterPwd)
             {
-                // uzivatel volbu zapnul
+                // the user enabled the option
                 CChangeMasterPassword dlg(HWindow, &PasswordManager);
                 if (dlg.Execute() == IDOK)
                 {
@@ -427,13 +427,13 @@ CCfgPageSecurity::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
                 else
                 {
-                    // pokud uzivatel zadal Cancel, vypneme prave zapinanou volbu
+                    // if the user cancels, revert the attempted enable
                     CheckDlgButton(HWindow, IDC_SEC_ENABLE_MASTERPWD, BST_UNCHECKED);
                 }
             }
             else
             {
-                // uzivatel volbu vypnul
+                // the user disabled the option
                 CRemoveMasterPassword dlg(HWindow, &PasswordManager);
                 if (dlg.Execute() == IDOK)
                 {
@@ -442,24 +442,24 @@ CCfgPageSecurity::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
                 else
                 {
-                    // pokud uzivatel zadal Cancel, vypneme zapneme vypinanou volbu
+                    // if the user cancels, restore the option that was being disabled
                     CheckDlgButton(HWindow, IDC_SEC_ENABLE_MASTERPWD, BST_CHECKED);
                 }
             }
-            EnableControls(); // CheckDlgButton() nerozesle notifikace, musime se zavolat sami
+            EnableControls(); // CheckDlgButton() sends no notifications, so call EnableControls() manually
         }
 
         if (HIWORD(wParam) == BN_CLICKED && LOWORD(wParam) == IDC_SEC_CHANGE_MASTERPWD)
         {
             CChangeMasterPassword dlg(HWindow, &PasswordManager);
-            // pokud uzivatel resetnul heslo, vypneme checkbox
+            // if the password was cleared, uncheck the checkbox
             if (dlg.Execute() == IDOK)
             {
                 if (!PasswordManager.IsUsingMasterPassword())
                 {
                     CheckDlgButton(HWindow, IDC_SEC_ENABLE_MASTERPWD, BST_UNCHECKED);
-                    SetFocus(GetDlgItem(HWindow, IDC_SEC_ENABLE_MASTERPWD)); // focus musi mimo tlacitko, ktere za chvili zakazeme
-                    EnableControls();                                        // CheckDlgButton() nerozesle notifikace, musime se zavolat sami
+                    SetFocus(GetDlgItem(HWindow, IDC_SEC_ENABLE_MASTERPWD)); // move focus away from the button before disabling it
+                    EnableControls();                                        // CheckDlgButton() sends no notifications, so call EnableControls() manually
                 }
                 PasswordManager.NotifyAboutMasterPasswordChange(HWindow);
             }
@@ -476,9 +476,9 @@ CCfgPageSecurity::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 // CPasswordManager
 //
 
-// signatura binarne drzenych hesel
-#define PWDMNGR_SIGNATURE_SCRAMBLED 1 // heslo je pouze scrambled, pro ziskani plain text hesla neni potreba master password
-#define PWDMNGR_SIGNATURE_ENCRYPTED 2 // heslo je scrabled a navic AES sifrovane, vyzaduje master password
+// signature values for passwords stored in binary form
+#define PWDMNGR_SIGNATURE_SCRAMBLED 1 // the password is only scrambled; the master password is not needed to obtain the plain-text password
+#define PWDMNGR_SIGNATURE_ENCRYPTED 2 // the password is scrambled and then AES encrypted; it requires the master password
 
 CPasswordManager::CPasswordManager()
 {
@@ -542,34 +542,34 @@ BOOL CPasswordManager::EncryptPassword(const char* plainPassword, BYTE** encrypt
         return FALSE;
     }
 
-    // heslo vzdy protahneme scramblem, cimz odstinime mozny maly pocet znaku
-    char* scrambledPassword = (char*)malloc(lstrlen(plainPassword) + SCRAMBLE_LENGTH_EXTENSION); // rezerva pro scrambleni (password se tim prodluzuje)
+    // always scramble the password to hide otherwise short inputs
+    char* scrambledPassword = (char*)malloc(lstrlen(plainPassword) + SCRAMBLE_LENGTH_EXTENSION); // reserve room for scrambling (the password becomes longer)
     lstrcpy(scrambledPassword, plainPassword);
     ScramblePassword(scrambledPassword);
     int scrambledPasswordLen = (int)strlen(scrambledPassword);
 
     if (encrypt)
     {
-        *encryptedPassword = (BYTE*)malloc(1 + 16 + scrambledPasswordLen + 10);       // signatura + AES-SALT + pocet scrambled znaku + AES-MAC
-        **encryptedPassword = PWDMNGR_SIGNATURE_ENCRYPTED;                            // prvni znak nese signaturu
-        FillBufferWithRandomData(*encryptedPassword + 1, 16);                         // SALT
-        memcpy(*encryptedPassword + 1 + 16, scrambledPassword, scrambledPasswordLen); // pak nasleduje scrambled heslo bez terminatoru
+        *encryptedPassword = (BYTE*)malloc(1 + 16 + scrambledPasswordLen + 10);       // signature + AES salt + scrambled length + AES MAC
+        **encryptedPassword = PWDMNGR_SIGNATURE_ENCRYPTED;                            // store the signature in the first byte
+        FillBufferWithRandomData(*encryptedPassword + 1, 16);                         // fill the salt
+        memcpy(*encryptedPassword + 1 + 16, scrambledPassword, scrambledPasswordLen); // copy the scrambled password without the terminator
 
         CSalAES aes;
-        WORD dummy; // zbytecna slabina, ignorujeme
-        int ret = SalamanderCrypt->AESInit(&aes, PASSWORD_MANAGER_AES_MODE, PlainMasterPassword, strlen(PlainMasterPassword), *encryptedPassword + 1, &dummy);
+        WORD dummy; // unnecessary weakness; ignore it
+        int ret = SalamanderCrypt->AESInit(&aes, PASSWORD_MANAGER_AES_MODE, PlainMasterPassword, strlen(PlainMasterPassword), *encryptedPassword + 1, &dummy); // the salt follows the signature in 16 bytes
         if (ret != SAL_AES_ERR_GOOD_RETURN)
-            TRACE_E("CPasswordManager::EncryptPassword(): unexpected state, ret=" << ret);       // nemelo by nastat
-        SalamanderCrypt->AESEncrypt(&aes, *encryptedPassword + 1 + 16, scrambledPasswordLen);    // scrambled heslo nechame prejet AESem
-        SalamanderCrypt->AESEnd(&aes, *encryptedPassword + 1 + 16 + scrambledPasswordLen, NULL); // ukladame vcetne MACu pro jednotliva hesla, kdyby se nam rozjela konfigurace
-        *encryptedPasswordSize = 1 + 16 + scrambledPasswordLen + 10;                             // zapiseme celkovou delku
+            TRACE_E("CPasswordManager::EncryptPassword(): unexpected state, ret=" << ret);       // should not happen
+        SalamanderCrypt->AESEncrypt(&aes, *encryptedPassword + 1 + 16, scrambledPasswordLen);    // encrypt the scrambled password with AES
+        SalamanderCrypt->AESEnd(&aes, *encryptedPassword + 1 + 16 + scrambledPasswordLen, NULL); // append the MAC so a corrupt configuration can be detected
+        *encryptedPasswordSize = 1 + 16 + scrambledPasswordLen + 10;                             // record the total length
     }
     else
     {
-        *encryptedPassword = (BYTE*)malloc(1 + scrambledPasswordLen);            // signatura + pocet scrambled znaku bez terminatoru
-        **encryptedPassword = PWDMNGR_SIGNATURE_SCRAMBLED;                       // prvni znak nese signaturu
-        memcpy(*encryptedPassword + 1, scrambledPassword, scrambledPasswordLen); // nasleduje scrambled heslo bez NULL terminatoru
-        *encryptedPasswordSize = 1 + scrambledPasswordLen;                       // zapiseme celkovou delku
+        *encryptedPassword = (BYTE*)malloc(1 + scrambledPasswordLen);            // signature + scrambled characters without the terminator
+        **encryptedPassword = PWDMNGR_SIGNATURE_SCRAMBLED;                       // store the signature in the first byte
+        memcpy(*encryptedPassword + 1, scrambledPassword, scrambledPasswordLen); // copy the scrambled password without the NULL terminator
+        *encryptedPasswordSize = 1 + scrambledPasswordLen;                       // record the total length
     }
     free(scrambledPassword);
 
@@ -595,14 +595,14 @@ BOOL CPasswordManager::DecryptPassword(const BYTE* encryptedPassword, int encryp
         TRACE_E("CPasswordManager::DecryptPassword(): encryptedPassword == NULL || encryptedPasswordSize == 0!");
         return FALSE;
     }
-    // pokud je heslo sifrovane pomoci AES a my nezname master password, selzeme
+    // if the password is encrypted with AES and we do not know the master password, we fail
     BOOL encrypted = IsPasswordEncrypted(encryptedPassword, encryptedPasswordSize);
     if (encrypted && (!UseMasterPassword || PlainMasterPassword == NULL) && OldPlainMasterPassword == NULL)
     {
         TRACE_I("CPasswordManager::DecryptPassword(): Master Password was not entered. Call AskForMasterPassword() first.");
         return FALSE;
     }
-    if (encrypted && (encryptedPasswordSize < 1 + 16 + 1 + 10)) // na vlastni heslo musi byt alespon jeden znak (signatura + SALT + heslo + MAC)
+    if (encrypted && (encryptedPasswordSize < 1 + 16 + 1 + 10)) // the password itself must contain at least one character (signature + SALT + password + MAC)
     {
         TRACE_E("CPasswordManager::DecryptPassword(): stored password is too small, probably corrupted!");
         return FALSE;
@@ -617,29 +617,29 @@ BOOL CPasswordManager::DecryptPassword(const BYTE* encryptedPassword, int encryp
 
 TRY_DECRYPT_AGAIN:
 
-    BYTE* tmpBuff = (BYTE*)malloc(encryptedPasswordSize + 1); // +1 pro terminator, abychom mohli po AES zavolat unscramble
+    BYTE* tmpBuff = (BYTE*)malloc(encryptedPasswordSize + 1); // +1 for the terminator so unscrambling works after AES
     memcpy(tmpBuff, encryptedPassword, encryptedPasswordSize);
-    tmpBuff[encryptedPasswordSize] = 0; // terminator pro unscramble
+    tmpBuff[encryptedPasswordSize] = 0; // terminator required by UnscramblePassword
 
-    int pwdOffset = 1; // signatura
+    int pwdOffset = 1; // skip the signature byte
     if (encrypted)
     {
-        // napred data rozsifrujeme pomoci AES
+        // decrypt the data with AES first
         CSalAES aes;
-        WORD dummy;                                                                                                                                 // zbytecna slabina, ignorujeme
-        int ret = SalamanderCrypt->AESInit(&aes, PASSWORD_MANAGER_AES_MODE, plainMasterPassword, strlen(plainMasterPassword), tmpBuff + 1, &dummy); // salt lezi za signaturou na 16 bajtech
+        WORD dummy;                                                                                                                                 // unnecessary weakness; ignore it
+        int ret = SalamanderCrypt->AESInit(&aes, PASSWORD_MANAGER_AES_MODE, plainMasterPassword, strlen(plainMasterPassword), tmpBuff + 1, &dummy); // the salt follows the signature in 16 bytes
         if (ret != SAL_AES_ERR_GOOD_RETURN)
-            TRACE_E("CPasswordManager::DecryptPassword(): unexpected state, ret=" << ret);        // nemelo by nastat
-        SalamanderCrypt->AESDecrypt(&aes, tmpBuff + 1 + 16, encryptedPasswordSize - 1 - 16 - 10); // rozsifrujeme heslo
-        BYTE mac[10];                                                                             // pro overeni spravnosti master password nam poslouzi MAC
+            TRACE_E("CPasswordManager::DecryptPassword(): unexpected state, ret=" << ret);        // should not happen
+        SalamanderCrypt->AESDecrypt(&aes, tmpBuff + 1 + 16, encryptedPasswordSize - 1 - 16 - 10); // decrypt the scrambled password
+        BYTE mac[10];                                                                             // the MAC verifies that the master password is correct
         SalamanderCrypt->AESEnd(&aes, mac, NULL);
         if (memcmp(mac, &tmpBuff[encryptedPasswordSize - 10], 10) != 0)
         {
-            memset(tmpBuff, 0, encryptedPasswordSize); // nulujeme buffer s plain heslem
+            memset(tmpBuff, 0, encryptedPasswordSize); // clear the buffer that held the plain password
             free(tmpBuff);
 
             if (plainMasterPassword == OldPlainMasterPassword && UseMasterPassword && PlainMasterPassword != NULL)
-            { // resi situaci, kdy mame heslo zasifrovane novym master passwordem (heslo nelze desifrovat puvodnim master passwordem, ale novym ano, tedy hlaska, ze heslo nejde desifrovat je matouci, protoze kdyz uzivatel zkusi heslo desifrovat novym master passwordem, povede se to a tedy uzivatel nema sanci najit to nedesifrovatelne heslo)
+            { // handle the case where the password is encrypted with the new master password (the original master password fails, but the new one succeeds, so without retrying the user would not know which password could not be decrypted)
                 plainMasterPassword = PlainMasterPassword;
                 goto TRY_DECRYPT_AGAIN;
             }
@@ -647,13 +647,13 @@ TRY_DECRYPT_AGAIN:
             TRACE_I("CPasswordManager::DecryptPassword(): wrong master password, password cannot be decrypted!");
             return FALSE;
         }
-        pwdOffset += 16;                         // preskocime AES-SALT
-        tmpBuff[encryptedPasswordSize - 10] = 0; // terminator pro unscramble (na miste prvniho znak MAC)
+        pwdOffset += 16;                         // skip the AES salt
+        tmpBuff[encryptedPasswordSize - 10] = 0; // terminator for unscramble (placed over the first MAC byte)
     }
-    // vnitrne jsou data scrambled, preskocime signaturu a pripadne AES-SALT
+    // data are stored scrambled; skip the signature and optional AES salt
     if (!UnscramblePassword((char*)tmpBuff + pwdOffset))
     {
-        memset(tmpBuff, 0, encryptedPasswordSize); // nulujeme buffer s plain heslem
+        memset(tmpBuff, 0, encryptedPasswordSize); // clear the buffer that held the plain password
         free(tmpBuff);
         return FALSE;
     }
@@ -663,7 +663,7 @@ TRY_DECRYPT_AGAIN:
         *plainPassword = DupStr((char*)tmpBuff + pwdOffset);
     }
 
-    memset(tmpBuff, 0, encryptedPasswordSize); // nulujeme buffer s plain heslem
+    memset(tmpBuff, 0, encryptedPasswordSize); // clear the buffer that held the plain password
     free(tmpBuff);
 
     return TRUE;
@@ -686,8 +686,8 @@ void CPasswordManager::SetMasterPassword(HWND hParent, const char* password)
 
     if (PlainMasterPassword != NULL)
     {
-        // pokud je nastaven master password, po dobu behu teto metody ho prehodime do OldPlainMasterPassword,
-        // aby mely pluginy moznost rozsifrovat jim zasifrovana hesla
+        // if a master password is set, during this method we move it to OldPlainMasterPassword,
+        // so that plugins can decrypt the passwords encrypted for them
         OldPlainMasterPassword = PlainMasterPassword;
         PlainMasterPassword = NULL;
     }
@@ -700,20 +700,20 @@ void CPasswordManager::SetMasterPassword(HWND hParent, const char* password)
 
     if (password == NULL || *password == 0)
     {
-        // zruseni master password
+        // master password removed
         UseMasterPassword = FALSE;
         Plugins.PasswordManagerEvent(hParent, PME_MASTERPASSWORDREMOVED);
     }
     else
     {
-        // nastaveni/zmena master password
+        // master password set or changed
         UseMasterPassword = TRUE;
         PlainMasterPassword = DupStr(password);
         CreateMasterPasswordVerifier(PlainMasterPassword);
         Plugins.PasswordManagerEvent(hParent, OldPlainMasterPassword == NULL ? PME_MASTERPASSWORDCREATED : PME_MASTERPASSWORDCHANGED);
     }
 
-    // vlakno se nam vratilo z volani Plugins.PasswordManagerEvent(), muzeme zahodit OldPlainMasterPassword
+    // after Plugins.PasswordManagerEvent() returns, discard OldPlainMasterPassword
     if (OldPlainMasterPassword != NULL)
     {
         free(OldPlainMasterPassword);
@@ -730,7 +730,7 @@ BOOL CPasswordManager::EnterMasterPassword(const char* password)
     }
     if (PlainMasterPassword != NULL)
     {
-        // pokud se nam snazi znovu vlozit aktualni heslo, tise to ignorujeme
+        // ignore attempts to re-enter the current password
         if (strcmp(PlainMasterPassword, password) == 0)
             return TRUE;
 
@@ -750,23 +750,23 @@ BOOL CPasswordManager::EnterMasterPassword(const char* password)
 
 void CPasswordManager::CreateMasterPasswordVerifier(const char* password)
 {
-    // naalokujeme strukturu pro verifier
+    // allocate the verifier structure
     CMasterPasswordVerifier* mpv;
     mpv = new CMasterPasswordVerifier;
 
-    // Salt a Dummy hodnoty budou nahodne
+    // fill Salt and Dummy with random data
     FillBufferWithRandomData(mpv->Salt, 16);
     FillBufferWithRandomData(mpv->Dummy, 16);
 
     CSalAES aes;
-    WORD dummy; // zbytecna slabina, ignorujeme
+    WORD dummy; // unnecessary weakness; ignore it
     int ret = SalamanderCrypt->AESInit(&aes, PASSWORD_MANAGER_AES_MODE, password, strlen(password), mpv->Salt, &dummy);
     if (ret != SAL_AES_ERR_GOOD_RETURN)
-        TRACE_E("CPasswordManager::CreateMasterPasswordVerifier(): unexpected state, ret=" << ret); // nemelo by nastat
-    SalamanderCrypt->AESEncrypt(&aes, mpv->Dummy, 16);                                              // Dummy nechame zasifrovat
-    SalamanderCrypt->AESEnd(&aes, mpv->MAC, NULL);                                                  // MAC si ulozime pro vlastni verifikaci
+        TRACE_E("CPasswordManager::CreateMasterPasswordVerifier(): unexpected state, ret=" << ret); // should not happen
+    SalamanderCrypt->AESEncrypt(&aes, mpv->Dummy, 16);                                              // encrypt Dummy
+    SalamanderCrypt->AESEnd(&aes, mpv->MAC, NULL);                                                  // store the MAC for later verification
 
-    // ulozime alokovanou strukturu
+    // store the allocated verifier
     if (MasterPasswordVerifier != NULL)
         delete MasterPasswordVerifier;
     MasterPasswordVerifier = mpv;
@@ -780,7 +780,7 @@ BOOL CPasswordManager::VerifyMasterPassword(const char* password)
         return FALSE;
     }
 
-    // pokud drzime master password v otevrenem stavu, muzeme provest jednoduche porovnani
+    // if the plaintext master password is cached, a direct comparison suffices
     if (PlainMasterPassword != NULL)
     {
         return (strcmp(PlainMasterPassword, password) == 0);
@@ -796,12 +796,12 @@ BOOL CPasswordManager::VerifyMasterPassword(const char* password)
     memcpy(&mpv, MasterPasswordVerifier, sizeof(CMasterPasswordVerifier));
 
     CSalAES aes;
-    WORD dummy; // zbytecna slabina, ignorujeme
+    WORD dummy; // unnecessary weakness; ignore it
     int ret = SalamanderCrypt->AESInit(&aes, PASSWORD_MANAGER_AES_MODE, password, strlen(password), mpv.Salt, &dummy);
     if (ret != SAL_AES_ERR_GOOD_RETURN)
-        TRACE_E("CPasswordManager::VerifyMasterPassword(): unexpected state, ret=" << ret); // nemelo by nastat
-    SalamanderCrypt->AESDecrypt(&aes, mpv.Dummy, 16);                                       // Dummy nechame rozsifrovat
-    SalamanderCrypt->AESEnd(&aes, mpv.MAC, NULL);                                           // MAC budeme kontrolovat
+        TRACE_E("CPasswordManager::VerifyMasterPassword(): unexpected state, ret=" << ret); // should not happen
+    SalamanderCrypt->AESDecrypt(&aes, mpv.Dummy, 16);                                       // let it decrypt Dummy
+    SalamanderCrypt->AESEnd(&aes, mpv.MAC, NULL);                                           // we will check the MAC
     return (memcmp(mpv.MAC, MasterPasswordVerifier->MAC, sizeof(mpv.MAC)) == 0);
 }
 
@@ -816,7 +816,7 @@ BOOL CPasswordManager::Save(HKEY hKey)
 {
     BOOL ret = TRUE;
 
-    // konfigurace password managera
+    // password manager configuration data
     if (ret)
         ret &= SetValue(hKey, SALAMANDER_PWDMNGR_USEMASTERPWD, REG_DWORD, &UseMasterPassword, sizeof(UseMasterPassword));
     if (UseMasterPassword)
@@ -835,7 +835,7 @@ BOOL CPasswordManager::Save(HKEY hKey)
 BOOL CPasswordManager::Load(HKEY hKey)
 {
     BOOL ret = TRUE;
-    // konfigurace password managera
+    // password manager configuration data
     if (ret)
         ret &= GetValue(hKey, SALAMANDER_PWDMNGR_USEMASTERPWD, REG_DWORD, &UseMasterPassword, sizeof(UseMasterPassword));
     if (UseMasterPassword)
@@ -850,13 +850,13 @@ BOOL CPasswordManager::Load(HKEY hKey)
 
 BOOL CPasswordManager::AskForMasterPassword(HWND hParent)
 {
-    // pokud se master password nepouziva, vratime FALSE
+    // return FALSE when master password usage is disabled
     if (!UseMasterPassword)
         return FALSE;
 
-    // na master password doptame (i v pripade, ze ho jiz zname -- volajici si to mohl overit predem pomoci IsMasterPasswordSet())
+    // prompt for the master password (even if cached; the caller may have checked using IsMasterPasswordSet())
     CEnterMasterPassword dlg(hParent, this);
-    return dlg.Execute() == IDOK; // pokud ho uzivatel spravne zadal, vratime TRUE, jinak FALSE
+    return dlg.Execute() == IDOK; // return TRUE when entered correctly, otherwise FALSE
 }
 
 //****************************************************************************

--- a/src/pwdmngr.h
+++ b/src/pwdmngr.h
@@ -71,91 +71,92 @@ protected:
 //
 // CPasswordManager
 //
-// Uloziste hesel. Pokud uzivatel zapne volbu "Use a master password",
-// jsou hesla v konfiguraci ulozena sifrovana pomoci AES. Jinak jsou
-// pouze scramblena metodou, kterou Petr zavedl puvodne v FTP clientu.
+// Password storage. When the user enables the "Use Master Password" option,
+// configuration passwords are encrypted with AES; otherwise they are only
+// scrambled using Petr's original FTP client method.
 //
-// Metody Password Manageru lze volat pouze z hlavniho threadu Salamandera.
-// Planovana mista pristupu jsou: FTP connect, WinSCP connect, konfigurace
-// Salamandera, Save/Load konfigurace Salamandera. Vse momentalne bezi v
-// hlavnim threadu, takze nemusime resit konkurenci a zamykani manageru.
+// Password manager methods may be called only from Salamander's main thread.
+// Planned call sites include FTP and WinSCP connection dialogs and the
+// configuration save/load workflows. Because all of them currently run on the
+// main thread, no explicit locking is required.
 
 #pragma pack(push)
 #pragma pack(1)
 struct CMasterPasswordVerifier
 {
-    BYTE Salt[16];  // nahodny salt, mode==3
-    BYTE Dummy[16]; // nahodna sifrovana data
-    BYTE MAC[10];   // kontrolni zaznam, pomoci ktereho overime spravnost master password
+    BYTE Salt[16];  // random salt, mode == 3
+    BYTE Dummy[16]; // random encrypted data
+    BYTE MAC[10];   // verifier used to check the master password
 };
 #pragma pack(pop)
 
 class CPasswordManager
 {
 private:
-    BOOL UseMasterPassword;                          // uzivatel (nekdy) zadal master password, ktery byl pouzit pro zasifrovani dat, samotny 'MasterPassword' vsak muze byt ted NULL a bude nutne se na nej doptat
-    char* PlainMasterPassword;                       // alokovane heslo (v otevrenem stavu) zakoncene nulou; NULL pokud ho uzivatel v ramci teto session nezadal; neuklada se do registry
-    char* OldPlainMasterPassword;                    // docasne drzi stare 'PlainMasterPassword' behem volani Plugins.PasswordManagerEvent(), aby plugin mohl pozadat o rozsifrovani hesel
-    CMasterPasswordVerifier* MasterPasswordVerifier; // slouzi pro overeni spravnosti master password; uklada se do registry; muze byt NULL
+    BOOL UseMasterPassword;                          // TRUE once the user has provided the master password; the plaintext value may later be NULL and must then be requested
+    char* PlainMasterPassword;                       // plaintext master password allocated with a trailing zero; NULL until entered during this session; not stored in the registry
+    char* OldPlainMasterPassword;                    // temporarily holds the previous PlainMasterPassword while Plugins.PasswordManagerEvent() runs so plugins can decrypt their data
+    CMasterPasswordVerifier* MasterPasswordVerifier; // verifier stored in the registry for subsequent master password checks; may be NULL
 
-    CSalamanderCryptAbstract* SalamanderCrypt; // interface pro praci s Crypt knihovnou
+    CSalamanderCryptAbstract* SalamanderCrypt; // interface to the cryptographic library
 
 public:
     CPasswordManager();
     ~CPasswordManager();
 
-    BOOL IsPasswordSecure(const char* password); // posoudi, zda je heslo dostatecne silne, vraci TRUE pokud ano, jinak FALSE
+    BOOL IsPasswordSecure(const char* password); // returns TRUE when the password meets strength requirements, otherwise FALSE
 
-    // nastavi master password, pokud je 'password' NULL nebo prazdnej retezec, vypne master password
+    // sets the master password; if 'password' is NULL or empty, master password protection is turned off
     void SetMasterPassword(HWND hParent, const char* password);
 
-    // slouzi pro vlozeni master password, ktery momentalne neni znamy v plain verzi
+    // supplies the master password when it is not currently known in plaintext
     BOOL EnterMasterPassword(const char* password);
 
     BOOL ChangeMasterPassword(HWND hParent);
-    BOOL IsUsingMasterPassword() { return UseMasterPassword; }         // jsou hesla chranena pomoci AES/Master Password?
-    BOOL IsMasterPasswordSet() { return PlainMasterPassword != NULL; } // zadal uzivatel v teto session Master Password?
+    BOOL IsUsingMasterPassword() { return UseMasterPassword; }         // TRUE when master password protection is active
+    BOOL IsMasterPasswordSet() { return PlainMasterPassword != NULL; } // TRUE if the user entered the master password in this session
 
-    // pokud je zapnute pouzivani master password a ten jeste nebyl v teto session zadan, zobrazi okno pro jeho zadani
-    // vraci FALSE pokud se v takovem pripade nepodari korektni master password zadat; ve vsech ostatnich pripadaech vraci TRUE
-    // metodu je nutne zavolat vzdy pred volanim metod EncryptPassword/DecryptPassword, pokud je encrypt/encrypted == TRUE
-    // pro zjednoduseni ji lze volat i v pripade, ze neni zapnute pouzivani master password (tise vrati TRUE)
+    // when master password usage is enabled and the password has not been entered
+    // in this session, displays a dialog for entering it
+    // returns FALSE if the correct master password cannot be entered in that situation; returns TRUE otherwise
+    // call this before EncryptPassword/DecryptPassword when encrypt/encrypted == TRUE
+    // callers may invoke it even when master password usage is turned off (quietly returns TRUE)
     BOOL AskForMasterPassword(HWND hParent);
 
     void NotifyAboutMasterPasswordChange(HWND hParent);
 
-    BOOL Save(HKEY hKey); // ulozi drzena hesla do Registry
-    BOOL Load(HKEY hKey); // nacte hesla z Registry
+    BOOL Save(HKEY hKey); // save password-manager data to the registry
+    BOOL Load(HKEY hKey); // load password-manager data from the registry
 
-    // 'encryptedPasswordSize' udava velikost bufferu, do ktereho bude ulozeno zasifrovane heslo; velikost musi byt o 50 znaku vetsi nez je delka 'plainPassword'
+    // 'encryptedPasswordSize' specifies the buffer size for the encrypted password; it must be 50 characters longer than 'plainPassword'
 
-    // zasifruje plain text heslo do binarniho tvaru pomoci silne sifry (AES)
-    // pred AES sifrovanim provede jeste scramble, kterym se pridava padding (posileni pro kratka hesla)
-    // pokud volajici vyzaduje zasifrovani hesla pomoci AES ('encrypt'==TRUE), pred volanim metody musi zavolat AskForMasterPassword(), ktera musi vratit TRUE
-    // 'plainPassword' je ukazatel na heslo v textove podobe, zakonecene nulou
-    // 'encryptedPassword' vrati ukazatel na Salamanderem alokovany binarni buffer s zasifrovanym heslem; tento buffer je treba dealokovat pomoci CSalamanderGeneralAbstract::Free
-    // 'encryptedPasswordSize' vrati velikost bufferu 'encryptedPassword' v bajtech
-    // pokud je 'encrypt' TRUE, funkce ma heslo zasifrovat pomoci AES (bezpecne, chranene pomoci master password); pokud je FALSE, heslo bude pouze scramblene
+    // encrypts the plaintext password into binary form using AES
+    // before AES encryption it performs an additional scramble that adds padding (hardening short passwords)
+    // if the caller requires AES password encryption ('encrypt' == TRUE), AskForMasterPassword() must succeed beforehand
+    // 'plainPassword' points to the zero-terminated password in text form
+    // 'encryptedPassword' receives a pointer to a binary buffer allocated by Salamander with the encrypted password; release it with CSalamanderGeneralAbstract::Free
+    // 'encryptedPasswordSize' receives the size of the 'encryptedPassword' buffer in bytes
+    // if 'encrypt' is TRUE, the function encrypts the password with AES (protected by the master password); if FALSE, the password is only scrambled
     BOOL EncryptPassword(const char* plainPassword, BYTE** encryptedPassword, int* encryptedPasswordSize, BOOL encrypt);
-    // 'plainPassword' je treba dealokovat pomoci CSalamanderGeneralAbstract::Free
-    // pokud je 'plainPassword' NULL, pouze overi, zda lze heslo rozsifrovat
+    // 'plainPassword' must be deallocated with CSalamanderGeneralAbstract::Free
+    // if 'plainPassword' is NULL, only checks whether the password can be decrypted
     BOOL DecryptPassword(const BYTE* encryptedPassword, int encryptedPasswordSize, char** plainPassword);
-    // vraci TRUE, pokud jde o AES-sifrovane heslo, jinak vraci FALSE; rozhoduje se podle signatury na prvnim bajtu hesla
+    // returns TRUE for an AES-encrypted password, otherwise returns FALSE; the signature in the first byte determines it
     BOOL IsPasswordEncrypted(const BYTE* encyptedPassword, int encyptedPasswordSize);
 
-    // prida do pole Passwords nove heslo, vraci TRUE v pripade uspechu (zaroven naplni 'passwordID' hodnotou vetsi nez nula a mensi nez 0xffffffff), jinak FALSE
-    // 'pluginDLLName' musi byt NULL, pokud heslo patri jadru Salamandera, jinak je plneno CPluginData
-    // 'password' je heslo v otevrenem stavu
-    //BOOL StorePassword(const char *pluginDLLName, const char *password, DWORD *passwordID); // volani musi predchazet uspesne AskForMasterPassword()
-    //BOOL SetPassword(const char *pluginDLLName, DWORD passwordID, const char *password); // volani musi predchazet uspesne AskForMasterPassword()
-    //BOOL GetPassword(const char *pluginDLLName, DWORD passwordID, char *password, int bufferLen); // volani musi predchazet uspesne AskForMasterPassword()
+    // adds a new password to the Passwords array; returns TRUE if successful (also fills 'passwordID' with a value greater than zero and less than 0xffffffff), otherwise FALSE
+    // 'pluginDLLName' must be NULL if the password belongs to Salamander's core, otherwise it is filled by CPluginData
+    // 'password' is the password in plain form
+    //BOOL StorePassword(const char *pluginDLLName, const char *password, DWORD *passwordID); // the call must be preceded by a successful AskForMasterPassword()
+    //BOOL SetPassword(const char *pluginDLLName, DWORD passwordID, const char *password); // the call must be preceded by a successful AskForMasterPassword()
+    //BOOL GetPassword(const char *pluginDLLName, DWORD passwordID, char *password, int bufferLen); // the call must be preceded by a successful AskForMasterPassword()
     //BOOL DeletePassword(const char *pluginDLLName, DWORD passwordID);
 
-    // overi, zda 'password' odpovida heslu drzenemu v 'MasterPasswordVerifier'; vraci TRUE pokud odpovida, jinak FALSE
+    // verifies that 'password' matches the value stored in MasterPasswordVerifier; returns TRUE on success, otherwise FALSE
     BOOL VerifyMasterPassword(const char* password);
 
 protected:
-    // naalokuje a napocita 'MasterPasswordVerifier', ktery ukladame do registry pro naslednou verifikaci
+    // allocates and computes MasterPasswordVerifier, which is stored in the registry for subsequent verification
     void CreateMasterPasswordVerifier(const char* password);
 };
 


### PR DESCRIPTION
## Summary
- polish English wording in password manager implementation comments for clarity and accuracy
- update password manager header comments to read naturally in English and explain responsibilities precisely

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e952d3d6e88322b626873e7a4ea58a