### PR TITLE
Clarify translations for remap and config comments in zip.h

### DIFF
--- a/src/zip.h
+++ b/src/zip.h
@@ -18,9 +18,9 @@ class CStaticText;
 class CZIPUnpackProgress : public CCommonDialog
 {
 protected:
-    const char* RemapNameFrom; // mapovani jmen z tmp-adresare
-    const char* RemapNameTo;   // na jmeno archivu, ze ktereho vybalujeme
-    BOOL FileProgress;         // pro variantu s jednim progressem: TRUE="File:", FALSE="Total:"
+    const char* RemapNameFrom; // mapping of names originating in the temporary directory
+    const char* RemapNameTo;   // mapping target: the name of the archive we are unpacking from
+    BOOL FileProgress;         // for the single-progress variant: TRUE="File:", FALSE="Total:"
 
 public:
     CZIPUnpackProgress();
@@ -30,10 +30,10 @@ public:
 
     void Set(const char* title, HWND parent, const CQuadWord& totalSize, BOOL fileProgress);
     void Set(const char* title, HWND parent, const CQuadWord& totalSize1, const CQuadWord& totalSize2);
-    void SetTotal(const CQuadWord& total1, const CQuadWord& total2); // CQuadWord(-1, -1) znamena nenastavovat
+    void SetTotal(const CQuadWord& total1, const CQuadWord& total2); // CQuadWord(-1, -1) means do not set
 
-    int AddSize(int size, BOOL delayedPaint);                                       // vraci "continue?"
-    int SetSize(const CQuadWord& size1, const CQuadWord& size2, BOOL delayedPaint); // vraci "continue?", size == CQuadWord(-1, -1) znamena "nenastavovat"
+    int AddSize(int size, BOOL delayedPaint);                                       // returns "continue?"
+    int SetSize(const CQuadWord& size1, const CQuadWord& size2, BOOL delayedPaint); // returns "continue?"; size == CQuadWord(-1, -1) means "do not set"
 
     void NewLine(const char* txt, BOOL delayedPaint);
     void EnableCancel(BOOL enable);
@@ -46,33 +46,33 @@ public:
 protected:
     virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-    BOOL HasTwoProgress(); // TRUE - dvou-progressovy, jinak FALSE
+    BOOL HasTwoProgress(); // TRUE if the dialog shows two progress bars; otherwise FALSE
 
-    void DispatchMessages(); // rozesle zpravy z fronty, dava prilezitost k prekreslni, klikani na tlacitko
+    void DispatchMessages(); // dispatches queued messages, giving the UI a chance to repaint and handle button clicks
 
-    void FlushDataToControls(); // dirty data prenese do controlu (texty, progress bary)
+    void FlushDataToControls(); // pushes dirty data into the controls (texts, progress bars)
 
-    const char* Title;   // titulek - ukazatel do bufferu LoadStr (nepouzivat dlouho)
-    BOOL Cancel;         // uzivatel stornoval operaci, dialog by mel co nejdrive koncit
-    DWORD LastTickCount; // pro detekci ze uz je treba prekreslit zmenena data
+    const char* Title;   // dialog title pointer inside the LoadStr buffer (do not keep for long)
+    BOOL Cancel;         // user canceled the operation; the dialog should end as soon as possible
+    DWORD LastTickCount; // used to detect when it is time to repaint the changed data
 
-    // pozor: Summary, Summary2 a Lines budou v pripade nedostatku pameti NULL; pocitat s tim v kodu dialogu
+    // note: Summary, Summary2, and Lines will be NULL if memory is low; account for that in the dialog code
     CProgressBar* Summary;
     CProgressBar* Summary2;
     CStaticText* Lines[ZIP_UNPACK_NUMLINES];
 
-    char LinesCache[ZIP_UNPACK_NUMLINES][300]; // sem se uladaji texty, ktere se pozdeji zobrazi
-    int CacheIndex;                            // index do pole LinesCache, ktery se ma obsadit pristi radkou
-    BOOL CacheIsDirty;                         // je treba prenest cache do obrazovky?
+    char LinesCache[ZIP_UNPACK_NUMLINES][300]; // queued texts waiting to be displayed later
+    int CacheIndex;                            // index within LinesCache to be filled by the next line
+    BOOL CacheIsDirty;                         // TRUE if the cache needs to be sent to the screen
 
     CQuadWord TotalSize,
         ActualSize;
     CQuadWord TotalSize2,
         ActualSize2;
-    BOOL SizeIsDirty;  // je treba prenest Size do obrazovky?
-    BOOL Size2IsDirty; // je treba prenest Size2 do obrazovky?
+    BOOL SizeIsDirty;  // TRUE when Size needs to be pushed to the screen
+    BOOL Size2IsDirty; // TRUE when Size2 needs to be pushed to the screen
 
-    CITaskBarList3* TaskBarList3; // ukazatel na interface patrici hlavnimu oknu Salamandera
+    CITaskBarList3* TaskBarList3; // pointer to the interface owned by Salamander's main window
 };
 
 //
