### PR TITLE
Refine tooltip and version info translations

### DIFF
--- a/src/tooltip.h
+++ b/src/tooltip.h
@@ -7,41 +7,40 @@
 //
 // CToolTip
 //
-// Tento tooltip ma odstranit zakladni nevyhodu puvodni koncepce tooltipu.
-// Kazde okno melo vytvoreny vlastni tooltip objekt. Druha nevyhoda byla,
-// ze bylo nutne tomuto objektu predavat seznam oblasti, nad kteryma se
-// maji tooltipy vybalit.
+// This tooltip is supposed to eliminate the basic drawback of the original tooltip concept.
+// Each window had its own tooltip object created. The second drawback was that we had
+// to pass this object a list of regions over which the tooltips were supposed to pop up.
 //
-// Nova koncepce: CMainWindow bude vlastnit pouze jeden tooltip (instanci objektu).
-// Okno tooltipu se vytvari az ve chvili kdy je potreba a to v threadu, ktery
-// o zobrazeni pozadal. Duvod: potrebujeme, aby okno tooltipu v tomto threadu bezelo,
-// do 2.6b6 vcetne bezelo okenko tooltipu v hlavnim threadu Salamandera a pokud
-// ten stal, tooltipy se nezobrazovaly.
-// Pri pohybu mysi nad controlem, ktery bude pouzivat tento tooltip, bude control
-// pri vstupu do nove oblasti volat metodu SetCurrentID.
+// New concept: CMainWindow owns only one tooltip (a single object instance).
+// The tooltip window is created only at the moment when it is needed and in the thread
+// that requested the display. Reason: we need the tooltip window to run in this thread.
+// Up to version 2.6b6 inclusive the tooltip window ran in Salamander's main thread, and if that
+// thread stopped, the tooltips were not displayed. When the mouse moves over a control
+// that will use this tooltip, the control calls the SetCurrentID method whenever it enters
+// a new region.
 //
-// Rozhrani pro praci s tooltipem bude v const.h, aby bylo dostupnem vsem
-// controlum bez nutnosti includit mainwnd.h a tooltip.h.
+// The interface for working with the tooltip is declared in const.h so that all controls
+// can use it without having to include mainwnd.h and tooltip.h.
 //
 
