### PR TITLE
Refine English translations in shellib.h

### DIFF
--- a/src/shellib.h
+++ b/src/shellib.h
@@ -3,108 +3,108 @@
 
 #pragma once
 
-// inicializace knihovny
+// library initialization
 BOOL InitializeShellib();
 
-// uvolneni knihovny
+// library release
 void ReleaseShellib();
 
-// bezpecne volani IContextMenu2::GetCommandString() ve kterem to MS obcas pada
+// Safe call to IContextMenu2::GetCommandString() that avoids the occasional crash in Microsoft code
 HRESULT AuxGetCommandString(IContextMenu2* menu, UINT_PTR idCmd, UINT uType, UINT* pReserved, LPSTR pszName, UINT cchMax);
 
-// callback, ktery vraci jmena oznacenych souboru pro vytvareni nasl. interfacu
+// Callback that returns the names of selected files so that subsequent interfaces can be created
 typedef const char* (*CEnumFileNamesFunction)(int index, void* param);
 
-// vytvori data object pro drag&drop operace nad oznacenymi soubory a adresari z rootDir
+// Creates a data object for drag & drop operations on the selected files and directories from rootDir
 IDataObject* CreateIDataObject(HWND hOwnerWindow, const char* rootDir, int files,
                                CEnumFileNamesFunction nextFile, void* param);
 
-// vytvori interface kontextoveho menu pro oznacene soubory a adresare z rootDir
+// Creates a context menu interface for the selected files and directories from rootDir
 IContextMenu2* CreateIContextMenu2(HWND hOwnerWindow, const char* rootDir, int files,
                                    CEnumFileNamesFunction nextFile, void* param);
 
-// vytvori interface kontextoveho menu pro dany adresar
+// Creates a context menu interface for the given directory
 IContextMenu2* CreateIContextMenu2(HWND hOwnerWindow, const char* dir);
 
-// ma dany adresar nebo soubor drop-target?
+// Does the given directory or file have a drop target?
 BOOL HasDropTarget(const char* dir);
 
-// vytvori drop-target pro drag&drop operace do daneho adresare nebo souboru
+// Creates a drop target for drag & drop operations into the given directory or file
 IDropTarget* CreateIDropTarget(HWND hOwnerWindow, const char* dir);
 
-// otevre okno specialniho foldru
+// Opens a special folder window
 void OpenSpecFolder(HWND hOwnerWindow, int specFolder);
 
-// otevre okno folderu 'dir' a postavi focus na 'item'
+// Opens the folder window 'dir' and sets the focus to 'item'
 void OpenFolderAndFocusItem(HWND hOwnerWindow, const char* dir, const char* item);
 
-// otevre browse dialog a vybere cestu (mozne omezit jen na sitovou cestu)
-// hCenterWindow - okno, ke kteremu bude dialog centrovan
+// Opens a browse dialog and lets the user choose a path (optionally restricted to network paths)
+// hCenterWindow - window to which the dialog will be centered
 BOOL GetTargetDirectory(HWND parent, HWND hCenterWindow, const char* title, const char* comment,
                         char* path, BOOL onlyNet = FALSE, const char* initDir = NULL);
 
-// rozpozna jestli se nejedna o cestu do NetHood (adresar se souborem target.lnk),
-// pripadne zjisti kam vede target.lnk a cestu vraci v 'path'; 'path' je in/out cesta
-// (min. MAX_PATH znaku)
+// Detects whether this is a path inside NetHood (a directory containing the target.lnk file),
+// optionally resolves target.lnk and writes the resolved path to 'path'; 'path' is an in/out buffer
+// (at least MAX_PATH characters)
 void ResolveNetHoodPath(char* path);
 
 class CMenuNew;
 