@@ -84,47 +84,46 @@ class CSalamanderForOperations : public CSalamanderForOperationsAbstract
 {
 protected:
     CFilesWindow* Panel;
-    CZIPUnpackProgress UnpackProgress; // UnpackProgress dialog
-    BOOL ProgressDialog2;              // TRUE = dvou-progressovy, FALSE = jedno-progressovy UnpackProgress dialog
+    CZIPUnpackProgress UnpackProgress; // UnpackProgress dialog instance
+    BOOL ProgressDialog2;              // TRUE = UnpackProgress dialog with two progress bars, FALSE = single-progress dialog
     HWND FocusWnd;
 
-    // kontrolni mechanismus
-    DWORD ThreadID; // smeji nas volat pouze z threadu, ve kterem byl ukazatel na nas predan
-    BOOL Destroyed; // pokud je TRUE, objek jiz byl destruovan
+    // control mechanism
+    DWORD ThreadID; // only the thread in which our pointer was passed may call us
+    BOOL Destroyed; // if TRUE, the object has already been destroyed
 
 public:
     CSalamanderForOperations(CFilesWindow* panel);
     ~CSalamanderForOperations();
 
-    // PROGRESS DIALOG: dialog obsahuje jeden/dva ('twoProgressBars' FALSE/TRUE) progress-metry
-    // otevre progress-dialog s titulkem 'title'; 'parent' je parent okno progress-dialogu (je-li
-    // NULL, pouzije se hlavni okno); pokud obsahuje jen jeden progress-metr, muze byt popsan
-    // jako "File" ('fileProgress' je TRUE) nebo "Total" ('fileProgress' je FALSE)
+    // PROGRESS DIALOG: the dialog contains one or two progress meters (depending on 'twoProgressBars')
+    // opens the progress dialog with the title 'title'; 'parent' is the parent window of the progress dialog (if
+    // NULL, the main window is used); if it contains only one progress meter, it can be labeled
+    // as "File" ('fileProgress' is TRUE) or "Total" ('fileProgress' is FALSE)
     virtual void WINAPI OpenProgressDialog(const char* title, BOOL twoProgressBars, HWND parent, BOOL fileProgress);
-    // vypise text 'txt' (i nekolik radku - provadi se rozpad na radky) do progress-dialogu
+    // prints the text 'txt' (splits multiple lines) into the progress dialog
     virtual void WINAPI ProgressDialogAddText(const char* txt, BOOL delayedPaint);
-    // neni-li 'totalSize1' CQuadWord(-1, -1), nastavi 'totalSize1' jako 100 procent prvniho progress-metru,
-    // neni-li 'totalSize2' CQuadWord(-1, -1), nastavi 'totalSize2' jako 100 procent druheho progress-metru
-    // (pro progress-dialog s jednim progress-metrem je povinne 'totalSize2' CQuadWord(-1, -1))
+    // if 'totalSize1' is not CQuadWord(-1, -1), sets 'totalSize1' as 100 percent of the first progress meter,
+    // if 'totalSize2' is not CQuadWord(-1, -1), sets 'totalSize2' as 100 percent of the second progress meter
+    // (for a progress dialog with a single progress meter, 'totalSize2' must be CQuadWord(-1, -1))
     virtual void WINAPI ProgressSetTotalSize(const CQuadWord& totalSize1, const CQuadWord& totalSize2);
-    // neni-li 'size1' CQuadWord(-1, -1), nastavi velikost 'size1' (size1/total1*100 procent) na prvnim progress-metru,
-    // neni-li 'size2' CQuadWord(-1, -1), nastavi velikost 'size2' (size2/total2*100 procent) na druhem progress-metru
-    // (pro progress-dialog s jednim progress-metrem je povinne 'size2' CQuadWord(-1, -1)), vraci informaci jestli ma
-    // akce pokracovat (FALSE = konec)
+    // if 'size1' is not CQuadWord(-1, -1), sets the value of 'size1' (size1/total1*100 percent) on the first progress meter,
+    // if 'size2' is not CQuadWord(-1, -1), sets the value of 'size2' (size2/total2*100 percent) on the second progress meter
+    // (for a progress dialog with a single progress meter, 'size2' must be CQuadWord(-1, -1)); returns whether the action should continue (FALSE = end)
     virtual BOOL WINAPI ProgressSetSize(const CQuadWord& size1, const CQuadWord& size2, BOOL delayedPaint);
-    // prida (pripadne k oboum progress-metrum) velikost 'size' (size/total*100 procent progressu),
-    // vraci informaci jestli ma akce pokracovat (FALSE = konec)
+    // adds the size 'size' (optionally to both progress meters) (size/total*100 percent progress),
+    // returns whether the action should continue (FALSE = end)
     virtual BOOL WINAPI ProgressAddSize(int size, BOOL delayedPaint);
-    // enabluje/disabluje tlacitko Cancel
+    // enables/disables the Cancel button
     virtual void WINAPI ProgressEnableCancel(BOOL enable);
-    // vraci HWND dialogu progressu (hodi se pri vypisu chyb a dotazu pri otevrenem progress-dialogu)
+    // returns the progress dialog HWND (useful for displaying errors and prompts while the progress dialog is open)
     virtual HWND WINAPI ProgressGetHWND() { return UnpackProgress.HWindow; }
-    // zavre progress-dialog
+    // closes the progress dialog
     virtual void WINAPI CloseProgressDialog();
 
-    // presune vsechny soubory ze 'source' adresare do 'target' adresare,
-    // navic premapovava predpony zobrazovanych jmen ('remapNameFrom' -> 'remapNameTo')
-    // vraci uspech operace
+    // moves all files from the 'source' directory to the 'target' directory,
+    // additionally remaps the prefixes of displayed names ('remapNameFrom' -> 'remapNameTo')
+    // returns whether the operation succeeded
     virtual BOOL WINAPI MoveFiles(const char* source, const char* target, const char* remapNameFrom,
                                   const char* remapNameTo);
 };