-// Pouzivane zpravy:
-// WM_USER_TTGETTEXT - slouzi k dotazu na text s urcitym ID
-//   wParam = ID predany pri SetCurrentToolTip
-//   lParam = buffer (ukazuje do bufferu tooltipu) maxilmani pocet znaku je TOOLTIP_TEXT_MAX
-//            pred volanim teto message je na nulty znak vlozen terminator
-//            text muze obsahovat \n pro prechod na novy radek a \t pro vlozeni tabem
-// pokud okno zapise do bufferu retezec terminovany nulou, bude zobrazen v tooltipu
-// jinak nebude tooltip zobrazen
+// Messages used:
+// WM_USER_TTGETTEXT - used to request the text with a specific ID
+//   wParam = ID passed to SetCurrentToolTip
+//   lParam = buffer (points to the tooltip buffer); the maximum number of characters is TOOLTIP_TEXT_MAX
+//            before calling this message, the zeroth character is filled with the terminator
+//            the text can contain \n to move to a new line and \t to insert a tab
+// If the window writes a null-terminated string into the buffer, the tooltip will show it;
+// otherwise the tooltip will not be shown.
 //
 
 class CToolTip : public CWindow
 {
     enum TipTimerModeEnum
     {
-        ttmNone,         // nebezi zadny casovac
-        ttmWaitingOpen,  // ceka se na otevreni tool tipu
-        ttmWaitingClose, // ceka se na zavreni tool tipu
-        ttmWaitingKill,  // ceka se na vystup z rezimu zobrazovani
+        ttmNone,         // no timer is running
+        ttmWaitingOpen,  // waiting for the tooltip to open
+        ttmWaitingClose, // waiting for the tooltip to close
+        ttmWaitingKill,  // waiting to exit the display mode
     };
 
 protected:
@@ -53,9 +52,9 @@ protected:
     DWORD HideCounter;
     DWORD HideCounterMax;
     POINT LastCursorPos;
-    BOOL IsModal;     // je prave vykonvana nase message loop?
-    BOOL ExitASAP;    // zavri se co nejdriv a prestan byt modalni
-    UINT_PTR TimerID; // vracene ze SetTimer, potrebujeme pro KillTimer
+    BOOL IsModal;     // is our message loop running right now?
+    BOOL ExitASAP;    // close as soon as possible and stop being modal
+    UINT_PTR TimerID; // returned from SetTimer, we need it for KillTimer
 
 public:
     CToolTip(CObjectOrigin origin = ooStatic);
@@ -63,37 +62,36 @@ public:
 
     BOOL RegisterClass();
 
-    // hParent je nezbytny, aby se pri jeho zavreni zavrel take tooltip
-    // bez nej se nam delo, ze skoncil thread parenta, ale okno tooltipu zustalo
-    // otevrene, ale uz neslo zavrit (neexistoval jeho thread) -> pady pri
-    // ukonceni Salamandera (nastesti to bylo pred release 2.5b7)
+    // hParent is necessary so that the tooltip closes together with it.
+    // Without it we had cases where the parent's thread finished, but the tooltip window stayed
+    // open and could no longer be closed (its thread no longer existed) -> crashes when
+    // Salamander exited (fortunately before release 2.5b7).
     BOOL Create(HWND hParent);
 
-    // Tato metoda spusti casovac a pokud do jeho vyprseni neni zavolana znovu
-    // pozada okno 'hNotifyWindow' o text pomoci zpravy WM_USER_TTGETTEXT,
-    // ktery pak zobrazi pod kurzor na jeho aktualnich souradnicich.
-    // Promenna 'id' slouzi k rozliseni oblasti pri komunikaci s oknem 'hNotifyWindow'.
-    // Pokud bude tato metoda zavolana vicekrat se stejnym parametrem 'id', budou
-    // se tyto dalsi volani ignorovat.
-    // Hodnota 0 parametru 'hNotifyWindow' je vyhrazena pro zhasnuti okna a preruseni
-    // beziciho casovace.
-    // parametr 'showDelay' ma vyznam pokud je 'hNotifyWindow' != NULL
-    // pokud je vetsi nebo roven 1, urcuje za jak dlouho dojde ke zobrazeni tooltipu v [ms]
-    // pokud je roven 0, pouzije se implicitni prodleva
-    // pokud je -1, casovac se vubec nenastartuje
+    // This method starts a timer and, unless it is called again before the timer expires,
+    // asks the 'hNotifyWindow' window for the text through the WM_USER_TTGETTEXT message and then
+    // shows it under the cursor at its current coordinates.
+    // The 'id' parameter identifies the region when communicating with the 'hNotifyWindow' window.
+    // If the method is called more than once with the same 'id' parameter, the additional calls are ignored.
+    // The value 0 for the 'hNotifyWindow' parameter is reserved for hiding the window and stopping
+    // the running timer.
+    // The 'showDelay' parameter matters if 'hNotifyWindow' != NULL:
+    // if it is greater than or equal to 1, it specifies the delay before the tooltip is shown [ms]
+    // if it equals 0, the default delay is used
+    // if it is -1, the timer is not started at all
     void SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay);
 
-    // potlaci zobrazeni tooltipu na aktualnich souradnicich mysi
-    // uzitecne volat pri aktivaci okna, ve kterem se tooltipy pouzivaji
-    // nebude tak dochazet k nechtenemu zobrazeni tooltipu
+    // Suppresses showing the tooltip at the current mouse coordinates.
+    // Useful to call when activating a window in which tooltips are used,
+    // so there will not be unintended tooltip displays.
     void SuppressToolTipOnCurrentMousePos();
 
-    // pokud se podari text zobrazit, vrati TRUE; pokud neni dodan novy text, vrati FALSE
-    // pokud je considerCursor==TRUE, omeri kurzor a posune tooltip pod nej
-    // pokud je modal==TRUE, spusti messageloop, ktera hlida zpravy pro zavreni tooltipu a vrati se az po jeho zhasnuti
+    // Returns TRUE if the text can be shown; returns FALSE if no new text was supplied.
+    // If considerCursor==TRUE, it checks the cursor and moves the tooltip under it.
+    // If modal==TRUE, it starts a message loop that watches for tooltip-closing messages and returns only after it fades out.
     BOOL Show(int x, int y, BOOL considerCursor, BOOL modal, HWND hParent);
 
