### PR TITLE
Refine Salmon comment translations

### DIFF
--- a/src/salmoncl.cpp
+++ b/src/salmoncl.cpp
@@ -11,12 +11,12 @@ HANDLE HSalmonProcess = NULL;
 
 //****************************************************************************
 
-// POZOR: bezime z entry point, pred inicializaci RTL, globalnich objektu, atd
-// nevolat TRACE, HANDLES, RTL, ...
+// WARNING: we execute from the entry point before the RTL, global objects, etc. are initialized.
+// Do not call TRACE, HANDLES, RTL, ...
 
 HANDLE GetBugReporterRegistryMutex()
 {
-    // prava uplne otevrena pro vsechny procesy
+    // grant full permissions to every process
     SECURITY_ATTRIBUTES secAttr;
     char secDesc[SECURITY_DESCRIPTOR_MIN_LENGTH];
     secAttr.nLength = sizeof(secAttr);
@@ -24,11 +24,11 @@ HANDLE GetBugReporterRegistryMutex()
     secAttr.lpSecurityDescriptor = &secDesc;
     InitializeSecurityDescriptor(secAttr.lpSecurityDescriptor, SECURITY_DESCRIPTOR_REVISION);
     SetSecurityDescriptorDacl(secAttr.lpSecurityDescriptor, TRUE, 0, FALSE);
-    // do nazvu mutexu by bylo sikovne pridat SID, protoze procesy s ruznym SID bezi s jinym HKCU stromem
-    // ale pro jednoduchost na to kaslem a mutex bude opravdu globalni
+    // it would be useful to add the SID to the mutex name because processes with a different SID use a different HKCU tree
+    // but for simplicity we ignore that and keep the mutex truly global
     const char* MUTEX_NAME = "Global\\AltapSalamanderBugReporterRegistryMutex";
     HANDLE hMutex = NOHANDLES(CreateMutex(&secAttr, FALSE, MUTEX_NAME));
-    if (hMutex == NULL) // uz create umi otevrite existujici mutex, ale muze selhat, proto pak zkusime jeste open
+    if (hMutex == NULL) // CreateMutex can open an existing mutex, but it may fail, so try OpenMutex afterwards
         hMutex = NOHANDLES(OpenMutex(SYNCHRONIZE, FALSE, MUTEX_NAME));
     return hMutex;
 }
@@ -38,8 +38,8 @@ BOOL SalmonGetBugReportUID(DWORD64* uid)
     const char* BUG_REPORTER_KEY = "Software\\Open Salamander\\Bug Reporter";
     const char* BUG_REPORTER_UID = "ID";
 
-    // tato sekce se pousti pri startu Salamandera a teoreticky muze dojit k soucasnemu ctani/zapisu registry
-    // proto budeme pristup hlidat globalnim mutexem
+    // this section runs during Salamander start-up and simultaneous registry access could theoretically occur
+    // so we guard it with a global mutex
     HANDLE hMutex = GetBugReporterRegistryMutex();
     if (hMutex != NULL)
         WaitForSingleObject(hMutex, INFINITE);
@@ -48,7 +48,7 @@ BOOL SalmonGetBugReportUID(DWORD64* uid)
     LONG res = NOHANDLES(RegOpenKeyEx(HKEY_CURRENT_USER, BUG_REPORTER_KEY, 0, KEY_READ, &hKey));
     if (res == ERROR_SUCCESS)
     {
-        // pokusime se nacist stary udaj, pokud existuje
+        // try to load the previous record if it exists
         DWORD gettedType;
         DWORD bufferSize = sizeof(*uid);
         res = RegQueryValueEx(hKey, BUG_REPORTER_UID, 0, &gettedType, (BYTE*)uid, &bufferSize);
@@ -56,17 +56,17 @@ BOOL SalmonGetBugReportUID(DWORD64* uid)
             *uid = 0;
         NOHANDLES(RegCloseKey(hKey));
     }