@@ -136,32 +135,32 @@ public:
 
 class CSalamanderDirectory;
 
-// CSalamanderDirectoryAddCache slouzi pro optimalizaci pridavani souboru
-// do CSalamanderDirectory (metoda AddFile)
+// CSalamanderDirectoryAddCache is used to optimize adding files
+// to CSalamanderDirectory (AddFile method)
 struct CSalamanderDirectoryAddCache
 {
-    int PathLen;               // pocet platnych znaku v 'Path'
-    char Path[MAX_PATH];       // cachovana cesta
-    CSalamanderDirectory* Dir; // ukazatel na CSalamanderDirectory, do ktereho jsou pridavany soubory a adresare s cestou 'Path'
+    int PathLen;               // number of valid characters in 'Path'
+    char Path[MAX_PATH];       // cached path
+    CSalamanderDirectory* Dir; // pointer to the CSalamanderDirectory to which files and directories with the 'Path' path are being added
 };
 
 class CSalamanderDirectory : public CSalamanderDirectoryAbstract
 {
 protected:
-    CFilesArray Dirs;                              // jmena podadresaru (obsah je v SalamDirs na stejnem indexu)
-    TDirectArray<CSalamanderDirectory*> SalamDirs; // ukazatele na CSalamanderDirectory (ukazatele jsou NULL az do okamziku prvniho pristupu, pak se teprve alokuji objekty)
-    CFilesArray Files;                             // jmena souboru
-    DWORD ValidData;                               // maska platnosti dat z CFileData
-    DWORD Flags;                                   // priznaky objektu (viz SALDIRFLAG_XXX)
-    BOOL IsForFS;                                  // TRUE jde-li o sal-dir pro FS, FALSE jde-li o sal-dir pro archivy
-    CSalamanderDirectoryAddCache* AddCache;        // pokud je ruzny od NULL, slouzi k optimalizaci pridavani souboru metodou AddFile; jinak se nepouziva
+    CFilesArray Dirs;                              // names of subdirectories (contents stored in SalamDirs at the same index)
+    TDirectArray<CSalamanderDirectory*> SalamDirs; // pointers to CSalamanderDirectory (pointers are NULL until first access, then the objects are allocated)
+    CFilesArray Files;                             // file names
+    DWORD ValidData;                               // validity mask for data from CFileData
+    DWORD Flags;                                   // object flags (see SALDIRFLAG_XXX)
+    BOOL IsForFS;                                  // TRUE if this is a sal-dir for FS, FALSE if it is a sal-dir for archives
+    CSalamanderDirectoryAddCache* AddCache;        // if not NULL, used to optimize adding files via AddFile; otherwise unused
 
 public:
-    CSalamanderDirectory(BOOL isForFS, DWORD validData = VALID_DATA_ALL_FS_ARC, DWORD flags = -1 /* nastavi se podle isForFS */);
+    CSalamanderDirectory(BOOL isForFS, DWORD validData = VALID_DATA_ALL_FS_ARC, DWORD flags = -1 /* set according to isForFS */);
     ~CSalamanderDirectory();
 
     // *********************************************************************************
-    // metody rozhrani CSalamanderDirectoryAbstract
+    // methods of the CSalamanderDirectoryAbstract interface
     // *********************************************************************************
     virtual void WINAPI Clear(CPluginDataInterfaceAbstract* pluginData);
     virtual void WINAPI SetValidData(DWORD validData);
@@ -177,48 +176,46 @@ public:
     virtual void WINAPI SetApproximateCount(int files, int dirs);
 
     // *********************************************************************************
-    // pomocne metody (nepristupne z pluginu)
+    // helper methods (inaccessible from plugins)
     // *********************************************************************************
 
-    // pro optimalizaci metody AddFile
+    // for optimizing the AddFile method
     void AllocAddCache();
     void FreeAddCache();
 
-    // podle Flags bud StrICmp nebo strcmp (StrCmpEx) - rozliseni case sensitive/insensitive porovnani
+    // depending on Flags either StrICmp or strcmp (StrCmpEx) - selects case sensitive/insensitive comparison
     int SalDirStrCmp(const char* s1, const char* s2);
     int SalDirStrCmpEx(const char* s1, int l1, const char* s2, int l2);
 
-    // vola pro vsechny soubory (je-li 'releaseFiles' TRUE) a pro vsechny adresare
-    // (je-li 'releaseDirs' TRUE) 'pluginData'.ReleaseFilesOrDirs (uvolneni dat plug-inu)
+    // calls 'pluginData'.ReleaseFilesOrDirs (releasing plug-in data) for all files (if 'releaseFiles' is TRUE) and all directories
+    // (if 'releaseDirs' is TRUE)
     void ReleasePluginData(CPluginDataInterfaceEncapsulation& pluginData, BOOL releaseFiles,
                            BOOL releaseDirs);
 
-    // vraci adresare ze zadane cesty (relativni k tomuto salamander-adresari)
+    // returns directories from the specified path (relative to this Salamander directory)
     CFilesArray* GetDirs(const char* path);
-    // vraci soubory ze zadane cesty (relativni k tomuto salamander-adresari)
+    // returns files from the specified path (relative to this Salamander directory)
     CFilesArray* GetFiles(const char* path);
 
-    // vraci nadrazeny adresar pro cestu 'path' (pro root a nezname cesty vraci NULL)
+    // returns the parent directory for the path 'path' (returns NULL for root and unknown paths)
     const CFileData* GetUpperDir(const char* path);
 
-    // vraci soucet velikosti vsech obsazenych souboru, pozor: nutne vynulovat pocitadla
+    // returns the sum of sizes of all contained files; note: counters must be reset beforehand
     CQuadWord GetSize(int* dirsCount = NULL, int* filesCount = NULL, TDirectArray<CQuadWord>* sizes = NULL);
-    // vraci velikost adresare - soucet vsech souboru v nem, pozor: nutne vynulovat pocitadla
+    // returns the directory size (sum of all files in it); note: counters must be reset beforehand
     CQuadWord GetDirSize(const char* path, const char* dirName, int* dirsCount = NULL,
                          int* filesCount = NULL, TDirectArray<CQuadWord>* sizes = NULL);
-    // vraci salamander-dir pro zadany adresar; je-li 'readOnly' TRUE, nesmi dojit k zapisu
-    // do vraceneho salamander-dir objektu
+    // returns the salamander-dir for the specified directory; if 'readOnly' is TRUE, the returned salamander-dir object must not be modified
     CSalamanderDirectory* GetSalamanderDir(const char* path, BOOL readOnly);
-    // vraci salamander-dir pro zadany index adresare; nesmi dojit k zapisu do vraceneho
-    // salamander-dir objektu
+    // returns the salamander-dir for the specified directory index; the returned salamander-dir object must not be modified
     CSalamanderDirectory* GetSalamanderDir(int i);
-    // vraci index adresare zadaneho jmenem
+    // returns the index of the directory specified by name
     int GetIndex(const char* dir);
-    // je na tomto indexu adresar?
+    // is there a directory at this index?
     BOOL IsDirectory(int i) { return i >= 0 && i < Dirs.Count; }
-    // je na tomto indexu soubor?
+    // is there a file at this index?
     BOOL IsFile(int i) { return i >= Dirs.Count && i < Dirs.Count + Files.Count; }
-    // vraci soubor pro zadany index
+    // returns the file for the specified index
     CFileData* GetFileEx(int i)
     {
         if (i >= Dirs.Count && i < Dirs.Count + Files.Count)
@@ -226,7 +223,7 @@ public:
         else
             return NULL;
     }
-    // vraci adresar pro zadany index
+    // returns the directory for the specified index
     CFileData* GetDirEx(int i)
     {
         if (i >= 0 && i < Dirs.Count)
@@ -240,15 +237,15 @@ public:
     DWORD GetFlags() { return Flags; }
 
 protected:
-    // pomocna metoda: alokuje objekt salamader-dir na indexu 'index' v poli SalamDirs,
-    // vraci ukazatel na objekt (nebo NULL pri chybe)
+    // helper method: allocates a salamander-dir object at index 'index' in the SalamDirs array,
+    // returns a pointer to the object (or NULL on error)
     CSalamanderDirectory* AllocSalamDir(int index);
 
     BOOL FindDir(const char* path, const char*& s, int& i, const CFileData& file,
                  CPluginDataInterfaceAbstract* pluginData, const char* archivePath);
 
-    // metody AddFileInt a AddDirInt vraceji v pripade uspechu ukazatel na CSalamanderDirectory,
-    // do ktereho byla polozka pridana; jinak vraceji NULL
+    // the AddFileInt and AddDirInt methods return a pointer to CSalamanderDirectory on success,
+    // into which the item was added; otherwise they return NULL
     CSalamanderDirectory* AddFileInt(const char* path, CFileData& file,
                                      CPluginDataInterfaceAbstract* pluginData,
                                      const char* archivePath);
@@ -257,7 +254,7 @@ protected:
                                     const char* archivePath);
 };
 