-    // zhasne tooltip
+    // extinguishes the tooltip
     void Hide();
 
     void OnTimer();
@@ -104,7 +102,7 @@ protected:
     BOOL GetText();
     void GetNeededWindowSize(SIZE* sz);
 
-    void MessageLoop(); // pro modalni variantu tooltipu
+    void MessageLoop(); // for the modal tooltip variant
 
     void MySetTimer(DWORD elapse);
     void MyKillTimer();

--- a/src/usermenu.h
+++ b/src/usermenu.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#define USRMNUARGS_MAXLEN 32772    // velikost bufferu (+1 proti maximalni delce stringu) (=32776 (Vista/Win7 pres .bat) - 5 ("C:\\a ") + 1)
-#define USRMNUCMDLINE_MAXLEN 32777 // velikost bufferu (+1 proti maximalni delce stringu)
+#define USRMNUARGS_MAXLEN 32772    // buffer size (+1 compared to the maximum string length) (=32776 (Vista/Win7 via .bat) - 5 ("C:\\a ") + 1)
+#define USRMNUCMDLINE_MAXLEN 32777 // buffer size (+1 compared to the maximum string length)
 
 //****************************************************************************
 //
@@ -13,11 +13,11 @@
 
 struct CUserMenuIconData
 {
-    char FileName[MAX_PATH];  // jmeno souboru, ze ktereho mame cist ikonu z indexu IconIndex (pres ExtractIconEx())
-    DWORD IconIndex;          // viz komentar k FileName
-    char UMCommand[MAX_PATH]; // jmeno souboru, ze ktereho mame cist ikonu (pres GetFileOrPathIconAux())
+    char FileName[MAX_PATH];  // name of the file from which we should read the icon at IconIndex (via ExtractIconEx())
+    DWORD IconIndex;          // see the comment for FileName
+    char UMCommand[MAX_PATH]; // name of the file from which we should read the icon (via GetFileOrPathIconAux())
 
-    HICON LoadedIcon; // NULL = nenactena ikona, jinak handle nactene ikony
+    HICON LoadedIcon; // NULL = icon not loaded, otherwise handle of the loaded icon
 
     CUserMenuIconData(const char* fileName, DWORD iconIndex, const char* umCommand);
     ~CUserMenuIconData();
@@ -28,7 +28,7 @@ struct CUserMenuIconData
 class CUserMenuIconDataArr : public TIndirectArray<CUserMenuIconData>
 {
 protected:
-    DWORD IRThreadID; // unikatni ID threadu pro nacitani techto ikon
+    DWORD IRThreadID; // unique thread ID for loading these icons
 
 public:
     CUserMenuIconDataArr() : TIndirectArray<CUserMenuIconData>(50, 50) { IRThreadID = 0; }
@@ -42,45 +42,45 @@ public:
 class CUserMenuIconBkgndReader
 {
 protected:
-    BOOL SysColorsChanged; // pomocna promenna pro zjisteni zmeny systemovych barev od okamziku otevreni cfg dialogu
+    BOOL SysColorsChanged; // helper variable to detect changes in system colors since the config dialog opened
 
-    CRITICAL_SECTION CS;       // sekce pro pristup k datum objektu
-    DWORD IconReaderThreadUID; // generator unikatnich ID threadu pro cteni ikon
-    BOOL CurIRThreadIDIsValid; // TRUE = thread bezi a CurIRThreadID je platne
-    DWORD CurIRThreadID;       // unikatni ID threadu (viz IconReaderThreadUID), ve kterem se ctou ikony pro aktualni verzi user-menu
-    BOOL AlreadyStopped;       // TRUE = uz zadne cteni ikon, hlavni okno se zavrelo/zavira
+    CRITICAL_SECTION CS;       // critical section protecting the object's data
+    DWORD IconReaderThreadUID; // generator of unique thread IDs for reading icons
+    BOOL CurIRThreadIDIsValid; // TRUE = the thread is running and CurIRThreadID is valid
+    DWORD CurIRThreadID;       // unique thread ID (see IconReaderThreadUID) that loads icons for the current user menu version
+    BOOL AlreadyStopped;       // TRUE = no more icon reading, the main window has closed/is closing
 
-    int UserMenuIconsInUse;                            // > 0: ikony z user menu jsou prave v otevrenem menu, nemuzeme je hned updatnout na nove ikony; muze byt nejvys 2 (cfg Salama + Find: user menu)
-    CUserMenuIconDataArr* UserMenuIIU_BkgndReaderData; // uschovna novych ikon pri UserMenuIconsInUse > 0
-    DWORD UserMenuIIU_ThreadID;                        // uschovna ID threadu (pro zjisteni aktualnosti dat) pri UserMenuIconsInUse > 0
+    int UserMenuIconsInUse;                            // > 0: user menu icons are currently in an open menu, so we cannot update them immediately; at most 2 (Salamander cfg + Find: user menu)
+    CUserMenuIconDataArr* UserMenuIIU_BkgndReaderData; // storage for new icons when UserMenuIconsInUse > 0
+    DWORD UserMenuIIU_ThreadID;                        // storage for thread IDs (to determine data freshness) when UserMenuIconsInUse > 0
 
 public:
     CUserMenuIconBkgndReader();
     ~CUserMenuIconBkgndReader();
 
-    // hlavni okno se zavira = uz nechceme prijimat zadna data o ikonach v user menu
+    // The main window is closing -> we no longer want to receive any user menu icon data.
     void EndProcessing();
 
-    // POZOR: uvnitr se dealokuje 'bkgndReaderData'
+    // WARNING: 'bkgndReaderData' is deallocated inside.
     void StartBkgndReadingIcons(CUserMenuIconDataArr* bkgndReaderData);
 
     BOOL IsCurrentIRThreadID(DWORD threadID);
 
     BOOL IsReadingIcons();
 
-    // POZOR: po volani teto funkce je za uvolneni 'bkgndReaderData' zodpovedny tento objekt
+    // WARNING: after calling this function this object is responsible for freeing 'bkgndReaderData'.
     void ReadingFinished(DWORD threadID, CUserMenuIconDataArr* bkgndReaderData);
 
-    // vstup/vystup do sekce, kde se pouzivaji ikony z user menu a tedy neni je mozne
-    // behem provadeni teto sekce updatit (hlavne jde o otevreni user menu)
+    // Enter/leave the section where user menu icons are being used and therefore cannot
+    // be updated while the section is executing (mainly when opening the user menu).
     void BeginUserMenuIconsInUse();
     void EndUserMenuIconsInUse();
 
-    // pokud se nacetly ikony pro jiz neaktualni user menu, vraci FALSE, jinak:
-    // pokud jsou ikony prave v otevrenem menu (viz UserMenuIconsInUse), vraci FALSE;
-    // pokud nejsou ikony prave v otevrenem menu, vraci TRUE a POZOR: neopusti CS,
-    // aby byl blokovany pristup z ostatnich threadu (hlavne pristup k user menu z threadu
-    // Findu), pro vystup z CS po updatu ikon se pouziva LeaveCSAfterUMIconsUpdate()
+    // If icons for an already outdated user menu were loaded, returns FALSE. Otherwise:
+    // if the icons are currently in an open menu (see UserMenuIconsInUse), returns FALSE;
+    // if the icons are not in an open menu, returns TRUE and WARNING: keeps the CS locked,
+    // so access from other threads is blocked (mainly access to the user menu from the Find thread).
+    // After updating the icons, use LeaveCSAfterUMIconsUpdate() to exit the CS.
     BOOL EnterCSIfCanUpdateUMIcons(CUserMenuIconDataArr** bkgndReaderData, DWORD threadID);
     void LeaveCSAfterUMIconsUpdate();
 
@@ -98,10 +98,10 @@ extern CUserMenuIconBkgndReader UserMenuIconBkgndReader;
 
 enum CUserMenuItemType
 {
-    umitItem,         // klasicka polozka
-    umitSubmenuBegin, // oznacuje zacatek popupu
-    umitSubmenuEnd,   // oznacuje konec popupu
-    umitSeparator     // oznacuje konec popupu
+    umitItem,         // standard item
+    umitSubmenuBegin, // marks the start of a popup
+    umitSubmenuEnd,   // marks the end of a popup
+    umitSeparator     // marks the end of a popup
 };
 
 struct CUserMenuItem
@@ -131,17 +131,17 @@ struct CUserMenuItem
 
     ~CUserMenuItem();
 
-    // pokusi se vytahnout handle ikony v tomto poradi
-    // a) promenne Icon
+    // Tries to retrieve the icon handle in this order
+    // a) the Icon variable
     // b) SHGetFileInfo
-    // c) veme default ze systemu
-    // cteni ikon na pozadi: je-li 'bkgndReaderData' NULL, cteme hned, jinak se ikony
-    // ctou na pozadi - je-li 'getIconsFromReader' FALSE, sbirame do 'bkgndReaderData',
-    // co nacist, je-li TRUE, ikony uz jsou nactene a jen prevezmeme handly nactenych
-    // ikon z 'bkgndReaderData'
+    // c) take the system default
+    // Reading icons in the background: if 'bkgndReaderData' is NULL, we read immediately; otherwise the icons
+    // are read in the background. If 'getIconsFromReader' is FALSE, we collect what to load into 'bkgndReaderData'.
+    // If it is TRUE, the icons are already loaded and we simply take over the handles of the loaded icons
+    // stored in 'bkgndReaderData'.
     BOOL GetIconHandle(CUserMenuIconDataArr* bkgndReaderData, BOOL getIconsFromReader);
 
-    // prohleda ItemName na & a vrati HotKey a TRUE kdyz ji najde
+    // Searches ItemName for '&' and returns the hotkey; returns TRUE if one is found.
     BOOL GetHotKey(char* key);
 
     BOOL Set(char* name, char* umCommand, char* arguments, char* initDir, char* icon);
@@ -161,10 +161,10 @@ public:
     CUserMenuItems(DWORD base, DWORD delta, CDeleteType dt = dtDelete)
         : TIndirectArray<CUserMenuItem>(base, delta, dt) {}
 
-    // nakopci seznam ze 'source'
+    // Copies the list from 'source'.
     BOOL LoadUMI(CUserMenuItems& source, BOOL readNewIconsOnBkgnd);
 
-    // hleda posledni (zaviraci) polozku submenu adresovaneho promennou 'index'
-    // pokud ukonecni nenajde, vrati -1
+    // Searches for the closing submenu item referenced by the 'index' variable.
+    // Returns -1 if no closing item is found.
     int GetSubmenuEndIndex(int index);
 };

--- a/src/versinfo.cpp
+++ b/src/versinfo.cpp
@@ -173,9 +173,9 @@ CVersionInfo::LoadBlock(const BYTE*& ptr, CVersionBlock* parent)
         }
     }
 