-    // pokud UID zatim neexistuje, vytvorime ho a ulozime
+    // if the UID does not exist yet, create and store it
     if (*uid == 0)
     {
         GUID guid;
         if (CoCreateGuid(&guid) == S_OK)
         {
-            // nebudeme ukladat a odesilat cely GUID, staci jeho polovina, xornuta s druhou
+            // we do not need to store or send the entire GUID; XORing one half with the other is sufficient
             DWORD64* dw64 = (DWORD64*)&guid;
             *uid = dw64[0] ^ dw64[1];
 
-            // pokusime se ho ulozit
+            // try to store it
             DWORD createType;
             LONG res2 = NOHANDLES(RegCreateKeyEx(HKEY_CURRENT_USER, BUG_REPORTER_KEY, 0, NULL, REG_OPTION_NON_VOLATILE,
                                                  KEY_READ | KEY_WRITE, NULL, &hKey, &createType));
@@ -74,7 +74,7 @@ BOOL SalmonGetBugReportUID(DWORD64* uid)
             {
                 res2 = RegSetValueEx(hKey, BUG_REPORTER_UID, 0, REG_QWORD, (BYTE*)uid, sizeof(*uid));
                 if (res2 != ERROR_SUCCESS)
-                    *uid = 0; // pri selhani chceme nulu
+                    *uid = 0; // fall back to zero on failure
                 NOHANDLES(RegCloseKey(hKey));
             }
         }
@@ -90,7 +90,7 @@ BOOL SalmonGetBugReportUID(DWORD64* uid)
 
 BOOL SalmonSharedMemInit(CSalmonSharedMemory* mem)
 {
-    SECURITY_ATTRIBUTES sa; // povolime dedeni handlu do child procesu (mohou pak pracovat primo s nasim eventem)
+    SECURITY_ATTRIBUTES sa; // allow child processes to inherit handles so they can work directly with our events
     sa.nLength = sizeof(sa);
     sa.lpSecurityDescriptor = NULL;
     sa.bInheritHandle = TRUE;
@@ -98,25 +98,25 @@ BOOL SalmonSharedMemInit(CSalmonSharedMemory* mem)
     RtlFillMemory(mem, sizeof(CSalmonSharedMemory), 0);
 
     mem->Version = SALMON_SHARED_MEMORY_VERSION;
-    // salmon bude spusten jako child proces s bInheritHandles==TRUE, takze muze pristupovat primo k temto handlum
+    // Salmon runs as a child process with bInheritHandles == TRUE so it can access these handles directly
     mem->ProcessId = GetCurrentProcessId();
     mem->Process = NOHANDLES(OpenProcess(SYNCHRONIZE | PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, TRUE, mem->ProcessId));
-    mem->Fire = NOHANDLES(CreateEvent(&sa, TRUE, FALSE, NULL));      // "nonsignaled" state, manual
-    mem->Done = NOHANDLES(CreateEvent(&sa, TRUE, FALSE, NULL));      // "nonsignaled" state, manual
-    mem->SetSLG = NOHANDLES(CreateEvent(&sa, TRUE, FALSE, NULL));    // "nonsignaled" state, manual
-    mem->CheckBugs = NOHANDLES(CreateEvent(&sa, TRUE, FALSE, NULL)); // "nonsignaled" state, manual
+    mem->Fire = NOHANDLES(CreateEvent(&sa, TRUE, FALSE, NULL));      // manual reset, initially non-signaled
+    mem->Done = NOHANDLES(CreateEvent(&sa, TRUE, FALSE, NULL));      // manual reset, initially non-signaled
+    mem->SetSLG = NOHANDLES(CreateEvent(&sa, TRUE, FALSE, NULL));    // manual reset, initially non-signaled
+    mem->CheckBugs = NOHANDLES(CreateEvent(&sa, TRUE, FALSE, NULL)); // manual reset, initially non-signaled
 
-    // cestu pro bug reporty nove davame do LOCAL_APPDATA, kam standardne minidumpy uklada Windows WER
-    // cestu hned nevytvarime, o to se postarame az v okamziku padu
+    // store the bug report path in LOCAL_APPDATA, where Windows WER normally writes minidumps
+    // do not create the path immediately; create the directory only once a crash occurs
     if (SHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, mem->BugPath) == S_OK)
     {
         int len = lstrlen(mem->BugPath);
-        if (len > 0 && mem->BugPath[len - 1] == '\\') // radeji overime zpetne lomitko na konci cesty
+        if (len > 0 && mem->BugPath[len - 1] == '\\') // as a precaution trim any trailing backslash at the end of the path
             mem->BugPath[len - 1] = 0;
         lstrcat(mem->BugPath, "\\Open Salamander");
     }
 
-    // zaklad jmena pro bug reporty
+    // base name for bug report files
     strcpy(mem->BugName, "AS" VERSINFO_SAL_SHORT_VERSION);
 
     return (mem->Process != NULL && mem->Fire != NULL && mem->Done != NULL && mem->SetSLG != NULL &&
@@ -125,9 +125,9 @@ BOOL SalmonSharedMemInit(CSalmonSharedMemory* mem)
 
 void GetStartupSLGName(char* slgName, DWORD slgNameMax)
 {
-    // vytahneme z registry nazev SLG, ktere se pravdepodobne bude pouzivat
-    // dale za behu Salamandera muze dojit k volbe jineho, ktere se dodatecne zmeni
-    // toto slouzi pouze jako default; pokud zaznam nenalezneme, predame prazdny retezec
+    // read from the registry the SLG that is most likely to be used
+    // Salamander may later switch to a different one while it is running
+    // this only provides the default; if no record is found, return an empty string
     slgName[0] = 0;
 
     char keyName[MAX_PATH];
@@ -162,9 +162,9 @@ BOOL SalmonStartProcess(const char* fileMappingName) //Configuration.LoadedSLGNa
     GetModuleFileName(NULL, cmd, MAX_PATH);
     *(strrchr(cmd, '\\') + 1) = 0;
     lstrcat(cmd, "utils\\salmon.exe");
-    AddDoubleQuotesIfNeeded(cmd, MAX_PATH); // CreateProcess chce mit jmeno s mezerama v uvozovkach (jinak zkousi ruzny varianty, viz help)
+    AddDoubleQuotesIfNeeded(cmd, MAX_PATH); // CreateProcess requires names with spaces to be quoted; otherwise it tries different variants (see help)
     GetStartupSLGName(slgName, sizeof(slgName));
-    wsprintf(cmd + strlen(cmd), " \"%s\" \"%s\"", fileMappingName, slgName); // slgName muze byt prazdny retezec, pokud neexistuje konfigurace
+    wsprintf(cmd + strlen(cmd), " \"%s\" \"%s\"", fileMappingName, slgName); // slgName can be empty if the configuration does not exist
     memset(&si, 0, sizeof(STARTUPINFO));
     si.cb = sizeof(STARTUPINFO);
     si.wShowWindow = SW_SHOWNORMAL;
@@ -172,8 +172,8 @@ BOOL SalmonStartProcess(const char* fileMappingName) //Configuration.LoadedSLGNa
     *(strrchr(rtlDir, '\\') + 1) = 0;
     GetCurrentDirectory(MAX_PATH, oldCurDir);
 
-    // dalsi pokus o reseni problemu nez rozdelime SALMON.EXE na EXE+DLL
-    // zkusime pro child process (SALMON.EXE) rozsirit PATH env promennou o cestu k RTL
+    // another attempt to solve the problem before we split SALMON.EXE into EXE + DLL
+    // append the RTL path to the child process PATH (SALMON.EXE)
     if (GetEnvironmentVariable("PATH", envPATH, MAX_ENV_PATH) != 0)
     {
         if (lstrlen(envPATH) + 2 + lstrlen(rtlDir) < MAX_ENV_PATH)
@@ -190,24 +190,24 @@ BOOL SalmonStartProcess(const char* fileMappingName) //Configuration.LoadedSLGNa
     else
         envPATH[0] = 0;
 
-    // puvodne jsme pouze predavali rtlDir do CreateProcess, ale v nekterych kombinacich s UAC salmon.exe nebylo mozne spustit,
-    // protoze nevidel RTL: https://forum.altap.cz/viewtopic.php?f=2&t=6957&p=26548#p26548
-    // zkusime jeste navic nastavit current directory
-    // pokud nezabere, muzeme zkusit do CreateProcess misto rtlDir predat NULL, pak by se podle MSDN mel podedit current directory od spoustejiciho procesu
+    // originally we only passed rtlDir to CreateProcess, but in some combinations with UAC salmon.exe could not be started
+    // because it could not see the RTL: https://forum.altap.cz/viewtopic.php?f=2&t=6957&p=26548#p26548
+    // we also set the current directory
+    // if that does not help, try passing NULL to CreateProcess instead of rtlDir; according to MSDN the current directory should then be inherited from the launching process
     SetCurrentDirectory(rtlDir);
-    // EDIT 4/2014: udelal jsem nekolik testu s Support@bluesware.ch a chr.mue@gmail.com viz maily
-    // Vidim dve mozna reseni: zkusime rozsirit pro child proces PATH env promennou k SALRTL.
-    // Druha moznost je rozdelit SALMON.EXE na EXE bez RTL a DLL s implicitne linkovanym RTL. Pred loadem SALMON.DLL
-    // by jiz z beziciho SALMON.EXE bylo mozne nastavit current dir a SALMON.DLL naloadit runtime, coz by snad proslo.
+    // EDIT 4/2014: I ran several tests with Support@bluesware.ch and chr.mue@gmail.com; see the emails
+    // I can see two possible solutions: extend the PATH environment variable for the child process so it includes SALRTL.
+    // The second option is to split SALMON.EXE into an EXE without RTL and a DLL with the implicitly linked RTL. Before loading SALMON.DLL
+    // the running SALMON.EXE could set the current directory and load SALMON.DLL at runtime, which should hopefully work.
     // ----
-    // Na mem pocitaci kazde ze tri pouzitych nastaveni cesty funguje samo o sobe (ENV PATH, SetCurrentDirectory a rtlDir parametr ve volani CreateProcess
-    if (NOHANDLES(CreateProcess(NULL, cmd, NULL, NULL, TRUE, //bInheritHandles==TRUE, potrebuje predat handly eventu!
+    // On my computer each of the three path-setting strategies works independently (ENV PATH, SetCurrentDirectory, and the rtlDir parameter in the CreateProcess call)
+    if (NOHANDLES(CreateProcess(NULL, cmd, NULL, NULL, TRUE, // bInheritHandles == TRUE, the event handles must be inherited!
                                 CREATE_DEFAULT_ERROR_MODE | HIGH_PRIORITY_CLASS, NULL,
                                 rtlDir, &si, &pi)))
     {
-        HSalmonProcess = pi.hProcess;                           // handle salmon procesu potrebujeme, abychom byli schopni detekovat, ze zije
-        AllowSetForegroundWindow(SalGetProcessId(pi.hProcess)); // pustime salmon nad nas
-        //NOHANDLES(CloseHandle(pi.hProcess)); // nechame je s klidem leaknout, stejne by slo o posledni uvolnovane handly pred koncem procesu
+        HSalmonProcess = pi.hProcess;                           // store the Salmon process handle so we can tell that it is still alive
+        AllowSetForegroundWindow(SalGetProcessId(pi.hProcess)); // allow Salmon to bring itself to the foreground above us
+        //NOHANDLES(CloseHandle(pi.hProcess)); // let them leak; they would be the last handles released before the process ends anyway
         //NOHANDLES(CloseHandle(pi.hThread));
         ret = TRUE;
     }
@@ -227,7 +227,7 @@ BOOL SalmonStartProcess(const char* fileMappingName) //Configuration.LoadedSLGNa
 //  return FALSE;
 //}
 
-// Chceme se dozvedet o SEH Exceptions i na x64 Windows 7 SP1 a dal
+// We want to be notified about SEH exceptions even on x64 Windows 7 SP1 and newer
 // http://blog.paulbetts.org/index.php/2010/07/20/the-case-of-the-disappearing-onload-exception-user-mode-callback-exceptions-in-x64/
 // http://connect.microsoft.com/VisualStudio/feedback/details/550944/hardware-exceptions-on-x64-machines-are-silently-caught-in-wndproc-messages
 // http://support.microsoft.com/kb/976038
@@ -264,12 +264,12 @@ BOOL SalmonInit()
 
     SalmonSharedMemory = NULL;
     char salmonFileMappingName[SALMON_FILEMAPPIN_NAME_SIZE];
-    // alokace sdileneho mista v pagefile.sys
+    // allocate shared space in pagefile.sys
     DWORD ti = (GetTickCount() >> 3) & 0xFFF;
-    while (TRUE) // hledame unikatni jmeno pro file-mapping
+    while (TRUE) // search for a unique name for the file mapping
     {
         wsprintf(salmonFileMappingName, "Salmon%X", ti++);
-        SalmonFileMapping = NOHANDLES(CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, // FIXME_X64 nepredavame x86/x64 nekompatibilni data?
+        SalmonFileMapping = NOHANDLES(CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, // FIXME_X64 are we passing incompatible x86/x64 data?
                                                         sizeof(CSalmonSharedMemory), salmonFileMappingName));
         if (SalmonFileMapping == NULL || GetLastError() != ERROR_ALREADY_EXISTS)
             break;
@@ -277,7 +277,7 @@ BOOL SalmonInit()
     }
     if (SalmonFileMapping != NULL)
     {
-        SalmonSharedMemory = (CSalmonSharedMemory*)NOHANDLES(MapViewOfFile(SalmonFileMapping, FILE_MAP_WRITE, 0, 0, 0)); // FIXME_X64 nepredavame x86/x64 nekompatibilni data?
+        SalmonSharedMemory = (CSalmonSharedMemory*)NOHANDLES(MapViewOfFile(SalmonFileMapping, FILE_MAP_WRITE, 0, 0, 0)); // FIXME_X64 are we passing incompatible x86/x64 data?
         if (SalmonSharedMemory != NULL)
         {
             ZeroMemory(SalmonSharedMemory, sizeof(CSalmonSharedMemory));
@@ -285,17 +285,17 @@ BOOL SalmonInit()
             {
                 SalmonGetBugReportUID(&SalmonSharedMemory->UID);
 
-                // pokud se nezdari salmon spustit, stale vratime TRUE - problem bude oznamen pozdeji jiz po nacteni SLG
+                // if Salmon cannot be started, still return TRUE—the problem will be reported later after the SLG is loaded
                 SalmonStartProcess(salmonFileMappingName);
                 return TRUE;
             }
         }
     }
-    // doslo k zavazne (a nepredpokladane) chybe, zablokujeme spusteni Salamander, hlaska bude anglicky (nemame slg)
+    // a critical (and unexpected) error occurred; block Salamander start-up and show the message in English (the SLG is not loaded)
     return FALSE;
 }
 
-// info ze nebezi salmon staci zobrazit jednou
+// the notification that Salmon is not running only needs to be shown once
 static BOOL SalmonNotRunningReported = FALSE;
 
 void SalmonSetSLG(const char* slgName)
@@ -305,12 +305,12 @@ void SalmonSetSLG(const char* slgName)
     strcpy(SalmonSharedMemory->SLGName, slgName);
     SetEvent(SalmonSharedMemory->SetSLG);
 
-    // cekame na signal ze Salmon, ze zpracoval ukol (event Done) nebo na pripad, kdy nekdo Salmon sestrelil
+    // wait for Salmon to signal that it has processed the task (event Done) or in case Salmon was terminated
     HANDLE arr[2];
     arr[0] = HSalmonProcess;
     arr[1] = SalmonSharedMemory->Done;
     DWORD waitRet = WaitForMultipleObjects(2, arr, FALSE, INFINITE);
-    if (waitRet != WAIT_OBJECT_0 + 1) // nekdo sestrelil salmon nebo se neco podelalo v komunikaci
+    if (waitRet != WAIT_OBJECT_0 + 1) // Salmon exited or something went wrong in the communication
     {
         if (!SalmonNotRunningReported && HLanguage != NULL)
         {
@@ -326,12 +326,12 @@ void SalmonCheckBugs()
     ResetEvent(SalmonSharedMemory->Done);
     SetEvent(SalmonSharedMemory->CheckBugs);
 
-    // cekame na signal ze Salmon, ze zpracoval ukol (event Done) nebo na pripad, kdy nekdo Salmon sestrelil
+    // wait for Salmon to signal that it has processed the task (event Done) or in case Salmon was terminated
     HANDLE arr[2];
     arr[0] = HSalmonProcess;
     arr[1] = SalmonSharedMemory->Done;
     DWORD waitRet = WaitForMultipleObjects(2, arr, FALSE, INFINITE);
-    if (waitRet != WAIT_OBJECT_0 + 1) // nekdo sestrelil salmon nebo se neco podelalo v komunikaci
+    if (waitRet != WAIT_OBJECT_0 + 1) // Salmon exited or something went wrong in the communication
     {
         if (!SalmonNotRunningReported && HLanguage != NULL)
         {
@@ -349,7 +349,7 @@ BOOL SalmonFireAndWait(const EXCEPTION_POINTERS* e, char* bugReportPath)
     SalmonSharedMemory->ContextRecord = *e->ContextRecord;
     SetEvent(SalmonSharedMemory->Fire);
 
-    // cekame na signal ze Salmon, ze zpracoval ukol (event Done) nebo na pripad, kdy nekdo Salmon sestrelil
+    // wait for Salmon to signal that it has processed the task (event Done) or in case Salmon was terminated
     HANDLE arr[2];
     arr[0] = HSalmonProcess;
     arr[1] = SalmonSharedMemory->Done;

--- a/src/salmoncl.h
+++ b/src/salmoncl.h
@@ -4,11 +4,11 @@
 #pragma once
 
 // SalmonClient
-// Modul SALMON.EXE slouzi k out-of-process generovani minidumpu, jeho zabaleni a upload na server
-// SALMON musi bezet od startu Salamandera, aby mohl na pady reagovat. Pady pred spusteni SALMON
-// probehnou tise a SALMON je zpracuje "priste"
+// The SALMON.EXE module runs out-of-process to generate minidumps, package them, and upload them to the server.
+// SALMON must run from Salamander start-up onward to react to crashes. Crashes that happen before SALMON starts
+// are silent and SALMON processes them "next time".
 //
-// tento header je sdileny mezi projekty SALMON a SALAMAND kvuli pameti, pres kterou komunikuji
+// This header is shared between the SALMON and SALAMAND projects because they communicate through shared memory.
 //
 // out of process minidumps
 // http://www.nynaeve.net/?p=128
@@ -24,7 +24,7 @@
 
 #define SALMON_FILEMAPPIN_NAME_SIZE 20
 
-// x64 a x86 verze Salamander/Salmon nejsou kompatibilni
+// the x64 and x86 versions of Salamander/Salmon are not compatible
 #ifdef _WIN64
 #define SALMON_SHARED_MEMORY_VERSION_PLATFORM 0x10000000
 #else
@@ -36,21 +36,21 @@
 #pragma pack(4)
 struct CSalmonSharedMemory
 {
-    DWORD Version;           // SALMON_SHARED_MEMORY_VERSION (pokud nesouhlasi pro SALAM/SALMON, je rvat a nekomunikovat...)
-    HANDLE Process;          // Handle parent procesu (abychom mohli cekat na jeho terminovani); tutu proto hodnotu nechame leakovat
-    DWORD ProcessId;         // ID padleho parent procesu
-    DWORD ThreadId;          // ID padleho threadu
-    HANDLE Fire;             // AS signalizuje SALMONu, ze ma odeslat reporty
-    HANDLE Done;             // SALMON vraci do AS, ze je hotovo
-    HANDLE SetSLG;           // AS signalizuje SALMONu, ze ma nacist SLG podle bufferu SLGName, ktery pred nasetovani eventu nastavi
-    HANDLE CheckBugs;        // AS signalizuje SALMONu, ze ma zkontrolvat adresar s bug reporty a pokud nejake najde (z nejakeho predesleho padu), nabidnout jejich upload
-    char SLGName[MAX_PATH];  // ma vyznam ve chvili, kdy AS nasetuje SetSLG a rika, ktere SLG se ma nacist
-    char BugPath[MAX_PATH];  // nastavuje Salamander, udava cestu kam budou padat bug reporty (cesta nemusi existovat, vytvari se az pri padu);
-    char BugName[MAX_PATH];  // nastavuje Salamander, udava vnitrni nazev souboru minidumpu/bug reportu
-    char BaseName[MAX_PATH]; // nastavuje salmon, jde o sestavu "UID-BugName-DATUM-CAS"; pro minidump ze za to pripoji ".DMP"
-    DWORD64 UID;             // unikatni ID stroje, vytvari se xorem z GUID; uklada se v registry v Bug Reporter klici; nastavuje Salamander, salmon jen cte a vklada do nazvu bug reportu
+    DWORD Version;           // SALMON_SHARED_MEMORY_VERSION (if it does not match for SALAM/SALMON, shout and refuse to communicate...)
+    HANDLE Process;          // handle of the parent process (lets us wait for it to terminate); intentionally leaked
+    DWORD ProcessId;         // ID of the crashed parent process
+    DWORD ThreadId;          // ID of the crashed thread
+    HANDLE Fire;             // AS signals to SALMON that it should send reports
+    HANDLE Done;             // SALMON reports back to AS that it is finished
+    HANDLE SetSLG;           // AS signals to SALMON that it should load the SLG stored in the SLGName buffer before the event is signaled
+    HANDLE CheckBugs;        // AS signals to SALMON that it should check the directory with bug reports and, if it finds any (from some previous crash), offer to upload them
+    char SLGName[MAX_PATH];  // meaningful at the moment AS signals SetSLG and indicates which SLG should be loaded
+    char BugPath[MAX_PATH];  // set by Salamander; path for bug reports (created only when a crash occurs)
+    char BugName[MAX_PATH];  // set by Salamander; internal name of the minidump/bug report file
+    char BaseName[MAX_PATH]; // set by Salmon; constructed as "UID-BugName-DATE-TIME"; ".DMP" is appended for a minidump
+    DWORD64 UID;             // unique machine ID created by XORing the GUID; stored in the Bug Reporter key; set by Salamander, Salmon only reads it and inserts it into the bug report name
 
-    // predani EXCEPTION_POINTERS po jeho slozkach; nastavime pred nasetovanim eventu Fire
+    // pass EXCEPTION_POINTERS piece by piece; set before signaling the Fire event
     EXCEPTION_RECORD ExceptionRecord;
     CONTEXT ContextRecord;
 };
@@ -60,11 +60,11 @@ struct CSalmonSharedMemory
 #ifdef INSIDE_SALAMANDER
 
 BOOL SalmonInit();
-void SalmonSetSLG(const char* slgName); // nastavi do salmon jazyk
+void SalmonSetSLG(const char* slgName); // sets the language in salmon
 void SalmonCheckBugs();
 
-// ulozi do sdilene pameti info o exception a pozada salmon o vytvoreni minidumpu; potom ceka, az dobehne
-// vraci TRUE v pripade uspechu, FALSE pokud se nepodarilo z nejakeho duvodu Salmon zavolat
+// stores the exception info in shared memory and asks Salmon to create a minidump; then waits for it to finish
+// returns TRUE if successful, FALSE if Salmon could not be invoked for some reason
 BOOL SalmonFireAndWait(const EXCEPTION_POINTERS* e, char* bugReportPath);
 
 #endif //INSIDE_SALAMANDER

--- a/src/salshlib.cpp
+++ b/src/salshlib.cpp
@@ -16,30 +16,30 @@ extern "C"
 }
 #include "salshlib.h"
 
-// mutex pro pristup do sdilene pameti
+// mutex guarding access to shared memory
 HANDLE SalShExtSharedMemMutex = NULL;
-// sdilena pamet - viz struktura CSalShExtSharedMem
+// shared memory—see CSalShExtSharedMem
 HANDLE SalShExtSharedMem = NULL;
-// event pro zaslani zadosti o provedeni Paste ve zdrojovem Salamanderovi (pouziva se jen ve Vista+)
+// event used to request Paste execution in the source Salamander (Vista+ only)
 HANDLE SalShExtDoPasteEvent = NULL;
-// namapovana sdilena pamet - viz struktura CSalShExtSharedMem
+// mapped shared memory—see CSalShExtSharedMem
 CSalShExtSharedMem* SalShExtSharedMemView = NULL;
 
-// TRUE pokud se podarilo registrovat SalShExt/SalamExt/SalExtX86/SalExtX64.DLL nebo uz registrovane
-// bylo (kontroluje i soubor)
+// TRUE if SalShExt/SalamExt/SalExtX86/SalExtX64.DLL registered successfully or was already registered
+// (also verifies the file)
 BOOL SalShExtRegistered = FALSE;
 
-// maximalni prasarna: potrebujeme zjistit do ktereho okna probehne Drop, zjistujeme to
-// v GetData podle pozice mysi, v tyhle promenny je posledni vysledek testu
+// extreme hack: we need to remember which window Drop will target, determined
+// in GetData from the mouse position; this variable holds the last test result
 HWND LastWndFromGetData = NULL;
 
-// maximalni prasarna: potrebujeme zjistit do ktereho okna probehne Paste, zjistujeme to
-// v GetData podle foreground window, v tyhle promenny je posledni vysledek testu
+// extreme hack: we need to remember which window Paste will target, determined
+// in GetData from the foreground window; this variable holds the last test result
 HWND LastWndFromPasteGetData = NULL;
 
-BOOL OurDataOnClipboard = FALSE; // TRUE = na clipboardu je nas data-object (copy&paste z archivu)
+BOOL OurDataOnClipboard = FALSE; // TRUE = our data object is currently on the clipboard (copy & paste from the archive)
 
-// data pro Paste z clipboardu ulozena uvnitr "zdrojoveho" Salamandera
+// data used for Paste from the clipboard stored inside the "source" Salamander
 CSalShExtPastedData SalShExtPastedData;
 
 //*****************************************************************************
@@ -59,7 +59,7 @@ void InitSalShLib()
     if (SalShExtSharedMemMutex != NULL)
     {
         WaitForSingleObject(SalShExtSharedMemMutex, INFINITE);
-        SalShExtSharedMem = HANDLES_Q(CreateFileMapping(INVALID_HANDLE_VALUE, saPtr, PAGE_READWRITE, // FIXME_X64 nepredavame x86/x64 nekompatibilni data?
+        SalShExtSharedMem = HANDLES_Q(CreateFileMapping(INVALID_HANDLE_VALUE, saPtr, PAGE_READWRITE, // FIXME_X64 are we passing incompatible x86/x64 data?
                                                         0, sizeof(CSalShExtSharedMem),
                                                         SALSHEXT_SHAREDMEMNAME));
         BOOL created;
@@ -75,13 +75,13 @@ void InitSalShLib()
 
         if (SalShExtSharedMem != NULL)
         {
-            SalShExtSharedMemView = (CSalShExtSharedMem*)HANDLES(MapViewOfFile(SalShExtSharedMem, // FIXME_X64 nepredavame x86/x64 nekompatibilni data?
+            SalShExtSharedMemView = (CSalShExtSharedMem*)HANDLES(MapViewOfFile(SalShExtSharedMem, // FIXME_X64 are we passing incompatible x86/x64 data?
                                                                                FILE_MAP_WRITE, 0, 0, 0));
             if (SalShExtSharedMemView != NULL)
             {
                 if (created)
                 {
-                    memset(SalShExtSharedMemView, 0, sizeof(CSalShExtSharedMem)); // sice ma byt nulovana, ale nespolehame na to
+                    memset(SalShExtSharedMemView, 0, sizeof(CSalShExtSharedMem)); // it should already be zeroed, but we do not count on it
                     SalShExtSharedMemView->Size = sizeof(CSalShExtSharedMem);
                 }
             }
@@ -106,8 +106,8 @@ void ReleaseSalShLib()
     CALL_STACK_MESSAGE1("ReleaseSalShLib()");
     if (OurDataOnClipboard)
     {
-        OleSetClipboard(NULL);      // vyhodime nas data-object z clipboardu
-        OurDataOnClipboard = FALSE; // teoreticky zbytecne (melo by se nastavit v Release() fakeDataObjectu)
+        OleSetClipboard(NULL);      // remove our data object from the clipboard
+        OurDataOnClipboard = FALSE; // theoretically redundant (the fake data object's Release() should do this)
     }
     if (SalShExtSharedMemView != NULL)
         HANDLES(UnmapViewOfFile(SalShExtSharedMemView));
@@ -240,7 +240,7 @@ STDMETHODIMP CFakeDragDropDataObject::GetData(FORMATETC* formatEtc, STGMEDIUM* m
 
     if (formatEtc->cfFormat == CFSalFakeRealPath && (formatEtc->tymed & TYMED_HGLOBAL))
     {
-        HGLOBAL dataDup = NULL; // vyrobime kopii RealPath
+        HGLOBAL dataDup = NULL; // create a copy of RealPath
         int size = (int)strlen(RealPath) + 1;
         dataDup = NOHANDLES(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, size));
         if (dataDup != NULL)
@@ -257,7 +257,7 @@ STDMETHODIMP CFakeDragDropDataObject::GetData(FORMATETC* formatEtc, STGMEDIUM* m
                 dataDup = NULL;
             }
         }
-        if (dataDup != NULL) // mame data, ulozime je na medium a vratime
+        if (dataDup != NULL) // we have data, store it in the medium and return it
         {
             medium->tymed = TYMED_HGLOBAL;
             medium->hGlobal = dataDup;
@@ -290,7 +290,7 @@ STDMETHODIMP CFakeDragDropDataObject::GetData(FORMATETC* formatEtc, STGMEDIUM* m
                     dataDup = NULL;
                 }
             }
-            if (dataDup != NULL) // mame data, ulozime je na medium a vratime
+            if (dataDup != NULL) // we have data, store it in the medium and return it
             {
                 medium->tymed = TYMED_HGLOBAL;
                 medium->hGlobal = dataDup;
@@ -304,7 +304,7 @@ STDMETHODIMP CFakeDragDropDataObject::GetData(FORMATETC* formatEtc, STGMEDIUM* m
         {
             if (formatEtc->cfFormat == CFSalFakeSrcFSPath && (formatEtc->tymed & TYMED_HGLOBAL))
             {
-                HGLOBAL dataDup = NULL; // vyrobime kopii SrcFSPath
+                HGLOBAL dataDup = NULL; // create a copy of SrcFSPath
                 int size = (int)strlen(SrcFSPath) + 1;
                 dataDup = NOHANDLES(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, size));
                 if (dataDup != NULL)
@@ -321,7 +321,7 @@ STDMETHODIMP CFakeDragDropDataObject::GetData(FORMATETC* formatEtc, STGMEDIUM* m
                         dataDup = NULL;
                     }
                 }
-                if (dataDup != NULL) // mame data, ulozime je na medium a vratime
+                if (dataDup != NULL) // we have data, store it in the medium and return it
                 {
                     medium->tymed = TYMED_HGLOBAL;
                     medium->hGlobal = dataDup;
@@ -367,12 +367,12 @@ CFakeCopyPasteDataObject::Release(void)
     {
         OurDataOnClipboard = FALSE;
 
-        if (CutOrCopyDone) // pokud doslo k chybe behem cut/copy, cekani nema smysl a cisteni provedeme jinde
+        if (CutOrCopyDone) // if an error occurred during cut/copy, waiting makes no sense and we perform the cleanup elsewhere
         {
             //      TRACE_I("CFakeCopyPasteDataObject::Release(): deleting clipfake directory!");
 
-            // ted uz muzeme zrusit "paste" ve sdilene pameti, vycistit fake-dir a zrusit data-object
-            if (SalShExtSharedMemView != NULL) // ulozime cas do sdilene pameti (pro rozliseni mezi paste a jinym copy/move fake-diru)
+            // now we can cancel the "paste" in shared memory, clean up the fake dir, and remove the data object
+            if (SalShExtSharedMemView != NULL) // store the timestamp in shared memory (to distinguish between paste and another copy/move of the fake dir)
             {
                 //        TRACE_I("CFakeCopyPasteDataObject::Release(): DoPasteFromSalamander = FALSE");
                 WaitForSingleObject(SalShExtSharedMemMutex, INFINITE);
@@ -385,16 +385,16 @@ CFakeCopyPasteDataObject::Release(void)
             //      TRACE_I("CFakeCopyPasteDataObject::Release(): removedir");
             char* cutDir;
             if (CutDirectory(dir, &cutDir) && cutDir != NULL && strcmp(cutDir, "CLIPFAKE") == 0)
-            { // pro jistotu zkontrolujeme, jestli skutecne smazeme jen fake-dir
+            { // just to be sure, check that we really delete only the fake dir
                 RemoveTemporaryDir(dir);
             }
             //      TRACE_I("CFakeCopyPasteDataObject::Release(): posting WM_USER_SALSHEXT_TRYRELDATA");
             if (MainWindow != NULL)
-                PostMessage(MainWindow->HWindow, WM_USER_SALSHEXT_TRYRELDATA, 0, 0); // zkusime provest uvolneni dat (nejsou-li zamcena ani blokovana)
+                PostMessage(MainWindow->HWindow, WM_USER_SALSHEXT_TRYRELDATA, 0, 0); // try to release the data (if it is neither locked nor blocked)
         }
 
         delete this;
-        return 0; // nesmime sahnout do objektu, uz neexistuje
+        return 0; // we must not touch the object; it no longer exists
     }
     return RefCount;
 }
@@ -412,20 +412,20 @@ STDMETHODIMP CFakeCopyPasteDataObject::GetData(FORMATETC* formatEtc, STGMEDIUM* 
         medium->tymed = TYMED_HGLOBAL;
         medium->hGlobal = NULL;
         medium->pUnkForRelease = NULL;
-        return S_OK; // vracime S_OK, abysme vyhoveli testu ve funkci IsFakeDataObject()
+        return S_OK; // return S_OK to satisfy the test in the IsFakeDataObject() function
     }
     else
     {
         if (formatEtc->cfFormat == CFIdList)
-        { // Paste do Explorera pouziva tenhle format, ostatni nas nezajimaji (stejne nepouziji copy-hook)
-            // resi problem ve Win98: pri Copy to clipboard z Exploreru se na stavajici objekt na clipboardu
-            // vola GetData, az pak se uvolni a nahradi novym objektem z Exploreru (problem je 2 sekundovy
-            // timeout z duvodu cekani na zavolani copy-hooku - po GetData ho vzdycky ocekavame)
+        { // Paste into Explorer uses this format; the others do not matter (they do not use the copy hook anyway)
+            // solves a problem in Win98: when copying to the clipboard from Explorer, GetData is called on the existing object on the clipboard
+            // only afterwards is it released and replaced with a new object from Explorer (the problem is a 2-second
+            // timeout because we always expect the copy hook to be called after GetData)
             DWORD ti = GetTickCount();
-            if (ti - LastGetDataCallTime >= 100) // optimalizace: ukladame novy cas jen pri zmene o minimalne 100ms
+            if (ti - LastGetDataCallTime >= 100) // optimization: store a new time only if it changes by at least 100 ms
             {
                 LastGetDataCallTime = ti;
-                if (SalShExtSharedMemView != NULL) // ulozime cas do sdilene pameti (pro rozliseni mezi paste a jinym copy/move fake-diru)
+                if (SalShExtSharedMemView != NULL) // store the timestamp in shared memory (to distinguish between paste and another copy/move of the fake dir)
                 {
                     WaitForSingleObject(SalShExtSharedMemMutex, INFINITE);
                     SalShExtSharedMemView->ClipDataObjLastGetDataTime = ti;
@@ -470,7 +470,7 @@ BOOL CSalShExtPastedData::SetData(const char* archiveFileName, const char* pathI
 
     Clear();
 
-    LastWndFromPasteGetData = NULL; // pro prvni Paste to budeme nulovat zde
+    LastWndFromPasteGetData = NULL; // clear it for the first Paste
 
     lstrcpyn(ArchiveFileName, archiveFileName, MAX_PATH);
     lstrcpyn(PathInArchive, pathInArchive, MAX_PATH);
@@ -479,18 +479,18 @@ BOOL CSalShExtPastedData::SetData(const char* archiveFileName, const char* pathI
     for (i = 0; i < selIndexesCount; i++)
     {
         int index = selIndexes[i];
-        if (index < dirs->Count) // jde o adresar
+        if (index < dirs->Count) // it is a directory
         {
             if (!SelFilesAndDirs.Add(TRUE, dirs->At(index).Name))
                 break;
         }
-        else // jde o soubor
+        else // it is a file
         {
             if (!SelFilesAndDirs.Add(FALSE, files->At(index - dirs->Count).Name))
                 break;
         }
     }
-    if (i < selIndexesCount) // chyba nedostatku pameti
+    if (i < selIndexesCount) // ran out of memory
     {
         Clear();
         return FALSE;
@@ -518,17 +518,17 @@ void CSalShExtPastedData::ReleaseStoredArchiveData()
     {
         if (StoredPluginData.NotEmpty())
         {
-            // uvolnime data plug-inu pro jednotlive soubory a adresare
+            // release the plug-in data for individual files and directories
             BOOL releaseFiles = StoredPluginData.CallReleaseForFiles();
             BOOL releaseDirs = StoredPluginData.CallReleaseForDirs();
             if (releaseFiles || releaseDirs)
                 StoredArchiveDir->ReleasePluginData(StoredPluginData, releaseFiles, releaseDirs);
 
-            // uvolnime interface StoredPluginData
+            // release the StoredPluginData interface
             CPluginInterfaceEncapsulation plugin(StoredPluginData.GetPluginInterface(), StoredPluginData.GetBuiltForVersion());
             plugin.ReleasePluginDataInterface(StoredPluginData.GetInterface());
         }
-        StoredArchiveDir->Clear(NULL); // uvolnime "standardni" (Salamanderovska) data listingu
+        StoredArchiveDir->Clear(NULL); // release the "standard" (Salamander) listing data
         delete StoredArchiveDir;
     }
     StoredArchiveDir = NULL;
@@ -541,9 +541,9 @@ BOOL CSalShExtPastedData::WantData(const char* archiveFileName, CSalamanderDirec
 {
     CALL_STACK_MESSAGE1("CSalShExtPastedData::WantData()");
 
-    if (!Lock /* nemelo by nastat, ale sychrujeme se */ &&
+    if (!Lock /* should not happen, but we play it safe */ &&
         StrICmp(ArchiveFileName, archiveFileName) == 0 &&
-        archiveSize != CQuadWord(-1, -1) && // porusena date&time znamka svedci o archivu, ktery je nutne znovu nacist
+        archiveSize != CQuadWord(-1, -1) && // a corrupted date & time mark indicates an archive that must be reloaded
         (!pluginData.NotEmpty() || pluginData.CanBeCopiedToClipboard()))
     {
         ReleaseStoredArchiveData();
@@ -567,25 +567,25 @@ BOOL CSalShExtPastedData::CanUnloadPlugin(HWND parent, CPluginInterfaceAbstract*
     {
         if (ArchiveFileName[0] != 0)
         {
-            // zjistime, jestli unloadeny plugin ma co docineni s nasim archivem,
-            // plug-in by se klidne mohl unloadnout behem pouziti archivatoru (kazda funkce archivatoru
-            // si plug-in naloadi), ale nic se nema prehanet, takze pripadny listing archivu zrusime
+            // find out whether the unloaded plug-in has anything to do with our archive;
+            // the plug-in could unload itself while the archiver is used (each archiver function
+            // loads the plug-in), but better safe than sorry, so we cancel any existing archive listing
             int format = PackerFormatConfig.PackIsArchive(ArchiveFileName);
-            if (format != 0) // nasli jsme podporovany archiv
+            if (format != 0) // we found a supported archive
             {
                 format--;
                 CPluginData* data;
                 int index = PackerFormatConfig.GetUnpackerIndex(format);
-                if (index < 0) // view: jde o interni zpracovani (plug-in)?
+                if (index < 0) // view: is it processed internally (plug-in)?
                 {
                     data = Plugins.Get(-index - 1);
                     if (data != NULL && data->GetPluginInterface()->GetInterface() == plugin)
                         used = TRUE;
                 }
-                if (PackerFormatConfig.GetUsePacker(format)) // ma edit?
+                if (PackerFormatConfig.GetUsePacker(format)) // does it have an editor?
                 {
                     index = PackerFormatConfig.GetPackerIndex(format);
-                    if (index < 0) // jde o interni zpracovani (plug-in)?
+                    if (index < 0) // is it processed internally (plug-in)?
                     {
                         data = Plugins.Get(-index - 1);
                         if (data != NULL && data->GetPluginInterface()->GetInterface() == plugin)
@@ -597,8 +597,8 @@ BOOL CSalShExtPastedData::CanUnloadPlugin(HWND parent, CPluginInterfaceAbstract*
     }
 
     if (used)
-        ReleaseStoredArchiveData(); // pouzivame data pluginu, musime je (nebo jen bude lepsi je) uvolnit
-    return TRUE;                    // unload pluginu je mozny
+        ReleaseStoredArchiveData(); // we are using plug-in data, so release it
+    return TRUE;                    // unloading the plug-in is possible
 }
 
 void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
@@ -615,7 +615,7 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
         return;
     }
 
-    BeginStopRefresh(); // cmuchal si da pohov
+    BeginStopRefresh(); // pause the sniffer
 
     char text[1000];
     CSalamanderDirectory* archiveDir = NULL;
@@ -624,42 +624,42 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
     {
         CFilesWindow* panel = j == 0 ? MainWindow->GetActivePanel() : MainWindow->GetNonActivePanel();
         if (panel->Is(ptZIPArchive) && StrICmp(ArchiveFileName, panel->GetZIPArchive()) == 0)
-        { // panel obsahuje nas archiv
+        { // the panel contains our archive
             BOOL archMaybeUpdated;
             panel->OfferArchiveUpdateIfNeeded(MainWindow->HWindow, IDS_ARCHIVECLOSEEDIT2, &archMaybeUpdated);
             if (archMaybeUpdated)
             {
-                EndStopRefresh(); // ted uz zase cmuchal nastartuje
+                EndStopRefresh(); // resume the sniffer
                 return;
             }
-            // vyuzijeme data z panelu (jsme v hl. threadu, panel se behem operace nemuze zmenit)
+            // reuse the data from the panel (we are in the main thread, the panel cannot change during the operation)
             archiveDir = panel->GetArchiveDir();
             pluginData = panel->PluginData.GetInterface();
             break;
         }
     }
 
-    if (StoredArchiveDir != NULL) // pokud mame nejaka data archivu ulozena
+    if (StoredArchiveDir != NULL) // if we have any archive data stored
     {
         if (archiveDir != NULL)
-            ReleaseStoredArchiveData(); // archiv je otevreny v panelu, ulozena data zrusime
-        else                            // zkusime ulozena data vyuzit, zkontrolujeme size&date souboru archivu
+            ReleaseStoredArchiveData(); // the archive is open in a panel, discard the stored data
+        else                            // try to use the stored data, check the archive file size and date
         {
             BOOL canUseData = FALSE;
-            FILETIME archiveDate;  // datum&cas souboru archivu
-            CQuadWord archiveSize; // velikost souboru archivu
+            FILETIME archiveDate;  // archive file date & time
+            CQuadWord archiveSize; // archive file size
             HANDLE file = HANDLES_Q(CreateFile(ArchiveFileName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
                                                NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL));
             if (file != INVALID_HANDLE_VALUE)
             {
                 GetFileTime(file, NULL, NULL, &archiveDate);
                 DWORD err = NO_ERROR;
-                SalGetFileSize(file, archiveSize, err); // vraci "uspech?" - ignorujeme, testujeme pozdeji 'err'
+                SalGetFileSize(file, archiveSize, err); // returns "success?"—ignore it, we test 'err' later
                 HANDLES(CloseHandle(file));
 
-                if (err == NO_ERROR &&                                        // size&date jsme ziskali a
-                    CompareFileTime(&archiveDate, &StoredArchiveDate) == 0 && // date se nelisi a
-                    archiveSize == StoredArchiveSize)                         // size se take nelisi
+                if (err == NO_ERROR &&                                        // size & date obtained and
+                    CompareFileTime(&archiveDate, &StoredArchiveDate) == 0 && // the date is identical and
+                    archiveSize == StoredArchiveSize)                         // the size is identical as well
                 {
                     canUseData = TRUE;
                 }
@@ -670,27 +670,27 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
                 pluginData = StoredPluginData.GetInterface();
             }
             else
-                ReleaseStoredArchiveData(); // soubor archivu se zmenil, ulozena data zrusime
+                ReleaseStoredArchiveData(); // the archive file changed, discard the stored data
         }
     }
 
-    if (archiveDir == NULL) // nemame data, musime archiv znovu vylistovat
+    if (archiveDir == NULL) // we have no data, we must list the archive again
     {
         CSalamanderDirectory* newArchiveDir = new CSalamanderDirectory(FALSE);
         if (newArchiveDir == NULL)
             TRACE_E(LOW_MEMORY);
         else
         {
-            // zjistime informace o souboru (existuje?, size, date&time)
+            // find information about the file (does it exist? size, date, and time)
             DWORD err = NO_ERROR;
-            FILETIME archiveDate;  // datum&cas souboru archivu
-            CQuadWord archiveSize; // velikost souboru archivu
+            FILETIME archiveDate;  // archive file date & time
+            CQuadWord archiveSize; // archive file size
             HANDLE file = HANDLES_Q(CreateFile(ArchiveFileName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
                                                NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL));
             if (file != INVALID_HANDLE_VALUE)
             {
                 GetFileTime(file, NULL, NULL, &archiveDate);
-                SalGetFileSize(file, archiveSize, err); // vraci "uspech?" - ignorujeme, testujeme pozdeji 'err'
+                SalGetFileSize(file, archiveSize, err); // returns "success?"—ignore it, we test 'err' later
                 HANDLES(CloseHandle(file));
             }
             else
@@ -703,7 +703,7 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
             }
             else
             {
-                // uplatnime optimalizovane pridavani do 'newArchiveDir'
+                // use optimized insertion into 'newArchiveDir'
                 newArchiveDir->AllocAddCache();
 
                 SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
@@ -716,22 +716,22 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
 
                 if (haveList)
                 {
-                    // uvolnime cache, at v objektu zbytecne nestrasi
+                    // release the cache so it does not linger on the object unnecessarily
                     newArchiveDir->FreeAddCache();
 
                     StoredArchiveDir = newArchiveDir;
-                    newArchiveDir = NULL; // aby se newArchiveDir neuvolnilo
+                    newArchiveDir = NULL; // prevent newArchiveDir from being released
                     if (plugin != NULL)
                     {
                         StoredPluginData.Init(pluginDataAbs, plugin->DLLName, plugin->Version,
                                               plugin->GetPluginInterface()->GetInterface(), plugin->BuiltForVersion);
                     }
                     else
-                        StoredPluginData.Init(NULL, NULL, NULL, NULL, 0); // pouzivaji jen plug-iny, Salamander ne
+                        StoredPluginData.Init(NULL, NULL, NULL, NULL, 0); // used only by plug-ins, not by Salamander
                     StoredArchiveDate = archiveDate;
                     StoredArchiveSize = archiveSize;
 
-                    archiveDir = StoredArchiveDir; // pro Paste operaci vyuzijeme novy listing
+                    archiveDir = StoredArchiveDir; // use the new listing for the Paste operation
                     pluginData = StoredPluginData.GetInterface();
                 }
             }
@@ -741,7 +741,7 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
         }
     }
 
-    if (archiveDir != NULL) // pokud mame data archivu, provedeme Paste
+    if (archiveDir != NULL) // if we have the archive data, perform the Paste
     {
         CPanelTmpEnumData data;
         SelFilesAndDirs.Sort();
@@ -773,9 +773,9 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
                 {
                     if (SelFilesAndDirs.Contains(TRUE, dirs->At(i).Name, &foundOnIndex) &&
                         foundOnIndex >= 0 && foundOnIndex < SelFilesAndDirs.GetDirsCount() &&
-                        !foundDirs[foundOnIndex]) // oznacujeme jen prvni instanci jmena (je-li vic shodnych jmen v SelFilesAndDirs, nefunguje to, pulenim (v Contains) dojdeme vzdy k tomu samemu)
+                        !foundDirs[foundOnIndex]) // mark only the first instance of the name (if there are multiple identical names in SelFilesAndDirs it does not work; halving in Contains always arrives at the same one)
                     {
-                        foundDirs[foundOnIndex] = TRUE; // toto jmeno bylo prave nalezeno
+                        foundDirs[foundOnIndex] = TRUE; // this name has just been found
                         data.Indexes[actIndex++] = i;
                     }
                 }
@@ -788,15 +788,15 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
                 {
                     if (SelFilesAndDirs.Contains(FALSE, files->At(i).Name, &foundOnIndex) &&
                         foundOnIndex >= 0 && foundOnIndex < SelFilesAndDirs.GetFilesCount() &&
-                        !foundFiles[foundOnIndex]) // oznacujeme jen prvni instanci jmena (je-li vic shodnych jmen v SelFilesAndDirs, nefunguje to, pulenim (v Contains) dojdeme vzdy k tomu samemu)
+                        !foundFiles[foundOnIndex]) // mark only the first instance of the name (if there are multiple identical names in SelFilesAndDirs it does not work; halving in Contains always arrives at the same one)
                     {
-                        foundFiles[foundOnIndex] = TRUE;            // toto jmeno bylo prave nalezeno
-                        data.Indexes[actIndex++] = dirs->Count + i; // vsechny soubory maji index posunuty za adresare, zvyk z panelu
+                        foundFiles[foundOnIndex] = TRUE;            // this name has just been found
+                        data.Indexes[actIndex++] = dirs->Count + i; // all files have their index shifted after directories, as is customary in the panel
                     }
                 }
             }
             data.IndexesCount = actIndex;
-            if (data.IndexesCount == 0) // nas zip-root cely odesel do vecnych lovist
+            if (data.IndexesCount == 0) // our ZIP root vanished completely
             {
                 SalMessageBox(MainWindow->HWindow, LoadStr(IDS_ARCFILESNOTFOUND),
                               LoadStr(IDS_ERRORUNPACK), MB_OK | MB_ICONEXCLAMATION);
@@ -804,7 +804,7 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
             else
             {
                 BOOL unpack = TRUE;
-                if (data.IndexesCount != SelFilesAndDirs.GetCount()) // nenaslo vsechny oznacene polozky z clipboardu (duplicity jmen nebo vymaz souboru z archivu)
+                if (data.IndexesCount != SelFilesAndDirs.GetCount()) // not all items selected on the clipboard were found (duplicate names or files deleted from the archive)
                 {
                     unpack = SalMessageBox(MainWindow->HWindow, LoadStr(IDS_ARCFILESNOTFOUND2),
                                            LoadStr(IDS_ERRORUNPACK),
@@ -824,22 +824,22 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
                     lstrcpyn(pathBuf, tgtPath, MAX_PATH);
                     int l = (int)strlen(pathBuf);
                     if (l > 3 && pathBuf[l - 1] == '\\')
-                        pathBuf[l - 1] = 0; // krom "c:\" zrusime koncovy backslash
+                        pathBuf[l - 1] = 0; // remove the trailing backslash except for "c:\"
 
-                    // vlastni rozpakovani
+                    // the actual unpacking
                     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
                     PackUncompress(MainWindow->HWindow, MainWindow->GetActivePanel(), ArchiveFileName,
                                    pluginData, pathBuf, PathInArchive, PanelSalEnumSelection, &data);
                     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
 
-                    //if (GetForegroundWindow() == MainWindow->HWindow)  // z nepochopitelnych duvodu mizi fokus z panelu pri drag&dropu do Explorera, vratime ho tam
+                    //if (GetForegroundWindow() == MainWindow->HWindow)  // for incomprehensible reasons the focus disappears from the panel during drag & drop to Explorer, so return it there
                     //  RestoreFocusInSourcePanel();
 
-                    // refresh neautomaticky refreshovanych adresaru
-                    // zmena na cilove ceste a jejich podadresarich (vytvareni novych adresaru a vypakovani
-                    // souboru/adresaru)
+                    // refresh directories that are not refreshed automatically
+                    // change on the target path and its subdirectories (creating new directories and unpacking
+                    // files/directories)
                     MainWindow->PostChangeOnPathNotification(pathBuf, TRUE);
-                    // zmena v adresari, kde je umisteny archiv (pri unpacku by nemelo nastat, ale radsi refreshneme)
+                    // change in the directory where the archive is located (should not happen during unpacking, but refresh it just in case)
                     lstrcpyn(pathBuf, ArchiveFileName, MAX_PATH);
                     CutDirectory(pathBuf);
                     MainWindow->PostChangeOnPathNotification(pathBuf, FALSE);
@@ -856,5 +856,5 @@ void CSalShExtPastedData::DoPasteOperation(BOOL copy, const char* tgtPath)
             free(foundFiles);
     }
 
-    EndStopRefresh(); // ted uz zase cmuchal nastartuje
+    EndStopRefresh(); // resume the sniffer
 }


### PR DESCRIPTION
## Summary
- polish Salmon client comments so startup coordination and IPC failure notes read naturally in English
- tighten the shared Salmon header wording for shared-memory fields and exception forwarding
- clarify the shell extension’s shared-memory and clipboard comments for clearer guidance during Paste workflows
- ensure the Salmon initialization failure comment uses "start-up" wording so Czech keywords no longer linger

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e96d5323bc832295ac97339495b27e