-// vraci New menu - handle popup-menu a IContextMenu pres ktere se prikazy spousti
+// Returns the New menu: the popup-menu handle and the IContextMenu used to execute commands
 void GetNewOrBackgroundMenu(HWND hOwnerWindow, const char* dir, CMenuNew* menu,
                             int minCmd, int maxCmd, BOOL backgoundMenu);
 
 struct CDragDropOperData
 {
-    char SrcPath[MAX_PATH];     // zdrojova cesta spolecna vsem souborum/adresarum z Names ("" == nepodarila se konverze cesty z Unicode)
-    TIndirectArray<char> Names; // razena alokovana jmena souboru/adresaru (v CF_HDROP se nerozlisuje jestli jde o soubor nebo adresar) ("" == nepodarila se konverze cesty z Unicode)
+    char SrcPath[MAX_PATH];     // Source path shared by all files/directories from Names ("" == path conversion from Unicode failed)
+    TIndirectArray<char> Names; // Sorted, allocated names of files/directories (CF_HDROP does not distinguish whether it is a file or a directory) ("" == path conversion from Unicode failed)
 
     CDragDropOperData() : Names(200, 200) { SrcPath[0] = 0; }
 };
 
-// zjisti jestli jsou v 'pDataObject' soubory a adresare z disku a zaroven jen z jedine cesty,
-// pripadne jejich jmena ulozi do 'namesList' (neni-li NULL)
+// Determines whether 'pDataObject' contains files and directories from disk and whether all of them share a single path.
+// Optionally stores the names in 'namesList' (if it is not NULL).
 BOOL IsSimpleSelection(IDataObject* pDataObject, CDragDropOperData* namesList);
 
-// vytahne pres GetDisplayNameOf(flags) jmeno pro 'pidl' (ID-list o jedno ID zkrati, ziska od
-// desktopu folder pro zkraceny ID-list a od tohoto folderu si vola GetDisplayNameOf pro posledni
-// ID se zadanymi 'flags'); pri uspechu vraci TRUE + jmeno v 'name' (buffer o velikosti 'nameSize');
-// 'pidl' nedealokuje; 'alloc' je iface ziskany pres CoGetMalloc
+// Retrieves the name for 'pidl' via GetDisplayNameOf(flags) (shortens the ID list by one element, obtains
+// the folder for the shortened ID list from the desktop, and calls GetDisplayNameOf with the given 'flags'
+// for the last ID from that folder); on success it returns TRUE and stores the name in 'name' (buffer of size 'nameSize');
+// does not deallocate 'pidl'; 'alloc' is an interface obtained through CoGetMalloc
 BOOL GetSHObjectName(ITEMIDLIST* pidl, DWORD flags, char* name, int nameSize, IMalloc* alloc);
 
-// TRUE = effect drag&dropu se napocital v pluginovem FS, tedy neni potreba forcovat Copy
-// v CImpIDropSource::GiveFeedback
+// TRUE = the drag & drop effect was calculated in the plugin FS, so it is not necessary to force Copy
+// in CImpIDropSource::GiveFeedback
 extern BOOL DragFromPluginFSEffectIsFromPlugin;
 
 //*****************************************************************************
 //
 // CImpIDropSource
 //
-// Zakladni verze objektu, chova se standardne (default kurzory atd.).
+// Basic version of the object; behaves normally (default cursors, etc.).
 //