-    // preskocime VERSIONINFO a retezec Key
+    // Skip the VERSIONINFO header and the Key string.
     ptr += sizeof(VERSIONINFO) + sizeof(WCHAR) * wcslen(block->Key);
-    // preskocime Padding
+    // Skip the padding.
     ptr = ALIGN_DWORD(BYTE*, ptr);
 
     switch (block->Type)
@@ -186,7 +186,7 @@ CVersionInfo::LoadBlock(const BYTE*& ptr, CVersionBlock* parent)
     {
         int valSize = info->wValueLength;
 
-        if (block->Type == vbtVersionInfo) // udelame par kontrol konzistence dat
+        if (block->Type == vbtVersionInfo) // perform a few data consistency checks
         {
             if (valSize != sizeof(VS_FIXEDFILEINFO))
             {
@@ -210,20 +210,20 @@ CVersionInfo::LoadBlock(const BYTE*& ptr, CVersionBlock* parent)
             return NULL;
         }
 
-        // preskocime Value
+        // Skip the value.
         ptr += valSize;
-        // preskocime padding
+        // Skip the padding.
         ptr = ALIGN_DWORD(BYTE*, ptr);
 
         if (block->Type == vbtString || block->Type == vbtVar)
         {
-            // String a Var nemaji childy, takze vypadneme
+            // String and Var blocks have no children, so we exit.
             return block;
         }
     }
     }
 