-// zjisti volne misto na ceste path a pokud neni >= totalSize zepta se jestli chce user pokracovat
+// checks the free space at 'path' and, if it is below totalSize, asks the user whether to continue
 BOOL TestFreeSpace(HWND parent, const char* path, const CQuadWord& totalSize, const char* messageTitle);
 
 //
@@ -265,7 +262,7 @@ BOOL TestFreeSpace(HWND parent, const char* path, const CQuadWord& totalSize, co
 // CPackerConfig
 //
 
-// typ polozky v tabulce custom pakovacu
+// item type in the custom packers table
 struct SPackCustomPacker
 {
     const char* CopyArgs[2];
@@ -277,7 +274,7 @@ struct SPackCustomPacker
     const char* Exe;
 };
 
-// typ polozky v tabulce custom rozpakovavacu
+// item type in the custom unpackers table
 struct SPackCustomUnpacker
 {
     const char* Args;
@@ -288,7 +285,7 @@ struct SPackCustomUnpacker
     const char* Exe;
 };
 
-// tabulky custom pakovacu
+// custom packer tables
 extern SPackCustomPacker CustomPackers[];
 extern SPackCustomUnpacker CustomUnpackers[];
 
@@ -297,12 +294,12 @@ extern SPackCustomUnpacker CustomUnpackers[];
 class CPackerConfigData
 {
 public:
-    char* Title; // jmeno pro usera
-    char* Ext;   // standardni pripona (bez tecky)
-    int Type;    // interni (-1, -2, ...; popis viz CPlugins)/externi (0; platnost dalsich polozek)
-                 // dodatek viz OldType nize
+    char* Title; // name shown to the user
+    char* Ext;   // standard extension (without the dot)
+    int Type;    // internal (-1, -2, ...; see CPlugins for details) / external (0; additional fields apply)
+                 // note: see OldType below
 
-    // data pro externi pakovace
+    // data for external packers
     char* CmdExecCopy;
     char* CmdArgsCopy;
     BOOL SupportMove;
@@ -311,7 +308,7 @@ public:
     BOOL SupportLongNames;
     BOOL NeedANSIListFile;
 
-    // pomocna promenna pro zjisteni typu udaju - TRUE = stare -> 'Type' (0 ZIP, 1 external, 2 TAR, 3 PAK)
+    // helper flag to detect the data layout - TRUE = legacy -> 'Type' (0 ZIP, 1 external, 2 TAR, 3 PAK)
     BOOL OldType;
 
 public:
@@ -377,24 +374,24 @@ public:
 class CPackerConfig
 {
 public:
-    BOOL Move; // move nebo copy do archivu?
+    BOOL Move; // should files be moved (instead of copied) into the archive?
 
 protected:
     int PreferedPacker;
-    TIndirectArray<CPackerConfigData> Packers; // pole informaci o pakovacich, polozky typu (CPackerConfigData *)
+    TIndirectArray<CPackerConfigData> Packers; // array of packer information, elements of type (CPackerConfigData *)
 
 public:
     CPackerConfig(/*BOOL disableDefaultValues = FALSE*/);
-    void InitializeDefaultValues(); // j.r. nahrazuje puvodni volani konstruktoru
+    void InitializeDefaultValues(); // j.r. replaces the original constructor call
     BOOL Load(CPackerConfig& src);
 
     void DeleteAllPackers() { Packers.DestroyMembers(); }
 
-    int AddPacker(BOOL toFirstIndex = FALSE); // vrati index zalozene polozky nebo -1 pri chybe
-    void AddDefault(int SalamVersion);        // prida archivery nove od verze SalamVersion
+    int AddPacker(BOOL toFirstIndex = FALSE); // returns the index of the created item or -1 on error
+    void AddDefault(int SalamVersion);        // adds archivers introduced since SalamVersion
 
-    // nastavi atributy; kdyz se neco posere, vyradi prvek z pole, zdestroji ho a vrati FALSE
-    // old == TRUE -> 'type' je ve stare konvenci (0 ZIP, 1 external, 2 TAR, 3 PAK)
+    // sets attributes; if something goes wrong, removes the item from the array, destroys it, and returns FALSE
+    // old == TRUE -> 'type' uses the old convention (0 ZIP, 1 external, 2 TAR, 3 PAK)
     BOOL SetPacker(int index, int type, const char* title, const char* ext, BOOL old,
                    BOOL supportLongNames = FALSE, BOOL supportMove = FALSE,
                    const char* cmdExecCopy = NULL, const char* cmdArgsCopy = NULL,
@@ -404,9 +401,9 @@ public:
     void SetPackerType(int index, int type) { Packers[index]->Type = type; }
     void SetPackerOldType(int index, BOOL oldType) { Packers[index]->OldType = oldType; }
     void SetPackerSupMove(int index, BOOL supMove) { Packers[index]->SupportMove = supMove; }
-    int GetPackersCount() { return Packers.Count; } // vrati pocet polozek v poli
-                                                    //    BOOL SwapPackers(int index1, int index2);         // prohodi dve polozky v poli
-    BOOL MovePacker(int srcIndex, int dstIndex);    // posune polozku
+    int GetPackersCount() { return Packers.Count; } // returns the number of items in the array
+                                                    //    BOOL SwapPackers(int index1, int index2);         // swaps two items in the array
+    BOOL MovePacker(int srcIndex, int dstIndex);    // moves an item within the array
     void DeletePacker(int index);
     void SetPackerCmdExecCopy(int index, const char* cmd)
     {
@@ -436,7 +433,7 @@ public:
     BOOL Save(int index, HKEY hKey);
     BOOL Load(HKEY hKey);
 
-    int GetPreferedPacker() // vraci -1 pokud neni zadny prefered
+    int GetPreferedPacker() // returns -1 if no preferred one exists
     {
         return (PreferedPacker < Packers.Count) ? PreferedPacker : -1;
     }
@@ -456,18 +453,18 @@ public:
 class CUnpackerConfigData
 {
 public:
-    char* Title; // jmeno pro usera
-    char* Ext;   // seznam standardnich pripon oddelenych strednikem
-    int Type;    // interni (-1, -2, ...; popis viz CPlugins)/externi (0; platnost dalsich polozek)
-                 // dodatek viz OldType nize
+    char* Title; // name shown to the user
+    char* Ext;   // list of standard extensions separated by semicolons
+    int Type;    // internal (-1, -2, ...; see CPlugins for details) / external (0; additional fields apply)
+                 // note: see OldType below
 
-    // data pro externi pakovace
+    // data for external unpackers
     char* CmdExecExtract;
     char* CmdArgsExtract;
     BOOL SupportLongNames;
     BOOL NeedANSIListFile;
 
-    // pomocna promenna pro zjisteni typu udaju - TRUE = stare -> 'Type' (0 ZIP, 1 external, 2 TAR, 3 PAK)
+    // helper flag to detect the data layout - TRUE = legacy -> 'Type' (0 ZIP, 1 external, 2 TAR, 3 PAK)
     BOOL OldType;
 
 public:
@@ -525,20 +522,20 @@ class CUnpackerConfig
 {
 protected:
     int PreferedUnpacker;
-    TIndirectArray<CUnpackerConfigData> Unpackers; // pole informaci o pakovacich, polozky typu (CUnpackerConfigData *)
+    TIndirectArray<CUnpackerConfigData> Unpackers; // array of unpacker information, elements of type (CUnpackerConfigData *)
 
 public:
     CUnpackerConfig(/*BOOL disableDefaultValues = FALSE*/);
-    void InitializeDefaultValues(); // j.r. nahrazuje puvodni volani konstruktoru
+    void InitializeDefaultValues(); // j.r. replaces the original constructor call
     BOOL Load(CUnpackerConfig& src);
 
     void DeleteAllUnpackers() { Unpackers.DestroyMembers(); }
 
-    int AddUnpacker(BOOL toFirstIndex = FALSE); // vrati index zalozene polozky nebo -1 pri chybe
-    void AddDefault(int SalamVersion);          // prida archivery nove od verze SalamVersion
+    int AddUnpacker(BOOL toFirstIndex = FALSE); // returns the index of the created item or -1 on error
+    void AddDefault(int SalamVersion);          // adds archivers introduced since SalamVersion
 
-    // nastavi atributy; kdyz se neco posere, vyradi prvek z pole, zdestroji ho a vrati FALSE
-    // old == TRUE -> 'type' je ve stare konvenci (0 ZIP, 1 external, 2 TAR, 3 PAK)
+    // sets attributes; if something goes wrong, removes the item from the array, destroys it, and returns FALSE
+    // old == TRUE -> 'type' uses the old convention (0 ZIP, 1 external, 2 TAR, 3 PAK)
     BOOL SetUnpacker(int index, int type, const char* title, const char* ext, BOOL old,
                      BOOL supportLongNames = FALSE,
                      const char* cmdExecExtract = NULL, const char* cmdArgsExtract = NULL,
@@ -546,9 +543,9 @@ public:
     BOOL SetUnpackerTitle(int index, const char* title);
     void SetUnpackerType(int index, int type) { Unpackers[index]->Type = type; }
     void SetUnpackerOldType(int index, BOOL oldType) { Unpackers[index]->OldType = oldType; }
-    int GetUnpackersCount() { return Unpackers.Count; } // vrati pocet polozek v poli
-                                                        //    BOOL SwapUnpackers(int index1, int index2);         // prohodi dve polozky v poli
-    BOOL MoveUnpacker(int srcIndex, int dstIndex);      // posune polozku
+    int GetUnpackersCount() { return Unpackers.Count; } // returns the number of items in the array
+                                                        //    BOOL SwapUnpackers(int index1, int index2);         // swaps two items in the array
+    BOOL MoveUnpacker(int srcIndex, int dstIndex);      // moves an item within the array
 
     void DeleteUnpacker(int index);
 
@@ -564,7 +561,7 @@ public:
     BOOL Save(int index, HKEY hKey);
     BOOL Load(HKEY hKey);
 
-    int GetPreferedUnpacker() // vraci -1 pokud neni zadny prefered
+    int GetPreferedUnpacker() // returns -1 if no preferred one exists
     {
         return (PreferedUnpacker < Unpackers.Count) ? PreferedUnpacker : -1;
     }


### PR DESCRIPTION
## Summary
- refine the CZIPUnpackProgress and CSalamanderForOperations comments to more literally describe the remapping fields and progress dialog behavior
- update packer and unpacker configuration comments to use clearer English phrasing for user-facing labels and constructor notes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9bdae796c832295af7ca78da6e369