-// Vyjimka: pri tazeni z pluginoveho FS (s moznymi efekty Copy i Move) do Explorera
-// na disk s TEMP adresarem se defaultne nabizi Move misto Copy (coz je logicky
-// nesmysl, useri cekaji Copy), proto je tento pripad znasilneny tak, ze ukazujeme
-// jiny kurzor nez je dwEffect v GiveFeedback a vysledny efekt pak bereme podle
-// posledniho tvaru kurzoru misto podle vysledku DoDragDrop.
+// Exception: when dragging from the plugin FS (with possible Copy and Move effects) into Explorer
+// to a disk with a TEMP directory, Move is offered by default instead of Copy (which is illogical,
+// users expect Copy), so this case is forced by showing
+// a different cursor than dwEffect in GiveFeedback, and the final effect is then taken from the
+// last cursor shape instead of from the result of DoDragDrop.
 
 class CImpIDropSource : public IDropSource
 {
 private:
     long RefCount;
-    DWORD MouseButton; // -1 = neinicializovana hodnota, jinak MK_LBUTTON nebo MK_RBUTTON
+    DWORD MouseButton; // -1 = uninitialized value, otherwise MK_LBUTTON or MK_RBUTTON
 
 public:
-    // posledni efekt vraceny metodou GiveFeedback - zavadime, protoze
-    // DoDragDrop nevraci dwEffect == DROPEFFECT_MOVE, pri MOVE vraci dwEffect == 0,
-    // duvody viz "Handling Shell Data Transfer Scenarios" sekce "Handling Optimized Move Operations":
+    // Last effect returned by GiveFeedback - introduced because
+    // DoDragDrop does not return dwEffect == DROPEFFECT_MOVE; for MOVE it returns dwEffect == 0.
+    // For the reasons, see "Handling Shell Data Transfer Scenarios", section "Handling Optimized Move Operations":
     // http://msdn.microsoft.com/en-us/library/windows/desktop/bb776904%28v=vs.85%29.aspx
-    // (zkracene: dela se optimalizovany Move, coz znamena ze se nedela kopie do cile nasledovana mazanim
-    //            originalu, aby zdroj nechtene nesmazal original (jeste nemusi byt presunuty), dostane
-    //            vysledek operace DROPEFFECT_NONE nebo DROPEFFECT_COPY)
+    // (in short: an optimized Move is done, which means that it does not create a copy at the destination followed by deleting
+    //            the original, so that the source does not accidentally delete the original (it may not have been moved yet), and it receives
+    //            the operation result DROPEFFECT_NONE or DROPEFFECT_COPY)
     DWORD LastEffect;
 
-    BOOL DragFromPluginFSWithCopyAndMove; // tazeni z pluginoveho FS s moznym Copy i Move, detaily viz vyse
+    BOOL DragFromPluginFSWithCopyAndMove; // dragging from the plugin FS with possible Copy and Move, details above
 
 public:
     CImpIDropSource(BOOL dragFromPluginFSWithCopyAndMove)
@@ -131,7 +131,7 @@ public:
         if (--RefCount == 0)
         {
             delete this;
-            return 0; // nesmime sahnout do objektu, uz neexistuje
+            return 0; // we must not touch the object, it no longer exists
         }
         return RefCount;
     }
@@ -144,7 +144,7 @@ public:
             BOOL shiftPressed = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
             BOOL controlPressed = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
             if ((!shiftPressed || controlPressed) && (dwEffect & DROPEFFECT_MOVE))
