### PR TITLE
Refine viewer comment translations

### DIFF
--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -20,8 +20,8 @@ HACCEL ViewerTable = NULL;
 BOOL UseCustomViewerFont = FALSE;
 LOGFONT ViewerLogFont;
 HMENU ViewerMenu = NULL;
-int CharWidth = 1,  // sirka znaku (v bodech), touho hodnotou se deli = nebudeme ji vubec davat na nulu
-    CharHeight = 1; // vyska znaku (v bodech), touho hodnotou se deli = nebudeme ji vubec davat na nulu
+int CharWidth = 1,  // character width (in points); we divide by this value, so we will never set it to zero
+    CharHeight = 1; // character height (in points); we divide by this value, so we will never set it to zero
 
 CRITICAL_SECTION ViewerFontMeasureCS;
 BOOL ViewerFontMeasured = FALSE;
@@ -70,7 +70,7 @@ void HistoryComboBox(HWND hWindow, CTransferInfo& ti, int ctrlID, char* Text,
                 SendMessage(hwnd, WM_SETTEXT, 0, (LPARAM)Text);
             }
 
-            // osetreni hex-modu
+            // hex mode handling
             if (hexMode)
             {
                 char* s = Text;
@@ -89,7 +89,7 @@ void HistoryComboBox(HWND hWindow, CTransferInfo& ti, int ctrlID, char* Text,
                 }
                 if (openedQuotes)
                     s = lastQuotes;
-                if (*s != 0) // obsahuje ne-hexa znak
+                if (*s != 0) // contains a non-hex character
                 {
                     if (!changeOnlyHistory)
                     {
@@ -101,7 +101,7 @@ void HistoryComboBox(HWND hWindow, CTransferInfo& ti, int ctrlID, char* Text,
                     ti.ErrorOn(ctrlID);
                 }
             }
-            // vse o.k. zalozime do historie
+            // everything is fine; store it in the history
             if (ti.IsGood())
             {
                 if (Text[0] != 0)
@@ -112,8 +112,8 @@ void HistoryComboBox(HWND hWindow, CTransferInfo& ti, int ctrlID, char* Text,
                     {
                         if (history[i] != NULL)
                         {
-                            if (strcmp(history[i], Text) == 0) // je-li uz v historii
-                            {                                  // pujde na 0. pozici
+                            if (strcmp(history[i], Text) == 0) // already in the history
+                            {                                  // move it to position 0
                                 if (i > 0)
                                 {
                                     char* swap = history[i];
@@ -150,7 +150,7 @@ void HistoryComboBox(HWND hWindow, CTransferInfo& ti, int ctrlID, char* Text,
         if (!changeOnlyHistory)
         {
             int i;
-            for (i = 0; i < historySize; i++) // naplneni listu combo-boxu
+            for (i = 0; i < historySize; i++) // fill the combo-box list
                 if (history[i] != NULL)
                     SendMessage(hwnd, CB_ADDSTRING, 0, (LPARAM)history[i]);
                 else
@@ -297,16 +297,16 @@ void ConvertHexToString(char* text, char* hex, int& len)
         {
             if (*s != ' ')
             {
-                if (*s == 0)
-                    break; // konec retezce
+                    if (*s == 0)
+                    break; // end of string
                 else
                 {
                     if (*s >= '0' && *s <= '9')
-                        value = (BYTE)(*s - '0'); // prvni cislice
+                        value = (BYTE)(*s - '0'); // first digit
                     else
                         value = (BYTE)(10 + (LowerCase[*s] - 'a'));
                     s++;
-                    if (*s != ' ' && *s != 0 && *s != '"') // druha cislice
+                    if (*s != ' ' && *s != 0 && *s != '"') // second digit
                     {
                         value <<= 4;
                         if (*s >= '0' && *s <= '9')
@@ -319,7 +319,7 @@ void ConvertHexToString(char* text, char* hex, int& len)
                 }
             }
             else
-                s++; // preskok mezery
+                s++; // skip the space
         }
     }
 }
@@ -336,9 +336,9 @@ void CFindSetDialog::Transfer(CTransferInfo& ti)
     HistoryComboBox(HWindow, ti, IDC_FINDTEXT, Text, FIND_TEXT_LEN, !Regular && HexMode,
                     VIEWER_HISTORY_SIZE, ViewerHistory);
     if (ti.Type == ttDataToWindow)
-    { // inicializace hledaneho textu podle oznaceni ve viewru (parent tohoto dialogu)
+    { // initialize the search text based on the selection in the viewer (the parent of this dialog)
         CWindowsObject* win = WindowsManager.GetWindowPtr(Parent);
-        if (win != NULL && win->Is(otViewerWindow)) // pro jistotu test je-li to okno viewru
+        if (win != NULL && win->Is(otViewerWindow)) // just to be sure, check that it is a viewer window
         {
             CViewerWindow* view = (CViewerWindow*)win;
             char buf[FIND_TEXT_LEN];
@@ -394,7 +394,7 @@ CFindSetDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_CLEARHISTORY:
     {
-        // mame promazat historie
+        // we should clear the histories
         ClearComboboxListbox(GetDlgItem(HWindow, IDC_FINDTEXT));
         return 0;
     }
@@ -405,7 +405,7 @@ CFindSetDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
         case IDCANCEL:
         {
-            HexMode = CancelHexMode; // aby byl Cancel korektni
+            HexMode = CancelHexMode; // keep Cancel correct
             Regular = CancelRegular;
             break;
         }
@@ -419,12 +419,12 @@ CFindSetDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 BOOL regular = (IsDlgButtonChecked(HWindow, IDC_VIEWREGEXP) == BST_CHECKED);
                 if (item->Keyword == EXECUTE_HELP)
                 {
-                    // otevreme help se strankou venovanou regular expressions
+                    // open the help page dedicated to regular expressions
                     OpenHtmlHelp(NULL, HWindow, HHCDisplayContext, IDH_REGEXP, FALSE);
                 }
                 if (item->Keyword != EXECUTE_HELP && !regular)
                 {
-                    // user zvolil nejaky vyraz -> zaskrtneme checkbox pro hledani regularu
+                    // the user selected an expression, so tick the checkbox for regular search
                     CheckDlgButton(HWindow, IDC_VIEWREGEXP, BST_CHECKED);
                     PostMessage(HWindow, WM_COMMAND, MAKELPARAM(IDC_VIEWREGEXP, BN_CLICKED), 0);
                 }
@@ -497,11 +497,11 @@ CViewerGoToOffsetDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_COMMAND:
     {
         if (LOWORD(wParam) == IDC_VGTO_HEX && HIWORD(wParam) == BN_CLICKED)
-        { // prepnuti HEX = zmena offsetu z dec na hex a opacne
+        { // switching HEX = change the offset from decimal to hex and back
             BOOL h = IsDlgButtonChecked(HWindow, IDC_VGTO_HEX) != BST_UNCHECKED;
             CTransferInfo ti(HWindow, ttDataFromWindow);
             __int64 off;
-            ti.EditLine(IDE_VGTO_OFFSET, off, TRUE, TRUE, !h, FALSE, TRUE); // chybu neukazujeme, jen neprevadime
+            ti.EditLine(IDE_VGTO_OFFSET, off, TRUE, TRUE, !h, FALSE, TRUE); // do not show an error; just skip conversion
             if (ti.IsGood())
             {
                 CTransferInfo ti2(HWindow, ttDataToWindow);
@@ -525,21 +525,21 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     : CWindow(origin), LineOffset(300, 100),
       FindDialog(HLanguage, IDD_FINDSET, IDD_FINDSET)
 {
-    // GDI promenne
+    // GDI variables
     BkgndBrush = NULL;
     BkgndBrushSel = NULL;
     ViewerFont = NULL;
 
     Width = Height = 0;
 
-    // dummy bitmapa -- spravna velikost az ve WM_SIZE
+    // dummy bitmap -- the correct size will be set in WM_SIZE
     if (!Bitmap.CreateBmp(NULL, 1, 1))
         TRACE_E("Unable to create bitmap or memory DC for viewer.");
 
     CreateViewerBrushs();
-    SetViewerFont(); // pouziva Bitmap (musi byt alokovana aspon jako 1x1) a Width (musi byt aspon inicializovana na 0)
+    SetViewerFont(); // uses Bitmap (must already be allocated to at least 1x1) and Width (must already be initialized to at least 0)
 
-    // ostatni promenne
+    // other variables
     HexOffsetLength = 0;
     CanSwitchToHex = TRUE;
     CanSwitchQuietlyToHex = FALSE;
@@ -555,7 +555,7 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     CodeTables.Init(MainWindow->HWindow);
     UseCodeTable = FALSE;
     if (fileName == NULL)
-        FileName = NULL; // chyba
+        FileName = NULL; // error
     else
     {
         char name[MAX_PATH];
@@ -579,8 +579,8 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     ViewSize = FileSize = 0;
     LastLineSize = FirstLineSize = 0;
     EnablePaint = TRUE;
-    StartSelection = -1; // zadna selectiona zatim nebyla
-    EndSelection = -1;   // zadna selectiona zatim nebyla
+    StartSelection = -1; // no selection yet
+    EndSelection = -1;   // no selection yet
     TooBigSelAction = 0;
     EndSelectionRow = -1;
     EndSelectionPrefX = -1;
@@ -627,7 +627,7 @@ CViewerWindow::~CViewerWindow()
     if (Lock != NULL)
     {
         SetEvent(Lock);
-        Lock = NULL; // ted uz je to jen na disk-cache
+        Lock = NULL; // now it is up to the disk cache
     }
     if (Buffer != NULL)
         free(Buffer);
@@ -684,29 +684,29 @@ int GetHexOffsetMode(unsigned __int64 fileSize, int& hexOffsetLength)
     if (fileSize == 0)
     {
         hexOffsetLength = 4;
-        return 1; // min. 4 mista
+        return 1; // at least 4 characters
     }
-    --fileSize;                                              // nejvetsi mozny offset v souboru je o jednu mensi nez velikost souboru
-    if (fileSize <= CQuadWord(0x0000FFFF, 0x00000000).Value) // staci 4 mista
+    --fileSize;                                              // the largest possible offset in the file is one less than the file size
+    if (fileSize <= CQuadWord(0x0000FFFF, 0x00000000).Value) // 4 characters are enough
     {
         hexOffsetLength = 4;
         return 1;
     }
     else
     {
-        if (fileSize <= CQuadWord(0xFFFFFFFF, 0x00000000).Value) // staci 8 mist
+        if (fileSize <= CQuadWord(0xFFFFFFFF, 0x00000000).Value) // 8 characters are enough
         {
             hexOffsetLength = 9;
             return 2;
         }
         else
         {
-            if (fileSize <= CQuadWord(0xFFFFFFFF, 0x0000FFFF).Value) // staci 12 mist
+            if (fileSize <= CQuadWord(0xFFFFFFFF, 0x0000FFFF).Value) // 12 characters are enough
             {
                 hexOffsetLength = 14;
                 return 3;
             }
-            else // nutnych 16 mist
+            else // 16 characters are necessary
             {
                 hexOffsetLength = 19;
                 return 4;
@@ -723,17 +723,17 @@ void PrintHexOffset(char* s, unsigned __int64 offset, int mode)
     {
     case 1:
         sprintf(s, "%04X", LOWORD64(offset));
-        return; // staci 4 mista
+        return; // 4 characters are enough
     case 2:
         sprintf(s, "%04X %04X", LOWORD64(offset >> 16), LOWORD64(offset));
-        return; // staci 8 mist
+        return; // 8 characters are enough
     case 3:
         sprintf(s, "%04X %04X %04X", LOWORD64(offset >> 32), LOWORD64(offset >> 16), LOWORD64(offset));
-        return; // staci 12 mist
+        return; // 12 characters are enough
     case 4:
         sprintf(s, "%04X %04X %04X %04X", LOWORD64(offset >> 48), LOWORD64(offset >> 32),
                 LOWORD64(offset >> 16), LOWORD64(offset));
-        return; // nutnych 16 mist
+        return; // 16 characters are necessary
     }
     TRACE_E("Unexpected situation in PrintHexOffset().");
 }
@@ -789,23 +789,23 @@ void CViewerWindow::Paint(HDC dc)
         r.right = BORDER_WIDTH;
         r.top = 0;
         r.bottom = Height;
-        FillRect(dc, &r, BkgndBrush); // vymaz sloupce vlevo od textu
+        FillRect(dc, &r, BkgndBrush); // clear the column to the left of the text
         RECT fullLine;
         fullLine.left = 0;
         fullLine.top = 0;
         fullLine.right = Width - BORDER_WIDTH;
-        fullLine.bottom = CharHeight /*Height*/; //j.r. W2K pomalostni patch
+        fullLine.bottom = CharHeight /*Height*/; // j.r. W2K slowness patch
 
         r.right = Width;
         ViewSize = 0;
         int lines = Height / CharHeight + 1;
         int columns = (Width - BORDER_WIDTH) / CharWidth;
-        char line[2001]; // max. 2000 plne viditelnych znaku na radku + 1 znak castecne viditelny
+        char line[2001]; // holds at most 2000 fully visible characters per line plus 1 partially visible character
         char* s;
         BOOL fatalErr = FALSE;
-        if (columns <= 2000) // jen kdyz neni prekroceno toto max.
+        if (columns <= 2000) // only when this maximum is not exceeded
         {
-            // urcim interval radku, ktery je treba prekreslit
+            // determine which rows need to be repainted
             RECT clipRect;
             int clipRet = GetClipBox(dc, &clipRect);
             int clipFirstRow = 0;
@@ -837,33 +837,33 @@ void CViewerWindow::Paint(HDC dc)
                 for (i = 0; i < lines; i++)
                 {
                     __int64 len = Prepare(NULL, lineOffset, 16, fatalErr);
-                    // if (fatalErr) FatalFileErrorOccured(); // je nize
+                    // if (fatalErr) FatalFileErrorOccured(); // see below
                     if (fatalErr)
                         break;
                     if (len == 0 && i + 1 != lines && SeekY != 0)
                     {
                         __int64 size = FileSize;
                         FileChanged(NULL, TRUE, fatalErr, FALSE);
-                        // if (fatalErr) FatalFileErrorOccured(); // je nize
+                        // if (fatalErr) FatalFileErrorOccured(); // see below
                         if (fatalErr || ExitTextMode)
                             break;
                         if (size != FileSize)
                         {
-                            setFindOffset = FALSE; // nechame to udelat az pri nasledujicim kole kresleni
+                            setFindOffset = FALSE; // leave it for the next drawing pass
                             ViewSize = 0;
                             FindNewSeekY(SeekY, fatalErr);
                             if (fatalErr || ExitTextMode)
                                 break;
                             FirstLineSize = LastLineSize = 0;
-                            // pokud se prohlizel zvetsujici se textovy soubor, kde posledni radka koncila
-                            // prechodem na novy radek pri rolovani dolu na konci souboru dochazelo k vadnemu
-                            // prekreslovani, ocekavam to i u HEX view, nasledujici invalidate zajisti komplet prekresleni
+                            // when viewing a growing text file whose last line ended with a line break,
+                            // scrolling down at the end of the file caused incorrect repainting;
+                            // we expect the same in HEX view, so the following invalidate ensures a full repaint
                             InvalidateRect(HWindow, NULL, FALSE);
                             break;
                         }
                     }
                     if (i + 1 != lines)
-                        ViewSize += len; // jen cele viditelne radky
+                        ViewSize += len; // count only fully visible lines
 
                     s = line;
                     if (len != 0)
@@ -890,7 +890,7 @@ void CViewerWindow::Paint(HDC dc)
                         s += len;
                     }
 
-                    int lineLen = (int)(s - line); // vypis radky
+                    int lineLen = (int)(s - line); // length of the line to print
                     if (OriginX < lineLen)
                     {
                         int u1, u2;
@@ -917,12 +917,12 @@ void CViewerWindow::Paint(HDC dc)
 
                         if (i >= clipFirstRow && i <= clipLastRow)
                         {
-                            RECT myLine = fullLine; // myLine je oblast s textem, kterou budeme kreslit pomalym BitBlt
+                            RECT myLine = fullLine; // myLine is the text area that we will draw with the slower BitBlt path
                             myLine.right = min(myLine.right, (lineLen + 1) * CharWidth);
                             FillRect(Bitmap.HMemDC, &myLine, BkgndBrush);
                             if (lineLen > OriginX)
                             {
-                                char* text = line + OriginX; // posun textu dle OriginX
+                                char* text = line + OriginX; // shift the text buffer according to OriginX
                                 u1 -= (int)OriginX;
                                 if (u1 < 0)
                                     u1 = 0;
@@ -935,14 +935,14 @@ void CViewerWindow::Paint(HDC dc)
                                 t2 -= (int)OriginX;
                                 if (t2 < 0)
                                     t2 = 0;
-                                // vypis textu odzadu - kvuli kurzive
-                                // u2, lineLen - OriginX norm
+                                // render text backwards because of italics
+                                // u2, lineLen - OriginX normal
                                 if (u2 < lineLen - OriginX)
                                 {
                                     MyTextOut(Bitmap.HMemDC, u2 * CharWidth, 0, text + u2,
                                               (int)(lineLen - OriginX - u2));
                                 }
-                                // u1, u2 sel
+                                // u1, u2 selected
                                 if (u1 < u2)
                                 {
                                     SetBkColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_BK_SELECTED]));
@@ -953,12 +953,12 @@ void CViewerWindow::Paint(HDC dc)
                                     SetTextColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_FG_NORMAL]));
                                     SetBkColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_BK_NORMAL]));
                                 }
-                                // t2, u1 norm
+                                // t2, u1 normal
                                 if (t2 < u1)
                                 {
                                     MyTextOut(Bitmap.HMemDC, t2 * CharWidth, 0, text + t2, u1 - t2);
                                 }
-                                // t1, t2 select
+                                // t1, t2 selected
                                 if (t1 < t2)
                                 {
                                     SetBkColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_BK_SELECTED]));
@@ -969,15 +969,15 @@ void CViewerWindow::Paint(HDC dc)
                                     SetTextColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_FG_NORMAL]));
                                     SetBkColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_BK_NORMAL]));
                                 }
-                                // 0, t1 norm
+                                // 0, t1 normal
                                 if (t1 > 0)
                                     MyTextOut(Bitmap.HMemDC, 0, 0, text, t1);
                             }
 
-                            // bitblt celeho radku do obrazovky
-                            BitBlt(dc, BORDER_WIDTH, CharHeight * i, (lineLen + 1) * CharWidth, // kvuli kurzive o prodlouzime radek o znak
+                            // bitblt the entire row to the screen
+                            BitBlt(dc, BORDER_WIDTH, CharHeight * i, (lineLen + 1) * CharWidth, // extend the line by one character so italics fit
                                    CharHeight, Bitmap.HMemDC, 0, 0, SRCCOPY);
-                            // je-li treba, domazeme prostor vpravo
+                            // if needed, clear the space on the right
                             if (myLine.right < fullLine.right)
                             {
                                 myLine.top = CharHeight * i;
@@ -993,7 +993,7 @@ void CViewerWindow::Paint(HDC dc)
                     if (lineOffset == FileSize)
                     {
                         r.left = BORDER_WIDTH;
-                        if (FileSize > 0) // JR: do AS2.52b1 (vcetne) jsme 0-bajtovy soubor v hex zobrazili tak, ze jsme prvni radek nepodmazavali (prijevilo se pri zmene velikosti okna)
+                        if (FileSize > 0) // JR: up to AS2.52b1 (inclusive) we rendered a 0-byte file in hex without clearing the first line (it appeared when resizing the window)
                             r.top = CharHeight * (i + 1);
                         else
                             r.top = 0;
@@ -1015,7 +1015,7 @@ void CViewerWindow::Paint(HDC dc)
                 if (WrapText && SeekY > 0)
                 {
                     __int64 len = Prepare(NULL, SeekY - (SeekY > 1 ? 2 : 1), SeekY > 1 ? 2 : 1, fatalErr);
-                    // if (fatalErr) FatalFileErrorOccured(); // je nize
+                    // if (fatalErr) FatalFileErrorOccured(); // see below
                     if (fatalErr)
                         break;
 
@@ -1030,34 +1030,34 @@ void CViewerWindow::Paint(HDC dc)
                 }
 
                 RECT endRect = fullLine;
-                __int64 lineOffset = SeekY; // offset zacatku radky v bytech
-                BOOL EOL = FALSE;           // TRUE pokud posledni radka koncila EOLem (dalsi radek existuje, muze byt prazdny)
-                int lineEOLSize = 0;        // delka EOLu (CR=1, LF=1, CRLF=2, NULL=1)
+                __int64 lineOffset = SeekY; // offset of the beginning of the line in bytes
+                BOOL EOL = FALSE;           // TRUE if the previous line ended with an EOL (the next line exists, it may be empty)
+                int lineEOLSize = 0;        // length of the EOL (CR=1, LF=1, CRLF=2, NULL=1)
                 for (int i = 0; i < lines; i++)
                 {
                     __int64 len = Prepare(NULL, lineOffset, APROX_LINE_LEN, fatalErr);
-                    // if (fatalErr) FatalFileErrorOccured(); // je nize
+                    // if (fatalErr) FatalFileErrorOccured(); // see below
                     if (fatalErr)
                         break;
                     if (len == 0 && i + 1 != lines && SeekY != 0)
                     {
                         __int64 size = FileSize;
                         FileChanged(NULL, TRUE, fatalErr, FALSE);
-                        // if (fatalErr) FatalFileErrorOccured(); // je nize
+                        // if (fatalErr) FatalFileErrorOccured(); // see below
                         if (fatalErr || ExitTextMode)
                             break;
                         if (size != FileSize)
                         {
-                            setFindOffset = FALSE; // nechame to udelat az pri nasledujicim kole kresleni
+                            setFindOffset = FALSE; // leave it for the next drawing pass
                             LineOffset.DestroyMembers();
                             ViewSize = 0;
                             FindNewSeekY(SeekY, fatalErr);
                             if (fatalErr || ExitTextMode)
                                 break;
                             FirstLineSize = LastLineSize = 0;
-                            // pokud se prohlizel zvetsujici se textovy soubor, kde posledni radka koncila
-                            // prechodem na novy radek pri rolovani dolu na konci souboru dochazelo k vadnemu
-                            // prekreslovani, nasledujici invalidate zajisti komplet prekresleni
+                            // when viewing a growing text file whose last line ended with a line break,
+                            // scrolling down at the end of the file caused incorrect repainting;
+                            // this invalidate call ensures a full repaint
                             InvalidateRect(HWindow, NULL, FALSE);
                             break;
                         }
@@ -1067,7 +1067,7 @@ void CViewerWindow::Paint(HDC dc)
                     {
                         int redrI = i;
                         if (redrI < clipFirstRow)
-                            redrI = clipFirstRow; // nebudeme prekreslovat zbytecne
+                            redrI = clipFirstRow; // avoid repainting unnecessarily
                         r.left = BORDER_WIDTH;
                         r.top = CharHeight * redrI;
                         r.bottom = CharHeight * clipLastRow;
@@ -1076,7 +1076,7 @@ void CViewerWindow::Paint(HDC dc)
                         if (r.top <= r.bottom)
                             FillRect(dc, &r, BkgndBrush);
 
-                        if (EOL) // pridani posledni prazdne radky do pole LineOffset -> radku nelze ignorovat
+                        if (EOL) // add the last empty line to the LineOffset array -> the line cannot be ignored
                         {
                             LineOffset.Add(lineOffset);
                             LineOffset.Add(lineOffset);
@@ -1085,25 +1085,25 @@ void CViewerWindow::Paint(HDC dc)
                         break;
                     }
 
-                    unsigned char* st;                                               // zacatek bufferu s obsahem radky
-                    unsigned char* s2;                                               // zpracovavany znak z bufferu s obsahem radky
-                    __int64 lineLen = 0;                                             // delka radky ve znacich (tabelator != 1 znak)
-                    BOOL lineEndIsWrapped = FALSE;                                   // je konec radky zalomeny kvuli zaplemu wrap rezimu?
-                    __int64 fullLineLen = 0;                                         // delka radky v bytech
-                    __int64 endX = OriginX + (Width - BORDER_WIDTH) / CharWidth + 1; // offset okraje obrazovky ve znacich
-                    BOOL onlyOne = (len == 1);                                       // posledni znak souboru ?
-                    __int64 startSel = min(StartSelection, EndSelection);            // zacatek oznaceni - offset v bytech
+                    unsigned char* st;                                               // start of the buffer with the line content
+                    unsigned char* s2;                                               // processed character from the buffer with the line content
+                    __int64 lineLen = 0;                                             // line length in characters (tab != 1 character)
+                    BOOL lineEndIsWrapped = FALSE;                                   // is the end of the line wrapped because wrap mode is enabled?
+                    __int64 fullLineLen = 0;                                         // line length in bytes
+                    __int64 endX = OriginX + (Width - BORDER_WIDTH) / CharWidth + 1; // screen edge offset in characters
+                    BOOL onlyOne = (len == 1);                                       // last character of the file?
+                    __int64 startSel = min(StartSelection, EndSelection);            // selection start - offset in bytes
                     if (startSel == -1)
                         startSel = 0;
-                    __int64 endSel = max(StartSelection, EndSelection); // konec oznaceni - offset v bytech
+                    __int64 endSel = max(StartSelection, EndSelection); // selection end - offset in bytes
                     if (endSel == -1)
                         endSel = 0;
                     if (startSel == endSel)
                         startSel = endSel = 0;
-                    BOOL startSelDone = startSel <= lineOffset; // zacatek oznaceni uz je nakresleny
-                    BOOL endSelDone = endSel < lineOffset;      // konec oznaceni uz je nakresleny
+                    BOOL startSelDone = startSel <= lineOffset; // the selection start has already been drawn
+                    BOOL endSelDone = endSel < lineOffset;      // the selection end has already been drawn
 
-                    __int64 tabSpaces = 0; // posun kvuli tabelatorum
+                    __int64 tabSpaces = 0; // shift caused by tabs
                     EOL = FALSE;
                     lineEOLSize = 0;
                     while (len != 0)
@@ -1111,7 +1111,7 @@ void CViewerWindow::Paint(HDC dc)
                         st = s2 = Buffer + (lineOffset + fullLineLen - Seek);
                         while (len--)
                         {
-                            if (*s2 == '\r') // 'konec radky \r' nebo '\r\n'
+                            if (*s2 == '\r') // 'end of line \r' or '\r\n'
                             {
                                 BOOL ok = FALSE;
                                 if (len > 0)
@@ -1135,7 +1135,7 @@ void CViewerWindow::Paint(HDC dc)
                                 else
                                 {
                                     if (!onlyOne)
-                                    { // radka jeste neskoncila, za hranici muze byt '\n'
+                                    { // the line has not ended yet; there may be '\n' beyond the boundary
                                         if (Configuration.EOL_CRLF)
                                         {
                                             len = -1;
@@ -1157,7 +1157,7 @@ void CViewerWindow::Paint(HDC dc)
                                         if (Configuration.EOL_CR)
                                         {
                                             ok = TRUE;
-                                            s2++; // posledni znak souboru je '\r'
+                                            s2++; // the last character of the file is '\r'
                                             EOL = TRUE;
                                             lineEOLSize = 1;
                                         }
@@ -1171,7 +1171,7 @@ void CViewerWindow::Paint(HDC dc)
                             }
                             else
                             {
-                                if (*s2 == '\n' || *s2 == 0) // konec radky '\n' nebo 0
+                                if (*s2 == '\n' || *s2 == 0) // end of line '\n' or 0
                                 {
                                     if ((*s2 == '\n') ? Configuration.EOL_LF : Configuration.EOL_NULL)
                                     {
@@ -1201,7 +1201,7 @@ void CViewerWindow::Paint(HDC dc)
                                         int tab = (int)(Configuration.TabSize - (lineLen % Configuration.TabSize));
                                         if (WrapText && lineLen + tab - 1 >= columns)
                                         {
-                                            tab = (int)max(1, columns - lineLen); // max. ke kraji, minimalne 1 znak
+                                            tab = (int)max(1, columns - lineLen); // at most to the edge, at least 1 character
                                         }
                                         tabSpaces += tab - 1;
                                         if (lineLen > OriginX - tab && endX > lineLen)
@@ -1225,14 +1225,14 @@ void CViewerWindow::Paint(HDC dc)
                                     TRACE_E("something's wrong");
 #endif // _DEBUG
                                 lineEndIsWrapped = TRUE;
-                                break; // predcasny konec radky
+                                break; // premature end of line
                             }
                             s2++;
                             lineLen++;
                         }
                         fullLineLen += s2 - st;
 
-                        // test na delku textove radky (nad 10000 znaku nabizime HEX mod)
+                        // test the text line length (over 10000 characters we offer HEX mode)
                         if (CanSwitchToHex && !ForceTextMode && fullLineLen > TEXT_MAX_LINE_LEN)
                         {
                             if (!CanSwitchQuietlyToHex)
@@ -1252,22 +1252,22 @@ void CViewerWindow::Paint(HDC dc)
                             }
                         }
 
-                        if (len == -1) // radka pokracuje do zatim nenacteneho useku
+                        if (len == -1) // the line continues into a yet unread section
                         {
                             len = Prepare(NULL, lineOffset + fullLineLen, APROX_LINE_LEN, fatalErr);
-                            // if (fatalErr) FatalFileErrorOccured(); // je nize
+                            // if (fatalErr) FatalFileErrorOccured(); // see below
                             if (fatalErr)
                                 break;
                             onlyOne = (len == 1);
                         }
                         else
-                            break; // radka je nactena cela
+                            break; // the entire line has been loaded
                     }
                     if (fatalErr || ExitTextMode)
                         break;
-                    LineOffset.Add(lineOffset);                             // offset zacatku radku
-                    LineOffset.Add(lineOffset + fullLineLen - lineEOLSize); // offset konce radku (pred EOL)
-                    LineOffset.Add(lineLen);                                // delka radku v zobrazenych znacich (TAB je vic znaku)
+                    LineOffset.Add(lineOffset);                             // line start offset
+                    LineOffset.Add(lineOffset + fullLineLen - lineEOLSize); // line end offset (before EOL)
+                    LineOffset.Add(lineLen);                                // line length in displayed characters (TAB is more characters)
                     if (!startSelDone)
                         startSel += tabSpaces;
                     if (!endSelDone)
@@ -1277,7 +1277,7 @@ void CViewerWindow::Paint(HDC dc)
                     {
                         int len2 = (Width - BORDER_WIDTH) / CharWidth;
                         if (len2 - 2 * xRollLimit < endSel - startSel)
-                        { // siroke retezce zkusime zobrazit co nejvice, takze xRollLimit -> 0
+                        { // try to show as much of long strings as possible, so set xRollLimit -> 0
                             xRollLimit = (len2 - (endSel - startSel)) / 2;
                             if (xRollLimit < 0)
                                 xRollLimit = 0;
@@ -1287,7 +1287,7 @@ void CViewerWindow::Paint(HDC dc)
                         if (startSel < lineOffset + lineLen)
                         {
                             __int64 originX = OriginX;
-                            if (startSel < left) // pohled je prilis vpravo
+                            if (startSel < left) // the view is too far to the right
                             {
                                 originX = startSel - lineOffset - xRollLimit;
                                 if (originX < 0)
@@ -1297,7 +1297,7 @@ void CViewerWindow::Paint(HDC dc)
                             {
                                 if (startSel >= right ||
                                     endSel < lineOffset + lineLen && endSel >= right)
-                                { // pohled je prilis vlevo
+                                { // the view is too far to the left
                                     originX = startSel - lineOffset - xRollLimit;
                                     if (originX < 0)
                                         originX = 0;
@@ -1307,15 +1307,15 @@ void CViewerWindow::Paint(HDC dc)
                                     originX = min(originX, originX2);
                                 }
                             }
-                            if (originX != OriginX) // doslo ke zmene
+                            if (originX != OriginX) // there was a change
                             {
-                                setFindOffset = FALSE; // reset FindOffset tu asi nehrozi, ale kdyby byl potreba, udelame ho az pri nasledujicim kole kresleni
+                                setFindOffset = FALSE; // resetting FindOffset probably is not needed here, but if it is, we will do it during the next drawing pass
                                 OriginX = originX;
                                 InvalidateRect(HWindow, NULL, FALSE);
-                                break; // je potreba zacit znovu
+                                break; // need to start over
                             }
                             else
-                                ScrollToSelection = FALSE; // neni potreba
+                                ScrollToSelection = FALSE; // not necessary
                         }
                     }
 
@@ -1323,7 +1323,7 @@ void CViewerWindow::Paint(HDC dc)
                         FirstLineSize = fullLineLen;
                     if (i + 1 < lines)
                     {
-                        ViewSize += fullLineLen; // jen cele viditelne radky
+                        ViewSize += fullLineLen; // count only fully visible lines
                         if (i + 2 == lines)
                             LastLineSize = fullLineLen;
                     }
@@ -1357,8 +1357,8 @@ void CViewerWindow::Paint(HDC dc)
 
                         if (i >= clipFirstRow && i <= clipLastRow)
                         {
-                            RECT myLine = fullLine;                                        // myLine je oblast s textem, kterou budeme kreslit pomalym BitBlt
-                            myLine.right = min(myLine.right, (int)(len2 + 1) * CharWidth); // znak navic kvuli kurzive
+                            RECT myLine = fullLine;                                        // myLine is the text area that we will draw with the slower BitBlt path
+                            myLine.right = min(myLine.right, (int)(len2 + 1) * CharWidth); // allow one extra character so italics fit
 
                             if (blackEnd)
                             {
@@ -1373,7 +1373,7 @@ void CViewerWindow::Paint(HDC dc)
                                 FillRect(Bitmap.HMemDC, &myLine, BkgndBrush);
 
                             if (lineLen > OriginX)
-                            { // vypis textu do Bitmap.HMemDC
+                            { // output text to Bitmap.HMemDC
                                 if (u3 > 0)
                                     MyTextOut(Bitmap.HMemDC, (int)((u1 + u2) * CharWidth), 0, line + u1 + u2, (int)u3);
                                 if (u2 > 0)
@@ -1390,11 +1390,11 @@ void CViewerWindow::Paint(HDC dc)
                                     MyTextOut(Bitmap.HMemDC, 0, 0, line, (int)u1);
                             }
 
-                            // bitblt celeho radku do obrazovky
+                            // bitblt the entire row to the screen
                             BitBlt(dc, BORDER_WIDTH, CharHeight * i, myLine.right,
                                    CharHeight, Bitmap.HMemDC, 0, 0, SRCCOPY);
 
-                            // je-li treba, domazeme prostor vpravo
+                            // if needed, clear the space on the right
                             if (myLine.right < fullLine.right)
                             {
                                 myLine.top = CharHeight * i;
@@ -1445,14 +1445,14 @@ void CViewerWindow::Paint(HDC dc)
         SetScrollBar();
         //    SetCursor(oldCursor);
     }
-    else // udelame alespon vymaz obrazovky
+    else // at least clear the screen
     {
         RECT r;
         r.left = 0;
         r.right = Width;
         r.top = 0;
         r.bottom = Height;
-        FillRect(dc, &r, BkgndBrush); // vymaz sloupce vlevo od textu
+        FillRect(dc, &r, BkgndBrush); // clear the column to the left of the text
         SetScrollBar();
     }
 }
@@ -1575,7 +1575,7 @@ void ClearViewerHistory(BOOL dataOnly)
 
     if (!dataOnly)
     {
-        // mame podriznout take combobox v otevrenych Find oknech
+        // also clear the combobox in any open Find windows
         ViewerWindowQueue.BroadcastMessage(WM_USER_CLEARHISTORY, 0, 0);
     }
 }
@@ -1584,7 +1584,7 @@ void ReleaseViewer()
 {
     if (ViewerMenu != NULL)
         DestroyMenu(ViewerMenu);
-    ClearViewerHistory(TRUE); // chceme pouze podriznout data
+    ClearViewerHistory(TRUE); // we only want to clear the data
     if (ViewerContinue != NULL)
         HANDLES(CloseHandle(ViewerContinue));
     HANDLES(DeleteCriticalSection(&ViewerFontMeasureCS));
@@ -1629,9 +1629,9 @@ void CViewerWindow::SetViewerFont()
 
         HANDLES(EnterCriticalSection(&ViewerFontMeasureCS));
 
-        // Vista: font fixedsys obsahuje znaky, ktere nemaji ocekavanou sirku (i kdyz je to fixed-width font), proto
-        // omerujeme jednotlive znaky a ty ktere nemaji spravnou sirku mapujeme na nahradni znak o spravne sirce
-        if (!WindowsXP64AndLater && !ViewerFontMeasured) // pred XP64 a Vistou jsme na tuhle prasecinku nenarazili, takze to nebudeme ani testovat (na XP, W2K, NT4, atd.)
+        // Vista: the fixedsys font contains characters that do not have the expected width (even though it is a fixed-width font), therefore
+        // we measure individual characters and map those with an incorrect width to a replacement character with the correct width
+        if (!WindowsXP64AndLater && !ViewerFontMeasured) // before XP64 and Vista we did not run into this mess, so we will not even test it (on XP, W2K, NT4, etc.)
         {
             ViewerFontMeasured = TRUE;
             ViewerFontNeedsMapping = FALSE;
@@ -1659,7 +1659,7 @@ void CViewerWindow::SetViewerFont()
                 {
                     if (rect.right - rect.left != CharWidth)
                     {
-                        if (x == 0xB7 /* middle dot */) // pokud je 'middle-dot' take spatne siroky, substituujeme za mezeru, ktera snad musi byt OK
+                        if (x == 0xB7 /* middle dot */) // if the middle dot is also incorrectly wide, substitute a space, which should be OK
                         {
                             substChar = ' ';
                             int z;

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -3,27 +3,26 @@
 
 #pragma once
 
-#define VIEW_BUFFER_SIZE 60000 // 0.5 * VIEW_BUFFER_SIZE musi byt > max. delka \
-                               // zobrazitelneho radku
-#define BORDER_WIDTH 3         // oddeluje text od okraje okna
+#define VIEW_BUFFER_SIZE 60000 // 0.5 * VIEW_BUFFER_SIZE must be > max. length of a displayable line
+#define BORDER_WIDTH 3         // separates the text from the window edge
 #define APROX_LINE_LEN 1000
 
-#define FIND_TEXT_LEN 201                    // +1; POZOR: melo by byt shodne s GREP_TEXT_LEN
-#define FIND_LINE_LEN 10000                  // musi byt > FIND_TEXT_LEN i max. delka radky pro REGEXP (pro GREP jine makro)
-#define TEXT_MAX_LINE_LEN 10000              // pri delsi radce se ptame na prechod do hexa rezimu, musi byt <= FIND_LINE_LEN
-#define RECOGNIZE_FILE_TYPE_BUFFER_LEN 10000 // kolik znaku ze zacatku souboru se ma pouzit pro rozpoznavani typu souboru (RecognizeFileType())
+#define FIND_TEXT_LEN 201                    // +1; WARNING: should match GREP_TEXT_LEN
+#define FIND_LINE_LEN 10000                  // must be > FIND_TEXT_LEN and the max line length for REGEXP (different macro for GREP)
+#define TEXT_MAX_LINE_LEN 10000              // when a line is longer we ask about switching to hex mode; must be <= FIND_LINE_LEN
+#define RECOGNIZE_FILE_TYPE_BUFFER_LEN 10000 // how many characters from the start of the file to use to recognize the file type (RecognizeFileType())
 
-#define VIEWER_HISTORY_SIZE 30 // pocet pamatovanych stringu
+#define VIEWER_HISTORY_SIZE 30 // number of remembered strings
 
-// menu positions - pri zmene menu predelat !
-#define VIEWER_FILE_MENU_INDEX 0         // v hlavnim menu viewru
-#define VIEWER_FILE_MENU_OTHFILESINDEX 3 // v submenu File hlavniho menu viewru
-#define VIEWER_EDIT_MENU_INDEX 1         // v hlavnim menu viewru
-#define VIEW_MENU_INDEX 3                // v hlavnim menu viewru
-#define CODING_MENU_INDEX 4              // v hlavnim menu viewru
-#define OPTIONS_MENU_INDEX 5             // v hlavnim menu viewru
+// menu positions - redo when the menu changes!
+#define VIEWER_FILE_MENU_INDEX 0         // in the viewer main menu
+#define VIEWER_FILE_MENU_OTHFILESINDEX 3 // in the File submenu of the viewer main menu
+#define VIEWER_EDIT_MENU_INDEX 1         // in the viewer main menu
+#define VIEW_MENU_INDEX 3                // in the viewer main menu
+#define CODING_MENU_INDEX 4              // in the viewer main menu
+#define OPTIONS_MENU_INDEX 5             // in the viewer main menu
 
-#define WM_USER_VIEWERREFRESH WM_APP + 201 // [0, 0] - ma se provest refresh
+#define WM_USER_VIEWERREFRESH WM_APP + 201 // [0, 0] - perform a refresh
 
 #ifndef INSIDE_SALAMANDER
 char* LoadStr(int resID);
@@ -83,7 +82,7 @@ public:
 protected:
     virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-    int CancelHexMode, // jen pro spravnou funkci tlacitka Cancel
+    int CancelHexMode, // only for the Cancel button to work correctly
         CancelRegular;
 };
 
@@ -121,7 +120,7 @@ public:
                   int enumFileNamesLastFileIndex);
     ~CViewerWindow();
 
-    void OpenFile(const char* file, const char* caption, BOOL wholeCaption); // neovlada Lock
+    void OpenFile(const char* file, const char* caption, BOOL wholeCaption); // does not manage Lock
 
     virtual BOOL Is(int type) { return type == otViewerWindow || CWindow::Is(type); }
     BOOL IsGood() { return Buffer != NULL && ViewerFont != NULL; }
@@ -151,58 +150,56 @@ public:
         }
     }
 
-    HANDLE GetLockObject(); // objekt pro disk-cache - view ze ZIPu
+    HANDLE GetLockObject(); // object for the disk cache - viewing from a ZIP
     void CloseLockObject();
 
-    void ConfigHasChanged(); // vola se po OK v konfiguracnim dialogu
+    void ConfigHasChanged(); // called after OK in the configuration dialog
 
-    // vraci text pro Find - (null-terminated) oznaceny blok, 'buf' je min.
-    // FIND_TEXT_LEN bytu; vraci TRUE pokud je buf naplnen (existuje blok, atd.); vraci pocet
-    // zapsanych znaku bez null-terminatoru do 'len'
+    // returns text for Find - the (null-terminated) selected block; 'buf' is at least
+    // FIND_TEXT_LEN bytes; returns TRUE if the buffer is filled (a block exists, etc.); returns the number
+    // of written characters without the null terminator into 'len'
     BOOL GetFindText(char* buf, int& len);
 
 protected:
-    void FatalFileErrorOccured(DWORD repeatCmd = -1); // vola se pokud nastane chyba v souboru (nutny refresh/clear viewru)
+    void FatalFileErrorOccured(DWORD repeatCmd = -1); // called when a file error occurs (viewer refresh/clear is required)
 
     void OnVScroll();
 
     void CodeCharacters(unsigned char* start, unsigned char* end);
-    // pokud je 'hFile' NULL, Prepare/LoadBefore/LoadBehind si soubor otevrou a zavrou
-    // pokud 'hFile' ukazuje na promennou (na zacatku inicializovat jeji hodnotu na NULL),
-    // metody si soubor otevrou a nastavi handle souboru do teto promenne (v pripade uspesneho otevreni).
-    // Pri pristim volani jiz soubor neoteviraji a pouziji handle z teto promenne.
-    // Pri odchodu handle nezaviraji, to uz si musi zajistit volajici. Jedna se o
-    // optimalizaci pro sitove disky, kde opakovane otvirani/zavirani souboru ukrutne
-    // zdrzovalo pri hledani.
+    // if 'hFile' is NULL, Prepare/LoadBefore/LoadBehind open and close the file themselves
+    // if 'hFile' points to a variable (initialize its value to NULL at the start),
+    // the methods open the file and store the file handle into that variable (when opening succeeds).
+    // On the next call they do not open the file again and reuse the handle from that variable.
+    // They also do not close the handle when exiting; the caller must handle that. This is an
+    // optimization for network drives where repeatedly opening/closing the file slowed down searching terribly.
     BOOL LoadBefore(HANDLE* hFile);
     BOOL LoadBehind(HANDLE* hFile);
 
-    // pokud doslo k chybe cteni, je fatalErr == TRUE, ExitTextMode tu nevznika (nestava se TRUE)
+    // if a read error occurs, fatalErr == TRUE; ExitTextMode does not arise here (it does not become TRUE)
     __int64 Prepare(HANDLE* hFile, __int64 offset, __int64 bytes, BOOL& fatalErr);
 
     void GoToEnd() { SeekY = MaxSeekY; }
-    // pokud doslo k chybe cteni, je fatalErr == TRUE, ExitTextMode je TRUE pokud se prepina do Hex rezimu
+    // if a read error occurs, fatalErr == TRUE; ExitTextMode is TRUE when switching to hex mode
     void FileChanged(HANDLE file, BOOL testOnlyFileSize, BOOL& fatalErr, BOOL detectFileType,
                      BOOL* calledHeightChanged = NULL);
-    // pokud doslo k chybe cteni, je fatalErr == TRUE, ExitTextMode je TRUE pokud se prepina do Hex rezimu
+    // if a read error occurs, fatalErr == TRUE; ExitTextMode is TRUE when switching to hex mode
     void HeightChanged(BOOL& fatalErr);
-    // pokud doslo k chybe cteni, je fatalErr == TRUE, ExitTextMode je TRUE pokud se prepina do Hex rezimu
+    // if a read error occurs, fatalErr == TRUE; ExitTextMode is TRUE when switching to hex mode
     __int64 ZeroLineSize(BOOL& fatalErr, __int64* firstLineEndOff = NULL, __int64* firstLineCharLen = NULL);
 
-    // jen pro textove zobrazeni, pokud doslo k chybe cteni, je fatalErr == TRUE, ExitTextMode je
-    // TRUE pokud se prepina do Hex rezimu
+    // text view only; if a read error occurs, fatalErr == TRUE; ExitTextMode is TRUE when switching to hex mode
     __int64 FindSeekBefore(__int64 seek, int lines, BOOL& fatalErr, __int64* firstLineEndOff = NULL,
                            __int64* firstLineCharLen = NULL, BOOL addLineIfSeekIsWrap = FALSE);
-    // 'hFile' parametr viz komentar k Prepare(), pokud doslo k chybe cteni, je fatalErr == TRUE,
-    // ExitTextMode tu nevznika (nestava se TRUE)
+    // 'hFile' parameter, see the comment for Prepare(); if a read error occurs, fatalErr == TRUE;
+    // ExitTextMode does not arise here (it does not become TRUE)
     BOOL FindNextEOL(HANDLE* hFile, __int64 seek, __int64 maxSeek, __int64& lineEnd, __int64& nextLineBegin, BOOL& fatalErr);
-    // pokud doslo k chybe cteni, je fatalErr == TRUE, ExitTextMode je TRUE pokud se prepina do Hex rezimu
+    // if a read error occurs, fatalErr == TRUE; ExitTextMode is TRUE when switching to hex mode
     BOOL FindPreviousEOL(HANDLE* hFile, __int64 seek, __int64 minSeek, __int64& lineBegin,
                          __int64& previousLineEnd, BOOL allowWrap,
                          BOOL takeLineBegin, BOOL& fatalErr, int* lines, __int64* firstLineEndOff = NULL,
                          __int64* firstLineCharLen = NULL, BOOL addLineIfSeekIsWrap = FALSE);
 
-    // pokud doslo k chybe cteni, je fatalErr == TRUE, ExitTextMode je TRUE pokud se prepina do Hex rezimu
+    // if a read error occurs, fatalErr == TRUE; ExitTextMode is TRUE when switching to hex mode
     __int64 FindBegin(__int64 seek, BOOL& fatalErr);
     void ChangeType(CViewType type);
 
@@ -210,82 +207,80 @@ protected:
     void SetScrollBar();
     virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-    // postne WM_MOUSEMOVE (pouziva se k posunu konce bloku na nove souradnice mysi nebo
-    // prepocitani konce bloku pri posunu view)
+    // posts WM_MOUSEMOVE (used to move the block end to new mouse coordinates or
+    // to recalculate the block end when the view shifts)
     void PostMouseMove();
 
-    // posun view o radek nahoru
+    // scroll the view one line up
     BOOL ScrollViewLineUp(DWORD repeatCmd = -1, BOOL* scrolled = NULL, BOOL repaint = TRUE,
                           __int64* firstLineEndOff = NULL, __int64* firstLineCharLen = NULL);
 
-    // posun view o radek dolu
+    // scroll the view one line down
     BOOL ScrollViewLineDown(BOOL fullRedraw = FALSE);
 
-    // invalidate + pripadne update vybranych radek viewu
+    // invalidate and optionally update selected rows of the view
     void InvalidateRows(int minRow, int maxRow, BOOL update = TRUE);
 
-    // pripadne posune OriginX, aby byla videt x-ova souradnice 'x' ve view
+    // adjust OriginX if needed so that the x coordinate 'x' is visible in the view
     void EnsureXVisibleInView(__int64 x, BOOL showPrevChar, BOOL& fullRedraw,
                               __int64 newFirstLineLen = -1, BOOL ignoreFirstLine = FALSE,
                               __int64 maxLineLen = -1);
 
-    // zjisti maximalni delku viditelne radky ve view (textovy rezim: musi byt prekresleno,
-    // jinak je neaktualni LineOffset)
+    // determine the maximum length of a visible line in the view (text mode: must be repainted,
+    // otherwise LineOffset is outdated)
     __int64 GetMaxVisibleLineLen(__int64 newFirstLineLen = -1, BOOL ignoreFirstLine = FALSE);
 
-    // zjisti maximum pro OriginX pro soucasne view (textovy rezim: musi byt prekresleno,
-    // jinak je neaktualni LineOffset)
+    // determine the maximum OriginX for the current view (text mode: must be repainted,
+    // otherwise LineOffset is outdated)
     __int64 GetMaxOriginX(__int64 newFirstLineLen = -1, BOOL ignoreFirstLine = FALSE, __int64 maxLineLen = -1);
 
-    // zjisti x-ovou souradnici 'x' pozice 'offset' v souboru na radku; neni-li 'lineInView' -1,
-    // vezme se radka 'lineInView' z LineOffset a 'lineBegOff', 'lineCharLen' a 'lineEndOff' se
-    // ignoruji
+    // determine the x coordinate 'x' of position 'offset' in the file on the line; if 'lineInView' is not -1,
+    // use the line 'lineInView' from LineOffset and ignore 'lineBegOff', 'lineCharLen', and 'lineEndOff'
     BOOL GetXFromOffsetInText(__int64* x, __int64 offset, int lineInView, __int64 lineBegOff = -1,
                               __int64 lineCharLen = -1, __int64 lineEndOff = -1);
 
-    // zjisti nejblizsi pozici 'offset' v souboru pro navrhovanou x-ovou souradnici 'suggestedX' v radku,
-    // v 'x' vraci x-ovou souradnici pozice 'offset' v souboru na radku; neni-li 'lineInView' -1,
-    // vezme se radka 'lineInView' z LineOffset a 'lineBegOff', 'lineCharLen' a 'lineEndOff' se
-    // ignoruji
+    // find the closest file position 'offset' for the suggested x coordinate 'suggestedX' on the line;
+    // returns in 'x' the x coordinate of position 'offset' in the file on the line; if 'lineInView' is not -1,
+    // use the line 'lineInView' from LineOffset and ignore 'lineBegOff', 'lineCharLen', and 'lineEndOff'
     BOOL GetOffsetFromXInText(__int64* x, __int64* offset, __int64 suggestedX, int lineInView,
                               __int64 lineBegOff = -1, __int64 lineCharLen = -1,
                               __int64 lineEndOff = -1);
 
-    // vraci offset v souboru podle souradnic [x, y] na obrazovce; je-li 'leftMost'
-    // FALSE je ruzny offset leve a prave pulky znaku, je-li TRUE pak kdekoliv na znaku
-    // je stale stejny offset (offset tohoto znaku) - pouziva se pri detekci kliknuti do bloku;
-    // je-li 'onHexNum' != NULL, a jde o hex rezim a [x, y] je na hex cislici nebo na znaku,
-    // bude '*onHexNum'==TRUE
-    // pokud doslo k chybe cteni, je fatalErr == TRUE, ExitTextMode tu nevznika (nestava se TRUE)
+    // return the file offset based on the [x, y] coordinates on the screen; if 'leftMost'
+    // is FALSE the left and right halves of a character correspond to different offsets, if TRUE any point on the character
+    // shares the same offset (the offset of that character) - used when detecting a click inside a block;
+    // if 'onHexNum' != NULL and we are in hex mode and [x, y] is on a hex digit or a character,
+    // '*onHexNum' becomes TRUE
+    // if a read error occurs, fatalErr == TRUE; ExitTextMode does not arise here (it does not become TRUE)
     BOOL GetOffset(__int64 x, __int64 y, __int64& offset, BOOL& fatalErr, BOOL leftMost = FALSE,
                    BOOL* onHexNum = NULL);
 
-    // vraci offset 'offset' v souboru na x-ove souradnici 'x' v radce zacinajici na offsetu
-    // 'lineBegOff' o delce 'lineCharLen' zobrazenych znaku (expandovane taby, v hex rezimu se
-    // nepouziva, dat na 0) a koncici na offsetu 'lineEndOff' (v hex rezimu se nepouziva, dat na 0);
-    // v 'offsetX' vraci x-ovou souradnici 'offset' (udelane jen pro textovy rezim, nemusi se
-    // shodovat s 'x'); je-li 'onHexNum' != NULL, a jde o hex rezim a na x-ove souradnici 'x' je
-    // hexa cislice nebo znak, bude '*onHexNum'==TRUE; pokud doslo k chybe cteni, je fatalErr == TRUE,
-    // ExitTextMode tu nevznika (nestava se TRUE); je-li 'getXFromOffset' TRUE (umime jen pro
-    // textovy rezim view, 'offset', 'offsetX' a 'onHexNum' dat NULL), vraci misto offsetu
-    // souradnici X (ve 'foundX') znaku na offsetu 'findOffset'
+    // return the file offset 'offset' at x coordinate 'x' on a line beginning at the offset
+    // 'lineBegOff' with a length of 'lineCharLen' displayed characters (expanded tabs; in hex mode this is
+    // not used in hex mode, set to 0) and ending at 'lineEndOff' (not used in hex mode, set to 0);
+    // returns in 'offsetX' the x coordinate of 'offset' (implemented only for text mode and
+    // not necessarily equal to 'x'); if 'onHexNum' != NULL and we are in hex mode and the x coordinate 'x' is on
+    // a hex digit or character, '*onHexNum' becomes TRUE; if a read error occurs, fatalErr == TRUE;
+    // ExitTextMode does not arise here (it does not become TRUE); if 'getXFromOffset' is TRUE (we support it only for
+    // the text view; set 'offset', 'offsetX', and 'onHexNum' to NULL), return the X coordinate (in 'foundX')
+    // of the character at offset 'findOffset'
     BOOL GetOffsetOrXAbs(__int64 x, __int64* offset, __int64* offsetX, __int64 lineBegOff, __int64 lineCharLen,
                          __int64 lineEndOff, BOOL& fatalErr, BOOL* onHexNum, BOOL getXFromOffset = FALSE,
                          __int64 findOffset = -1, __int64* foundX = NULL);
 
-    // u velke selectiony (nad 100MB) se zepta usera, jestli vazne chce alokovat selectionu
-    // pro D&D nebo clipboard
+    // for a large selection (over 100 MB) ask the user whether they really want to allocate the selection
+    // for drag & drop or the clipboard
     BOOL CheckSelectionIsNotTooBig(HWND parent, BOOL* msgBoxDisplayed = NULL);
 
-    // pokud doslo k chybe cteni, je fatalErr == TRUE, ExitTextMode tu nevznika (nestava se TRUE)
-    HGLOBAL GetSelectedText(BOOL& fatalErr); // text pro operace s clipboardem a drag&drop
+    // if a read error occurs, fatalErr == TRUE; ExitTextMode does not arise here (it does not become TRUE)
+    HGLOBAL GetSelectedText(BOOL& fatalErr); // text for clipboard and drag & drop operations
 
     void SetToolTipOffset(__int64 offset);
 
     void SetViewerCaption();
 
-    // nastaveni CodeType + UseCodeTable + CodeTable + titulku okna
-    // POZOR: je nutne, aby CodeTables.Valid(c) vracelo TRUE
+    // set CodeType + UseCodeTable + CodeTable + window caption
+    // WARNING: CodeTables.Valid(c) must return TRUE
     void SetCodeType(int c);
 
     BOOL CreateViewerBrushs();
@@ -302,104 +297,103 @@ protected:
 
     void FindNewSeekY(__int64 newSeekY, BOOL& fatalErr);
 
-    // interne vola SalMessageBox, jen pro nej zablokuje Paint (jen maze pozadi vieweru, nesaha na soubor)
+    // calls SalMessageBox internally and blocks Paint just for it (only clears the viewer background, does not touch the file)
     int SalMessageBoxViewerPaintBlocked(HWND hParent, LPCTSTR lpText, LPCTSTR lpCaption, UINT uType);
 
-    unsigned char* Buffer; // Buffer o velikosti VIEW_BUFFER_SIZE
-    char* FileName;        // aktualne prohlizeny soubor
-    __int64 Seek,          // offset 0. bytu v Bufferu v souboru
-        Loaded,            // pocet platnych bytu v Bufferu
-        OriginX,           // prvni zobrazeny sloupec (ve znacich)
-        SeekY,             // seek prvniho zobrazeneho radku
-        MaxSeekY,          // seek konce prohlizeneho souboru
-        FileSize,          // velikost souboru
-        ViewSize,          // velikost zobrazovaneho useku souboru (v bytech)
-        FirstLineSize,     // velikost 1. zobrazene radky (v bytech)
-        LastLineSize;      // velikost posledni cele zobrazene radky (v bytech)
+    unsigned char* Buffer; // buffer with size VIEW_BUFFER_SIZE
+    char* FileName;        // currently viewed file
+    __int64 Seek,          // offset of byte 0 in Buffer within the file
+        Loaded,            // number of valid bytes in Buffer
+        OriginX,           // first displayed column (in characters)
+        SeekY,             // seek of the first displayed line
+        MaxSeekY,          // seek of the end of the viewed file
+        FileSize,          // file size
+        ViewSize,          // size of the displayed portion of the file (in bytes)
+        FirstLineSize,     // size of the first displayed line (in bytes)
+        LastLineSize;      // size of the last fully displayed line (in bytes)
 
-    __int64 StartSelection,           // seek zacatku oznaceni (od toho znaku vcetne) (-1 = zadna selectiona jeste nebyla)
-        EndSelection;                 // seek konce oznaceni (az k tomu znaku ne vcetne) (-1 = zadna selectiona jeste nebyla)
-    int TooBigSelAction;              // D&D nebo auto-/copy-to-clip bloku nad 100MB: 0 = zeptat se, 1 = ANO, 2 = NE
-    int EndSelectionRow;              // y offset radky, ve ktere je EndSelection(relativni k client area)
-                                      // validni pouze pri tazeni bloku; slouzi k optimalizaci paintu
-                                      // pokud je -1, optimalizace se neprovede
-    __int64 EndSelectionPrefX;        // preferovana x-ova souradnice pri tazeni konce bloku pres Shift+sipky nahoru/dolu (-1 = neni)
-    TDirectArray<__int64> LineOffset; // pole s offsety zacatku + koncu (bez EOLu) radek + delkama v zobrazenych znacich (pro kazdou radku trojice cisel)
-    BOOL WrapIsBeforeFirstLine;       // jen u text-view pri wrap rezimu: pred prvni radkou view je wrap (a ne EOL)
-    BOOL MouseDrag;                   // tahne blok mysi ?
-    BOOL ChangingSelWithShiftKey;     // meni oznaceni pres Shift+klavesu (sipky, End, Home)
+    __int64 StartSelection,           // seek of the selection start (including that character) (-1 = no selection yet)
+        EndSelection;                 // seek of the selection end (up to but not including that character) (-1 = no selection yet)
+    int TooBigSelAction;              // D&D or auto-/copy-to-clip of blocks over 100 MB: 0 = ask, 1 = YES, 2 = NO
+    int EndSelectionRow;              // y offset of the line containing EndSelection (relative to the client area)
+                                      // valid only during block dragging; used to optimize painting
+                                      // if it is -1, the optimization is skipped
+    __int64 EndSelectionPrefX;        // preferred x coordinate when dragging the block end via Shift+up/down arrows (-1 = none)
+    TDirectArray<__int64> LineOffset; // array with offsets of line beginnings and ends (without EOL) plus lengths in displayed characters (a triple per line)
+    BOOL WrapIsBeforeFirstLine;       // text view only in wrap mode: the line before the first view line is a wrap (not an EOL)
+    BOOL MouseDrag;                   // is the block being dragged with the mouse?
+    BOOL ChangingSelWithShiftKey;     // is the selection being changed via Shift+key (arrows, End, Home)
 
     CFindSetDialog FindDialog;
     CSearchData SearchData;
     CRegularExpression RegExp;
-    __int64 FindOffset,              // seek od ktereho hledat
-        LastFindSeekY,               // seek zacatku prvniho radku obrazovky po hledani, pro detekci pohybu sem-tam
-        LastFindOffset;              // seek od ktereho se ma hledat (nastaveny po hledani), pro detekci pohybu sem-tam
-    BOOL ResetFindOffsetOnNextPaint; // TRUE = nastavit FindOffset pri nasledujicim WM_PAINT (az po vykresleni okna se zjisti velikost viditelne stranky a lze nastavit FindOffset i pro hledani pozpatku)
-    BOOL SelectionIsFindResult;      // TRUE = oznaceni vzniklo jako vysledek findu
+    __int64 FindOffset,              // seek from which to search
+        LastFindSeekY,               // seek of the first screen line after searching, for detecting back-and-forth movement
+        LastFindOffset;              // seek from which to search (set after searching), for detecting back-and-forth movement
+    BOOL ResetFindOffsetOnNextPaint; // TRUE = set FindOffset during the next WM_PAINT (the visible page size is known only after drawing, enabling FindOffset to be set even for backward searches)
+    BOOL SelectionIsFindResult;      // TRUE = the selection was created as a search result
 
     int DefViewMode; // 0 = Auto-Select, 1 = Text, 2 = Hex
-    CViewType Type;  // typ zobrazeni
-    BOOL EraseBkgnd; // aby se jednou nazacatku smazalo pozadi
+    CViewType Type;  // display type
+    BOOL EraseBkgnd; // ensure the background is cleared once at the beginning
 
-    int Width,  // sirka okna (v bodech)
-        Height; // vyska okna (v bodech)
+    int Width,  // window width (in points)
+        Height; // window height (in points)
 
-    BOOL EnablePaint; // kvuli rekurzivnimu volani Paintu pri chybach: FALSE = jen maze pozadi vieweru (nesaha na soubor)
+    BOOL EnablePaint; // for recursive Paint calls on errors: FALSE = only clear the viewer background (leave the file alone)
 
-    BOOL ScrollToSelection; // pri dalsim kresleni se odsune na pozici oznaceni (OriginX)
+    BOOL ScrollToSelection; // during the next drawing shift to the selection position (OriginX)
 
-    double ScrollScaleX,  // koeficient horizontalni scroll-bary
-        ScrollScaleY;     // koeficient vertikalni scroll-bary
-    BOOL EnableSetScroll; // behem dragu nebudu refreshovat udaje na scrollbare
+    double ScrollScaleX,  // horizontal scrollbar coefficient
+        ScrollScaleY;     // vertical scrollbar coefficient
+    BOOL EnableSetScroll; // do not refresh scrollbar data while dragging
 
-    __int64 ToolTipOffset; // hex mode: offset v souboru (zobrazuje se v tooltipu)
-    HWND HToolTip;         // okno tooltipu
+    __int64 ToolTipOffset; // hex mode: file offset (shown in the tooltip)
+    HWND HToolTip;         // tooltip window
 
-    HANDLE Lock; // handle pro disk-cache
+    HANDLE Lock; // handle for the disk cache
 
-    BOOL WrapText; // lokalni kopie Configuration.WrapText
+    BOOL WrapText; // local copy of Configuration.WrapText
 
-    BOOL CodePageAutoSelect;  // lokalni kopie Configuration.CodePageAutoSelect
-    char DefaultConvert[200]; // lokalni kopie Configuration.DefaultConvert
+    BOOL CodePageAutoSelect;  // local copy of Configuration.CodePageAutoSelect
+    char DefaultConvert[200]; // local copy of Configuration.DefaultConvert
 
-    BOOL ExitTextMode;  // TRUE = je treba urychlene ukoncit zpracovani akt. zpravy, prepiname do hex
-                        //        modu (soubor se pro textovy rezim nehodi, nema EOLs)
-    BOOL ForceTextMode; // TRUE = za kazdou cenu to chce mit user v textovem rezimu (pocka si)
+    BOOL ExitTextMode;  // TRUE = the current message processing must end quickly; switching to hex mode
+                        //         (the file is unsuitable for text mode, it lacks EOLs)
+    BOOL ForceTextMode; // TRUE = the user insists on text mode at any cost (they will wait)
 
-    int CodeType;        // ciselna identifikace kodovani pamet objektu CodeTables pro toto okno vieweru
-    BOOL UseCodeTable;   // ma se prekodovavat podle CodeTable?
-    char CodeTable[256]; // kodovaci tabulka
+    int CodeType;        // numeric encoding identifier; CodeTables memory for this viewer window
+    BOOL UseCodeTable;   // should CodeTable be used for recoding?
+    char CodeTable[256]; // code table
 
-    char CurrentDir[MAX_PATH]; // cesta pro open dialog
+    char CurrentDir[MAX_PATH]; // path for the open dialog
 
-    BOOL WaitForViewerRefresh;   // TRUE - ceka se na WM_USER_VIEWERREFRESH, ostatni prikazy se skipnou
-    __int64 LastSeekY;           // SeekY pred chybou
-    __int64 LastOriginX;         // OriginX pred chybou
-    DWORD RepeatCmdAfterRefresh; // prikaz k zopakovani po refreshi (-1 = zadny prikaz)
+    BOOL WaitForViewerRefresh;   // TRUE - waiting for WM_USER_VIEWERREFRESH; other commands are skipped
+    __int64 LastSeekY;           // SeekY before the error
+    __int64 LastOriginX;         // OriginX before the error
+    DWORD RepeatCmdAfterRefresh; // command to repeat after refresh (-1 = no command)
 
-    char* Caption;     // neni-li NULL, obsahuje navrhovany caption okna vieweru
-    BOOL WholeCaption; // ma vyznam pokud je Caption != NULL. TRUE -> v titulku
-                       // vieweru bude zobrazen pouze retezec Caption; FALSE -> za
-                       // Caption se pripoji standardni " - Viewer".
+    char* Caption;     // if not NULL, contains the proposed viewer window caption
+    BOOL WholeCaption; // meaningful if Caption != NULL. TRUE -> only Caption is displayed
+                       // in the viewer title; FALSE -> append the standard " - Viewer" to Caption.
 
-    BOOL CanSwitchToHex,           // TRUE pokud je mozne prepnuti do "hex" pri vice nez 10000 znacich na radku
-        CanSwitchQuietlyToHex,     // TRUE pokud se neni treba na prepnuti ptat (pri loadu souboru)
-        FindingSoDonotSwitchToHex; // TRUE pokud se ma blokovat prepnuti do "hex" pri vice nez 10000 znacich na radku (behem hledani v textu je to nezadouci)
+    BOOL CanSwitchToHex,           // TRUE if switching to hex is possible when there are more than 10000 characters per line
+        CanSwitchQuietlyToHex,     // TRUE if switching does not need confirmation (while loading a file)
+        FindingSoDonotSwitchToHex; // TRUE if switching to hex should be blocked when there are more than 10000 characters per line (undesirable during text searching)
 
-    int HexOffsetLength; // hex-mode: pocet znaku v offsetu (v prvnim sloupci zleva)
+    int HexOffsetLength; // hex mode: number of characters in the offset (in the leftmost column)
 
-    // GDI objekty (kazdy thread ma sve)
-    HBRUSH BkgndBrush;    // solid brush barvy pozadi okna
-    HBRUSH BkgndBrushSel; // solid brush barvy pozadi okna - selected text
+    // GDI objects (each thread has its own)
+    HBRUSH BkgndBrush;    // solid brush with the window background color
+    HBRUSH BkgndBrushSel; // solid brush with the window background color - selected text
 
     CBitmap Bitmap;
     HFONT ViewerFont;
 
-    int EnumFileNamesSourceUID;     // UID naseho zdroje pro enumeraci jmen ve vieweru
-    int EnumFileNamesLastFileIndex; // index prave prohlizeneho souboru
+    int EnumFileNamesSourceUID;     // UID of our source for enumerating names in the viewer
+    int EnumFileNamesLastFileIndex; // index of the currently viewed file
 
-    WPARAM VScrollWParam; // wParam z WM_VSCROLL/SB_THUMB*; -1 pokud neprobiha tazeni
+    WPARAM VScrollWParam; // wParam from WM_VSCROLL/SB_THUMB*; -1 if dragging is not in progress
     WPARAM VScrollWParamOld;
 
     int MouseWheelAccumulator;  // vertical
@@ -410,30 +404,30 @@ protected:
 
 BOOL InitializeViewer();
 void ReleaseViewer();
-void ClearViewerHistory(BOOL dataOnly); // promaze historie; pro dataOnly==FALSE maze combbox Find dialogu (je-li)
+void ClearViewerHistory(BOOL dataOnly); // clears histories; for dataOnly==FALSE also clears the Find dialog combobox (if any)
 void UpdateViewerColors(SALCOLOR* colors);
 
-extern const char* CVIEWERWINDOW_CLASSNAME; // trida okna vieweru
+extern const char* CVIEWERWINDOW_CLASSNAME; // viewer window class
 
-extern CWindowQueue ViewerWindowQueue; // seznam vsech oken vieweru
+extern CWindowQueue ViewerWindowQueue; // list of all viewer windows
 
-extern CFindSetDialog GlobalFindDialog; // pro inicializaci noveho okna vieweru
+extern CFindSetDialog GlobalFindDialog; // for initializing a new viewer window
 
-extern BOOL UseCustomViewerFont; // pokud je TRUE, pouzije se struktura ViewerLogFont ulozena v konfiguraci; jinak default hodnoty
+extern BOOL UseCustomViewerFont; // if TRUE, use the ViewerLogFont structure stored in the configuration; otherwise default values
 extern LOGFONT ViewerLogFont;
 extern HMENU ViewerMenu;
 extern HACCEL ViewerTable;
-extern int CharWidth, // sirka znaku (v bodech)
-    CharHeight;       // vyska znaku (v bodech)
+extern int CharWidth, // character width (in points)
+    CharHeight;       // character height (in points)
 
-// Vista: font fixedsys obsahuje znaky, ktere nemaji ocekavanou sirku (i kdyz je to fixed-width font), proto
-// omerujeme jednotlive znaky a ty ktere nemaji spravnou sirku mapujeme na nahradni znak o spravne sirce
-extern CRITICAL_SECTION ViewerFontMeasureCS; // kriticka sekce pro omerovani fontu
-extern BOOL ViewerFontMeasured;              // TRUE = uz jsme omerovali font vznikly z ViewerLogFont; FALSE = je potreba provest omereni fontu
-extern BOOL ViewerFontNeedsMapping;          // TRUE = je nutne pouzivat ViewerFontMapping; FALSE = font je OK, mapovani neni potreba
-extern char ViewerFontMapping[256];          // premapovani na znaky, ktere maji ocekavanou fixni sirku
+// Vista: the fixedsys font contains characters that do not have the expected width (even though it is a fixed-width font), therefore
+// measure individual characters and map those with an incorrect width to a replacement character with the correct width
+extern CRITICAL_SECTION ViewerFontMeasureCS; // critical section for measuring the font
+extern BOOL ViewerFontMeasured;              // TRUE = the font created from ViewerLogFont was already measured; FALSE = the font must be measured
+extern BOOL ViewerFontNeedsMapping;          // TRUE = ViewerFontMapping must be used; FALSE = the font is OK and mapping is unnecessary
+extern char ViewerFontMapping[256];          // remapping to characters that have the expected fixed width
 
-extern HANDLE ViewerContinue; // pomocny event - cekani na rozebehnuti threadu message-loopy
+extern HANDLE ViewerContinue; // helper event - waiting for the message-loop thread to start
 
 BOOL OpenViewer(const char* name, CViewType mode, int left, int top, int width, int height,
                 UINT showCmd, BOOL returnLock, HANDLE* lock, BOOL* lockOwner,


### PR DESCRIPTION
## Summary
- clarify the SetViewerFont prerequisites comment and refine paint-path explanations for repainting and BitBlt usage
- describe the repaint invalidation workaround and view-size accounting in smoother English while keeping semantics intact
- note that toggling HEX mode rewrites the offset and ensure the Find history cleanup comment reads naturally

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e9bb819ee88322b286411ccb60531d