-    // pridame child bloky
+    // Add child blocks.
     while (ptr < terminatorPtr)
     {
         CVersionBlock* child = LoadBlock(ptr, block);
@@ -415,14 +415,14 @@ BOOL CVersionInfo::SaveBlock(CVersionBlock* block, BYTE*& ptr, const BYTE* maxPt
         return FALSE;
     }
 
-    BYTE* oldPtr = ptr; // ulozim si pro nasledny vypocet velikosti nas a nasich childu
+    BYTE* oldPtr = ptr; // store it for the subsequent size calculation of us and our children
 
     // wLength
-    WORD* wLength = (WORD*)ptr; // ulozim si pro nasledne nastaveni
+    WORD* wLength = (WORD*)ptr; // keep it for setting later
     ptr += 2;
 
     // wValueLength
-    WORD* wValueLength = (WORD*)ptr; // ulozim si pro nasledne nastaveni
+    WORD* wValueLength = (WORD*)ptr; // keep it for setting later
     *wValueLength = 0;
     ptr += 2;
 
@@ -435,7 +435,7 @@ BOOL CVersionInfo::SaveBlock(CVersionBlock* block, BYTE*& ptr, const BYTE* maxPt
     memcpy(ptr, block->Key, size);
     ptr += size;
 
-    // padding
+    // Padding.
     ptr = ALIGN_DWORD(BYTE*, ptr);
 
     switch (block->Type)
@@ -489,14 +489,14 @@ BOOL CVersionInfo::SaveBlock(CVersionBlock* block, BYTE*& ptr, const BYTE* maxPt
     }
     }
 
-    // pokud nemam childy, ulozime velikost bez paddingu
+    // If there are no children, store the size without padding.
     if (block->Children.Count == 0)
         *wLength = (WORD)(ptr - oldPtr);
 
-    // padding
+    // Padding.
     ptr = ALIGN_DWORD(BYTE*, ptr);
 
-    // children
+    // Children.
     int i;
     for (i = 0; i < block->Children.Count; i++)
     {
@@ -505,7 +505,7 @@ BOOL CVersionInfo::SaveBlock(CVersionBlock* block, BYTE*& ptr, const BYTE* maxPt
             return FALSE;
     }
 
-    // v opacnem pripad s paddingem
+    // Otherwise include the padding as well.
     if (block->Children.Count > 0)
         *wLength = (WORD)(ptr - oldPtr);
 
@@ -521,7 +521,7 @@ BOOL CVersionInfo::UpdateResource(HANDLE hUpdateRes, int resID)
         return FALSE;
     }
     memset(buff, 0, 50000);
-    BYTE* ptr = buff; // pozor, hodnota bude zmenena
+    BYTE* ptr = buff; // note: the pointer value will be modified
     if (!SaveBlock(Root, ptr, ptr + 49999))
     {
         free(buff);

--- a/src/versinfo.h
+++ b/src/versinfo.h
@@ -3,16 +3,16 @@
 
 #pragma once
 
-// slouzi pro cteni (a pripadnou modifikaci) resource VERSIONINFO; pro cteni
-// by bylo mozne pouzit API GetFileVersionInfo/VerQueryValue, ale nasledna modifikace
-// neni podporena, takze problem resime vlastnim modulem navic by pouziti API
-// znamenalo linkovani Version.LIB/DLL, kterou na nic jineho nepouzivame
-// POZOR: modul se vyskytuje jak v Salanderu, tak v Translatoru
+// Used to read (and optionally modify) the VERSIONINFO resource. Reading alone could be handled
+// by the GetFileVersionInfo/VerQueryValue API, but that API does not support later modifications,
+// so we solve the problem with our own module. Using the API would also mean linking Version.LIB/DLL,
+// which we do not use for anything else.
+// WARNING: the module exists both in Salamander and in Translator.
 
-// pokud je definovana nasledujici promenna, bude modul podporovat vedle cteni take zapis
+// If the following macro is defined, the module supports writing in addition to reading.
 #define VERSINFO_SUPPORT_WRITE
 
-// umi ulozit resource na disk; slouzi pro ladici ucely modulu
+// Can save the resource to disk; used for module debugging purposes.
 #define VERSINFO_SUPPORT_DEBUG
 
 // VERSIONINFO
@@ -46,8 +46,8 @@ public:
     CVersionBlockType Type;
     WCHAR* Key;
     BOOL Text;      // 1 if the version resource contains text data and 0 if the version resource contains binary data
-    VOID* Value;    // zalezi na Type
-    WORD ValueSize; // pouzivame pouze pro Var, jinak pocitam
+    VOID* Value;    // depends on Type
+    WORD ValueSize; // used only for Var blocks, otherwise we compute it
     TIndirectArray<CVersionBlock> Children;
 
 public:
@@ -73,23 +73,23 @@ public:
     CVersionInfo();
     ~CVersionInfo();
 
-    // nacte VERSIONINFO ze specifikovaneho modulu
+    // Loads VERSIONINFO from the specified module.
     BOOL ReadResource(HINSTANCE hInstance, int resID);
 
-    // QueryValue slouzi k vytazeni dat z resource
-    // 'block' viz FindBlock
+    // QueryValue extracts data from the resource.
+    // 'block' - see FindBlock.
     BOOL QueryValue(const char* block, BYTE** buffer, DWORD* size);
 
-    // vytahne retezec ze sekce StringFileInfo, ktery rovnou konvertuje retezec z Unicode
-    // 'block' viz FindBlock
+    // Extracts a string from the StringFileInfo section and converts the Unicode string on the fly.
+    // 'block' - see FindBlock.
     BOOL QueryString(const char* block, char* buffer, DWORD maxSize, WCHAR* bufferW = NULL, DWORD maxSizeW = 0);
 
 #ifdef VERSINFO_SUPPORT_WRITE
-    // nastavi retezec do blocku 'block'; vraci TRUE v pripade uspechu, jinak FALSE
-    // blok musi jiz existovat
+    // Sets the string into the 'block' block; returns TRUE on success, otherwise FALSE.
+    // The block must already exist.
     BOOL SetString(const char* block, const char* buffer);
 
-    // alokuje kus pameti, pripravi VERSIONINFO stream a updatne resource
+    // Allocates a block of memory, prepares the VERSIONINFO stream, and updates the resource.
     BOOL UpdateResource(HANDLE hUpdateRes, int resID);
 #endif //VERSINFO_SUPPORT_WRITE
 
@@ -98,19 +98,19 @@ public:
 #endif //VERSINFO_SUPPORT_DEBUG
 
 private:
-    // ptr: ukazuje do streamu VS_VERSIONINFO na blok, ktery se ma nacist
-    // parent: NULL pokud jde o VS_VERSIONINFO, jinak ukazatel na rodice
+    // ptr: points into the VS_VERSIONINFO stream at the block to be loaded.
+    // parent: NULL for VS_VERSIONINFO, otherwise pointer to the parent block.
     CVersionBlock* LoadBlock(const BYTE*& ptr, CVersionBlock* parent);
 
-    // vyhleda blok
-    // 'block' je vstupni parametr a udava co se ma ziskat
-    //   "\" vrati ukazatel na VS_FIXEDFILEINFO
-    //   "\VarFileInfo\Translation" vrati ukazatel na DWORD
-    //   "\StringFileInfo\lang-codepage\string-name" vrati ukazatel na hodnotu (UNICODE)
+    // Locates a block.
+    // 'block' is the input parameter and specifies what to retrieve:
+    //   "\" returns a pointer to VS_FIXEDFILEINFO
+    //   "\VarFileInfo\Translation" returns a pointer to a DWORD
+    //   "\StringFileInfo\lang-codepage\string-name" returns a pointer to the value (UNICODE)
     CVersionBlock* FindBlock(const char* block);
 
 #ifdef VERSINFO_SUPPORT_WRITE
-    // rekurzivni funkce pro build VERSIONINFO streamu
+    // Recursive helper for building the VERSIONINFO stream.
     BOOL SaveBlock(CVersionBlock* block, BYTE*& ptr, const BYTE* maxPtr);
 #endif //VERSINFO_SUPPORT_WRITE
 };


### PR DESCRIPTION
## Summary
- retranslate the shared tooltip documentation to follow the original Czech wording more literally
- adjust user menu background icon loader comments for consistent English phrasing
- align VERSIONINFO parser comments with the original intent while keeping terminology consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9bb3dd57c8322ab899b9d99895ab3