-            { // ma se delat Copy, ale nabizi se Move -> tuhle situaci znasilnime, ukazeme Copy kurzor a do LastEffect dame Copy
+            { // Copy should be performed, but Move is offered -> force this situation, show the Copy cursor, and store Copy in LastEffect
                 LastEffect = DROPEFFECT_COPY;
                 SetCursor(LoadCursor(HInstance, MAKEINTRESOURCE(IDC_DRAGCOPYEFFECT)));
                 return S_OK;
@@ -173,11 +173,11 @@ public:
 //
 // CImpDropTarget
 //
-// vola definovane callbacky pro ziskani drop targetu (adresare),
-// oznameni dropnuti nebo ESC,
-// zbytek operaci necha provest systemovy objekt IDropTarget z IShellFolder
+// Calls the defined callbacks to obtain the drop target (directory),
+// notifies about the drop or ESC,
+// leaves the remaining operations to the system IDropTarget object from IShellFolder
 
-// zaznam pouzity v datech pro copy a move callback
+// Record stored in the data passed to the copy and move callback
 struct CCopyMoveRecord
 {
     char* FileName;
@@ -192,11 +192,11 @@ struct CCopyMoveRecord
     char* AllocChars(const wchar_t* name);
 };
 
-// data pro copy a move callback
+// Container of data passed to the copy and move callback
 class CCopyMoveData : public TIndirectArray<CCopyMoveRecord>
 {
 public:
-    BOOL MakeCopyOfName; // TRUE pokud se ma snazit o "Copy of..." pokud cil jiz existuje
+    BOOL MakeCopyOfName; // TRUE if it should attempt "Copy of..." when the target already exists
 
 public:
     CCopyMoveData(int base, int delta) : TIndirectArray<CCopyMoveRecord>(base, delta)
@@ -205,47 +205,47 @@ public:
     }
 };
 
-// callback pro copy a move operace, stara se o destrukci 'data'
+// Callback for copy and move operations. Takes care of destroying 'data'.
 typedef BOOL (*CDoCopyMove)(BOOL copy, char* targetDir, CCopyMoveData* data,
                             void* param);
 
-// callback pro drag&drop operace, 'copy' je TRUE/FALSE (copy/move), 'toArchive' je TRUE/FALSE
-// (to archive/FS), 'archiveOrFSName' (muze byt NULL, pokud se informace ma ziskat z panelu)
-// je jmeno souboru archivu nebo FS-name, 'archivePathOrUserPart' je cesta v archivu nebo
-// user-part FS cesty, 'data' obsahuji popis zdrojovych souboru/adresaru, funkce se stara
-// o destrukci objektu 'data', 'param' je parametr predany do konstruktoru CImpDropTarget
+// Callback for drag & drop operations. 'copy' is TRUE/FALSE (copy/move), 'toArchive' is TRUE/FALSE
+// (to archive/FS), 'archiveOrFSName' (can be NULL if the information should be obtained from the panel)
+// is the name of the archive file or the FS name, 'archivePathOrUserPart' is the path in the archive or
+// the user part of the FS path, 'data' contains a description of the source files/directories, the function
+// destroys the 'data' object, and 'param' is the parameter passed to the CImpDropTarget constructor
 typedef void (*CDoDragDropOper)(BOOL copy, BOOL toArchive, const char* archiveOrFSName,
                                 const char* archivePathOrUserPart, CDragDropOperData* data,
                                 void* param);
 
-// callback, ktery vraci cilovy adresar pro dany bod 'pt'
+// Callback that returns the target directory for the point 'pt'
 typedef const char* (*CGetCurDir)(POINTL& pt, void* param, DWORD* pdwEffect, BOOL rButton,
                                   BOOL& isTgtFile, DWORD keyState, int& tgtType, int srcType);
 
-// callback oznamujici konec drop operace, drop == FALSE pri ESC
+// Callback notifying about the end of the drop operation; drop == FALSE on ESC
 typedef void (*CDropEnd)(BOOL drop, BOOL shortcuts, void* param, BOOL ownRutine,
                          BOOL isFakeDataObject, int tgtType);
 
-// callback pro dotaz pred dokoncenim operace (drop)
+// Callback for a confirmation prompt before completing the operation (drop)
 typedef BOOL (*CConfirmDrop)(DWORD& effect, DWORD& defEffect, DWORD& grfKeyState);
 
-// callback oznamujici vstup a vystup mysi do targetu
+// Callback invoked when the mouse enters or leaves the target
 typedef void (*CEnterLeaveDrop)(BOOL enter, void* param);
 
-// callback, ktery povoluje pouziti nasich rutin pro copy/move
+// Callback that allows the use of our own routines for copy/move
 typedef BOOL (*CUseOwnRutine)(IDataObject* pDataObject);
 
-// callback pro zjisteni default drop effectu pri tazeni z FS na FS
+// Callback that determines the default drop effect when dragging from one FS path to another
 typedef void (*CGetFSToFSDropEffect)(const char* srcFSPath, const char* tgtFSPath,
                                      DWORD allowedEffects, DWORD keyState,
                                      DWORD* dropEffect, void* param);
 
 enum CIDTTgtType
 {
-    idtttWindows,          // soubory/adresare z windowsove cesty na windowsovou cestu
-    idtttArchive,          // soubory/adresare z windowsove cesty do archivu
-    idtttPluginFS,         // soubory/adresare z windowsove cesty do FS
-    idtttArchiveOnWinPath, // archiv na windowsove ceste (drop=pack to archive)
+    idtttWindows,          // files/directories from a Windows path to a Windows path
+    idtttArchive,          // files/directories from a Windows path into an archive
+    idtttPluginFS,         // files/directories from a Windows path into FS
+    idtttArchiveOnWinPath, // archive on a Windows path (drop = pack to archive)
     idtttFullPluginFSPath, // FS to FS
 };
 
@@ -256,9 +256,9 @@ private:
     HWND OwnerWindow;
     IDataObject* OldDataObject;
     BOOL OldDataObjectIsFake;
-    int OldDataObjectIsSimple;                 // -1 (neznama hodnota), TRUE/FALSE = je/neni jednoduchy (vsechna jmena na jedne ceste)
-    int OldDataObjectSrcType;                  // 0 (neznamy typ), 1/2 = archiv/FS
-    char OldDataObjectSrcFSPath[2 * MAX_PATH]; // jen pro typ FS: zdrojova FS cesta
+    int OldDataObjectIsSimple;                 // -1 (unknown value), TRUE/FALSE = is/is not simple (all names share one path)
+    int OldDataObjectSrcType;                  // 0 (unknown type), 1/2 = archive/FS
+    char OldDataObjectSrcFSPath[2 * MAX_PATH]; // only for FS type: source FS path
 
     CDoCopyMove DoCopyMove;
     void* DoCopyMoveParam;
@@ -275,18 +275,18 @@ private:
     CConfirmDrop ConfirmDrop;
     BOOL* ConfirmDropEnable;
 
-    int TgtType; // hodnoty viz CIDTTgtType; idtttWindows i pro archivy a FS bez moznosti dropnuti aktualniho dataobjectu
+    int TgtType; // see CIDTTgtType; idtttWindows also for archives and FS without the option to drop the current data object
     IDropTarget* CurDirDropTarget;
     char CurDir[2 * MAX_PATH];
 
     CEnterLeaveDrop EnterLeaveDrop;
     void* EnterLeaveDropParam;
 
-    BOOL RButton; // akce pravym tlacitkem mysi?
+    BOOL RButton; // action invoked with the right mouse button
 
     CUseOwnRutine UseOwnRutine;
 
-    DWORD LastEffect; // posledni effect zjisteny v DragEnter nebo DragOver (-1 => neplatny)
+    DWORD LastEffect; // last effect detected in DragEnter or DragOver (-1 => invalid)
 
     CGetFSToFSDropEffect GetFSToFSDropEffect;
     void* GetFSToFSDropEffectParam;
@@ -315,8 +315,8 @@ public:
         DropEndParam = dropEndParam;
         OldDataObject = NULL;
         OldDataObjectIsFake = FALSE;
-        OldDataObjectIsSimple = -1; // neznama hodnota
-        OldDataObjectSrcType = 0;   // neznamy typ
+        OldDataObjectIsSimple = -1; // unknown value
+        OldDataObjectSrcType = 0;   // unknown type
         OldDataObjectSrcFSPath[0] = 0;
         ConfirmDrop = confirmDrop;
         ConfirmDropEnable = confirmDropEnable;
@@ -353,7 +353,7 @@ public:
         if (--RefCount == 0)
         {
             delete this;
-            return 0; // nesmime sahnout do objektu, uz neexistuje
+            return 0; // we must not touch the object, it no longer exists
         }
         return RefCount;
     }
@@ -377,8 +377,8 @@ struct IContextMenu2;
 class CMenuNew
 {
 protected:
-    IContextMenu2* Menu2; // menu-interface 2
-    HMENU Menu;           // submenu New
+    IContextMenu2* Menu2; // IContextMenu2 interface associated with the menu
+    HMENU Menu;           // New submenu handle
 
 public:
     CMenuNew() { Init(); }
@@ -441,7 +441,7 @@ public:
         if (--RefCount == 0)
         {
             delete this;
-            return 0; // nesmime sahnout do objektu, uz neexistuje
+            return 0; // we must not touch the object, it no longer exists
         }
         return RefCount;
     }
@@ -506,5 +506,5 @@ public:
     }
 };
 
-// uvolni CopyMoveData
+// Releases a CCopyMoveData instance
 void DestroyCopyMoveData(CCopyMoveData* data);


### PR DESCRIPTION
## Summary
- polish introductory shell helper comments covering command string safety, data object creation, and NetHood handling
- clarify drag-and-drop data descriptions and callback semantics throughout the shell integration helpers
- refine drop target bookkeeping notes and menu wrapper comments for consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e96e65d92883229f76321b802159c4