### PR TITLE
Refine toolbar comment translations

### DIFF
--- a/src/toolbar3.cpp
+++ b/src/toolbar3.cpp
@@ -49,19 +49,19 @@ void CTBCustomizeDialog::DestroyItems()
     }
 }
 
-// naplni Items pole vsema tlacitkama, ktere muze toolbar obsahovat
+// Populate the Items array with every button the toolbar can contain.
 BOOL CTBCustomizeDialog::EnumButtons()
 {
     CALL_STACK_MESSAGE1("CTBCustomizeDialog::EnumButtons()");
-    // vycistime pole
+    // Clear the array.
     DestroyItems();
 
-    char textBuffer[1024]; // docasne buffery pro prijem retezcu
+    char textBuffer[1024]; // temporary buffers used to receive strings
     char nameBuffer[1024];
 
     HWND hNotifyWnd = ToolBar->HNotifyWindow;
     TLBI_ITEM_INFO2 tii;
-    tii.Mask = TLBI_MASK_STYLE; // na prvni misto seznamu zaradime separator
+    tii.Mask = TLBI_MASK_STYLE; // place a separator at the first position of the list
     tii.Style = TLBI_STYLE_SEPARATOR;
     tii.Index = -1;
     BOOL sent = TRUE;
@@ -81,7 +81,7 @@ BOOL CTBCustomizeDialog::EnumButtons()
         }
         if (sent)
         {
-            // naalokujeme kopie retezcu text a name
+            // Allocate persistent copies of the text and name strings.
             tii.TextLen = lstrlen(tii.Text);
             tii.NameLen = lstrlen(tii.Name);
             char* text = (char*)malloc(tii.TextLen + 1);
@@ -94,7 +94,7 @@ BOOL CTBCustomizeDialog::EnumButtons()
             name[tii.NameLen] = 0;
             tii.Text = text;
             tii.Name = name;
-            // vlozime polozku do pole
+            // insert the item into the array
             AllItems.Add(tii);
             tii.Index++;
         }
@@ -117,7 +117,7 @@ BOOL CTBCustomizeDialog::PresentInToolBar(DWORD id)
 BOOL CTBCustomizeDialog::FindIndex(DWORD id, int* index)
 {
     CALL_STACK_MESSAGE_NONE
-    // preskocime virtualni separator
+    // skip the virtual separator
     int i;
     for (i = 1; i < AllItems.Count; i++)
     {
@@ -140,9 +140,9 @@ void CTBCustomizeDialog::FillLists()
     SendMessage(HCurrentLB, LB_RESETCONTENT, 0, 0);
     int i;
     for (i = 0; i < AllItems.Count; i++)
-        if (i == 0 || !PresentInToolBar(AllItems[i].ID)) // pokud se nejedna o virtualni separator, kontrolujeme pritomnost v toolbare
+        if (i == 0 || !PresentInToolBar(AllItems[i].ID)) // include the virtual separator plus every button that is not currently on the toolbar
         {
-            int ret = (int)SendMessage(HAvailableLB, LB_ADDSTRING, 0, 1); // 1 je dumy hodnota, obchazime chybu WinXP
+            int ret = (int)SendMessage(HAvailableLB, LB_ADDSTRING, 0, 1); // 1 is a dummy value used to work around a WinXP bug
             if (ret != LB_ERR)
                 SendMessage(HAvailableLB, LB_SETITEMDATA, ret, (LPARAM)i);
         }
@@ -150,7 +150,7 @@ void CTBCustomizeDialog::FillLists()
     {
         int index;
         if (ToolBar->Items[i]->Style == TLBI_STYLE_SEPARATOR)
-            index = 0; // virtualni separator
+            index = 0; // virtual separator
         else
         {
             if (!FindIndex(ToolBar->Items[i]->ID, &index))
@@ -159,14 +159,14 @@ void CTBCustomizeDialog::FillLists()
                 continue;
             }
         }
-        int ret = (int)SendMessage(HCurrentLB, LB_ADDSTRING, 0, 1); // 1 je dumy hodnota, obchazime chybu WinXP
+        int ret = (int)SendMessage(HCurrentLB, LB_ADDSTRING, 0, 1); // 1 is a dummy value used to work around a WinXP bug
         if (ret != LB_ERR)
             SendMessage(HCurrentLB, LB_SETITEMDATA, ret, (LPARAM)index);
     }
-    // virtualni separator
+    // Append the virtual separator placeholder.
     SendMessage(HCurrentLB, LB_ADDSTRING, 0, (LPARAM)-1);
 
-    // nastavime selected polozky
+    // Select the default entries.
     SendMessage(HAvailableLB, LB_SETCURSEL, 0, 0);
     SendMessage(HCurrentLB, LB_SETCURSEL, 0, 0);
 
@@ -203,12 +203,12 @@ void CTBCustomizeDialog::OnAdd()
             if (aIndex >= aCount - 1)
                 aIndex = aCount - 2;
         }
-        // fix: pokud byl seznam odrolovan dolu a odebiraly se polozky zespodu,
-        // zmensoval se scrollbar, ale neupravoval se topindex
+        // Fix: when the list was scrolled down and items were removed from the bottom,
+        // the scrollbar shrank but the top index was not adjusted.
         SendMessage(HAvailableLB, LB_SETCURSEL, 0, 0);
         SendMessage(HAvailableLB, LB_SETCURSEL, aIndex, 0);
         SendMessage(HAvailableLB, WM_SETREDRAW, TRUE, 0);
-        int ret = (int)SendMessage(HCurrentLB, LB_INSERTSTRING, cIndex, 1); // 1 je dumy hodnota, obchazime chybu WinXP
+        int ret = (int)SendMessage(HCurrentLB, LB_INSERTSTRING, cIndex, 1); // 1 is a dummy value used to work around a WinXP bug
         if (ret != LB_ERR)
             SendMessage(HCurrentLB, LB_SETITEMDATA, ret, data);
         SendMessage(HCurrentLB, LB_SETCURSEL, cIndex + 1, 0);
@@ -229,8 +229,8 @@ void CTBCustomizeDialog::OnRemove()
         int data = (int)SendMessage(HCurrentLB, LB_GETITEMDATA, cIndex, 0);
         SendMessage(HCurrentLB, WM_SETREDRAW, FALSE, 0);
         SendMessage(HCurrentLB, LB_DELETESTRING, cIndex, 0);
-        // fix: pokud byl seznam odrolovan dolu a odebiraly se polozky zespodu,
-        // zmensoval se scrollbar, ale neupravoval se topindex
+        // Fix: when the list was scrolled down and items were removed from the bottom,
+        // the scrollbar shrank but the top index was not adjusted.
         SendMessage(HCurrentLB, LB_SETCURSEL, 0, 0);
         SendMessage(HCurrentLB, LB_SETCURSEL, cIndex, 0);
         SendMessage(HCurrentLB, WM_SETREDRAW, TRUE, 0);
@@ -244,7 +244,7 @@ void CTBCustomizeDialog::OnRemove()
                 if (tmp > data)
                     break;
             }
-            int ret = (int)SendMessage(HAvailableLB, LB_INSERTSTRING, index, 1); // 1 je dumy hodnota, obchazime chybu WinXP
+            int ret = (int)SendMessage(HAvailableLB, LB_INSERTSTRING, index, 1); // 1 is a dummy value used to work around a WinXP bug
             if (ret != LB_ERR)
                 SendMessage(HAvailableLB, LB_SETITEMDATA, ret, data);
         }
@@ -265,7 +265,7 @@ void CTBCustomizeDialog::MoveItem(int srcIndex, int tgtIndex)
     ToolBar->InsertItem2(tgtIndex - delta, TRUE, &AllItems[data]);
 
     SendMessage(HCurrentLB, LB_DELETESTRING, srcIndex, 0);
-    int ret = (int)SendMessage(HCurrentLB, LB_INSERTSTRING, tgtIndex - delta, 1); // 1 je dumy hodnota, obchazime chybu WinXP
+    int ret = (int)SendMessage(HCurrentLB, LB_INSERTSTRING, tgtIndex - delta, 1); // 1 is a dummy value, working around a WinXP bug
     if (ret != LB_ERR)
         SendMessage(HCurrentLB, LB_SETITEMDATA, ret, data);
     SendMessage(HCurrentLB, LB_SETCURSEL, tgtIndex - delta, 0);
@@ -320,7 +320,7 @@ CTBCustomizeDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             DragIndex = LBItemFromPt(dli->hWnd, dli->ptCursor, FALSE);
             if (DragMode == tbcdDragCurrent && DragIndex >= ToolBar->Items.Count)
             {
-                // virtualni separator nenechame tahnout
+                // do not allow the virtual separator to be dragged
                 DragMode = tbcdDragNone;
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, FALSE);
             }
@@ -398,12 +398,12 @@ CTBCustomizeDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         MakeDragList(HCurrentLB);
         DragNotify = RegisterWindowMessage(DRAGLISTMSGSTRING);
 
-        // vytahneme tlacitka
+        // retrieve the buttons
         EnumButtons();
         FillLists();
         EnableControls();
 
-        // napocitame vysku radku
+        // compute the row height
         int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
         int minHeight = max(iconSize, ToolBar->ImageHeight);
         HFONT hFont = (HFONT)SendMessage(HAvailableLB, WM_GETFONT, 0, 0);
@@ -416,7 +416,7 @@ CTBCustomizeDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SelectObject(hDC, hOldFont);
         HANDLES(ReleaseDC(HWindow, hDC));
         minHeight += 2;
-        // nastavime oba listboxy
+        // set both list boxes
         SendMessage(HAvailableLB, LB_SETITEMHEIGHT, 0, minHeight);
         SendMessage(HCurrentLB, LB_SETITEMHEIGHT, 0, minHeight);
         break;
@@ -526,22 +526,22 @@ void CToolBar::Customize()
     if (!(Style & TLB_STYLE_ADJUSTABLE))
         return;
 
-    // posleme notifikaci o zacatku konfigurace
+    // send a notification about the start of customization
     SendMessage(HNotifyWindow, WM_USER_TBBEGINADJUST, (WPARAM)HWindow, 0);
 
-    // behem konfigurace jsou vsechna tlacitka enabled
+    // all buttons are enabled during customization
     Customizing = TRUE;
     InvalidateRect(HWindow, NULL, FALSE);
     UpdateWindow(HWindow);
 
-    // provedeme konfiguraci
+    // perform the customization
     CTBCustomizeDialog dialog(this);
     dialog.Execute();
 
-    // vratime se k puvodnimu nastaveni tlacitek
+    // return to the original button setup
     Customizing = FALSE;
     InvalidateRect(HWindow, NULL, FALSE);
 
-    // posleme notifikaci o ukonceni konfigurace
+    // send a notification about the end of customization
     SendMessage(HNotifyWindow, WM_USER_TBENDADJUST, (WPARAM)HWindow, 0);
 }

--- a/src/toolbar4.cpp
+++ b/src/toolbar4.cpp
@@ -17,40 +17,40 @@
 
 struct CButtonData
 {
-    unsigned int ImageIndex : 16;   // zero base index
-    unsigned int Shell32ResID : 8;  // 0: ikona z image listu; 1..254: resID ikony z shell32.dll; 255: pouze alokovat volny prostor
-    unsigned int ToolTipResID : 16; // resID se stringem pro tooltip
-    unsigned int ID : 16;           // univerzalni Command
-    unsigned int LeftID : 16;       // Command pro levy panel
-    unsigned int RightID : 16;      // Command pro pravy panel
-    unsigned int DropDown : 1;      // bude mit drop down?
-    unsigned int WholeDropDown : 1; // bude mit whole drop down?
-    unsigned int Check : 1;         // jedna se o checkbox?
-    DWORD* Enabler;                 // ridici promenna pro enablovani tlacitka
-    DWORD* LeftEnabler;             // ridici promenna pro enablovani tlacitka
-    DWORD* RightEnabler;            // ridici promenna pro enablovani tlacitka
-    const char* SVGName;            // NULL pokud tlacitko nema SVG reprezentaci
+    unsigned int ImageIndex : 16;   // zero-based index
+    unsigned int Shell32ResID : 8;  // 0: icon from the image list; 1..254: icon resource ID from shell32.dll; 255: reserve an empty slot
+    unsigned int ToolTipResID : 16; // resID with the string for the tooltip
+    unsigned int ID : 16;           // universal command
+    unsigned int LeftID : 16;       // command for the left panel
+    unsigned int RightID : 16;      // command for the right panel
+    unsigned int DropDown : 1;      // should this button show a drop-down?
+    unsigned int WholeDropDown : 1; // should the entire button act as a drop-down?
+    unsigned int Check : 1;         // is this a checkbox?
+    DWORD* Enabler;                 // control flag used when enabling the button
+    DWORD* LeftEnabler;             // control flag used when enabling the button
+    DWORD* RightEnabler;            // control flag used when enabling the button
+    const char* SVGName;            // NULL if the button has no SVG representation
 };
 
 //****************************************************************************
 //
 // TBButtonEnum
 //
-// Unikatni indexy do pole ToolBarButton -  slouzi k adresaci tohoto pole.
-// Do tohoto pole lze pouze pridavat na konec.
+// Unique indexes into the ToolBarButtons array; used to address entries here.
+// Items can only be appended to this array.
 //
 
 #define TBBE_CONNECT_NET 0
 #define TBBE_DISCONNECT_NET 1
 #define TBBE_CREATE_DIR 2
 #define TBBE_FIND_FILE 3
-#define TBBE_VIEW_MODE 4 // drive brief
-//#define TBBE_DETAILED            5  // vyrazeno
+#define TBBE_VIEW_MODE 4 // formerly brief
+//#define TBBE_DETAILED            5  // removed
 #define TBBE_SORT_NAME 6
 #define TBBE_SORT_EXT 7
 #define TBBE_SORT_SIZE 8
 #define TBBE_SORT_DATE 9
-//#define TBBE_SORT_ATTR          10  // vyrazeno
+//#define TBBE_SORT_ATTR          10  // removed
 #define TBBE_PARENT_DIR 11
 #define TBBE_ROOT_DIR 12
 #define TBBE_FILTER 13
@@ -97,7 +97,7 @@ struct CButtonData
 #define TBBE_PERMISSIONS 54
 #define TBBE_CONVERT 55
 #define TBBE_UNSELECT_ALL 56
-#define TBBE_MENU 57 // vstup do menu
+#define TBBE_MENU 57 // enter the menu
 #define TBBE_ALTVIEW 58
 #define TBBE_EXIT 59
 #define TBBE_OCCUPIEDSPACE 60
@@ -254,9 +254,8 @@ CButtonData ToolBarButtons[TBBE_TERMINATOR] =
 //
 // TopToolbar
 //
-// Vyjadruje vsechna mozna tlacitka, ktera muze obsahovat TopToolbar.
-// Poradi udava poradi tlacitek v konfiguracnim dialogu toolbary a muze
-// byt libovolne meneno.
+// Represents all buttons that TopToolbar can contain.
+// The order defines how buttons appear in the toolbar configuration dialog and can be changed freely.
 //
 
 DWORD TopToolBarButtons[] =
@@ -357,7 +356,7 @@ DWORD TopToolBarButtons[] =
         NIB2(TBBE_HELP_CONTENTS)
             NIB2(TBBE_HELP_CONTEXT)
 
-                TBBE_TERMINATOR // terminator - musi zde byt !
+                TBBE_TERMINATOR // terminator - must remain here!
 };
 
 DWORD LeftToolBarButtons[] =
@@ -378,7 +377,7 @@ DWORD LeftToolBarButtons[] =
         TBBE_REFRESH,
         TBBE_SMART_COLUMN_MODE,
 
-        TBBE_TERMINATOR // terminator - musi zde byt !
+        TBBE_TERMINATOR // terminator - must remain here!
 };
 
 DWORD RightToolBarButtons[] =
@@ -399,7 +398,7 @@ DWORD RightToolBarButtons[] =
         TBBE_REFRESH,
         TBBE_SMART_COLUMN_MODE,
 
-        TBBE_TERMINATOR // terminator - musi zde byt !
+        TBBE_TERMINATOR // terminator - must remain here!
 };
 
 void GetSVGIconsMainToolbar(CSVGIcon** svgIcons, int* svgIconsCount)
@@ -418,9 +417,8 @@ void GetSVGIconsMainToolbar(CSVGIcon** svgIcons, int* svgIconsCount)
 //
 // CreateGrayscaleAndMaskBitmaps
 //
-// Vytvori novou bitmapu o hloubce 24 bitu, nakopiruje do ni zdrojovou
-// bitmapu a prevede ji na stupne sedi. Zaroven pripravi druhou bitmapu
-// s maskou dle transparentni barvy.
+// Creates a new 24-bit bitmap, copies the source bitmap into it, and converts it to grayscale.
+// At the same time, it prepares a second bitmap with a mask based on the transparent color.
 //
 
 BOOL CreateGrayscaleAndMaskBitmaps(HBITMAP hSource, COLORREF transparent,
@@ -434,11 +432,11 @@ BOOL CreateGrayscaleAndMaskBitmaps(HBITMAP hSource, COLORREF transparent,
     hMask = NULL;
     HDC hDC = HANDLES(GetDC(NULL));
 
-    // vytahnu rozmery bitmapy
+    // get the bitmap dimensions
     BITMAPINFO bi;
     memset(&bi, 0, sizeof(bi));
     bi.bmiHeader.biSize = sizeof(bi.bmiHeader);
-    bi.bmiHeader.biBitCount = 0; // nechceme paletu
+    bi.bmiHeader.biBitCount = 0; // we do not want a palette
 
     if (!GetDIBits(hDC,
                    hSource,
@@ -457,9 +455,9 @@ BOOL CreateGrayscaleAndMaskBitmaps(HBITMAP hSource, COLORREF transparent,
         goto exitus;
     }
 
-    // pozadovana barevna hloubka je 24 bitu
+    // Force a 24-bit color depth.
     bi.bmiHeader.biSizeImage = ((((bi.bmiHeader.biWidth * 24) + 31) & ~31) >> 3) * bi.bmiHeader.biHeight;
-    // naalokuju potrebny prostor
+    // Allocate the required storage.
     lpvBits = malloc(bi.bmiHeader.biSizeImage);
     if (lpvBits == NULL)
     {
@@ -477,7 +475,7 @@ BOOL CreateGrayscaleAndMaskBitmaps(HBITMAP hSource, COLORREF transparent,
     bi.bmiHeader.biBitCount = 24;
     bi.bmiHeader.biCompression = BI_RGB;
 
-    // vytahnu vlastni data
+    // Retrieve the bitmap data.
     if (!GetDIBits(hDC,
                    hSource,
                    0, bi.bmiHeader.biHeight,
@@ -489,7 +487,7 @@ BOOL CreateGrayscaleAndMaskBitmaps(HBITMAP hSource, COLORREF transparent,
         goto exitus;
     }
 
-    // vytahnu vlastni data pro mask
+    // Retrieve the mask data.
     if (!GetDIBits(hDC,
                    hSource,
                    0, bi.bmiHeader.biHeight,
@@ -501,7 +499,7 @@ BOOL CreateGrayscaleAndMaskBitmaps(HBITMAP hSource, COLORREF transparent,
         goto exitus;
     }
 
-    // prevedu na grayscale
+    // Convert the bitmap to grayscale.
     BYTE* rgb;
     BYTE* rgbMask;
     rgb = (BYTE*)lpvBits;
@@ -524,7 +522,7 @@ BOOL CreateGrayscaleAndMaskBitmaps(HBITMAP hSource, COLORREF transparent,
         rgbMask += 3;
     }
 
-    // vytvorim novou bitmapu nad grayscale datama
+    // Create a bitmap from the grayscale data.
     hGrayscale = HANDLES(CreateDIBitmap(hDC,
                                         &bi.bmiHeader,
                                         (LONG)CBM_INIT,
@@ -537,7 +535,7 @@ BOOL CreateGrayscaleAndMaskBitmaps(HBITMAP hSource, COLORREF transparent,
         goto exitus;
     }
 
-    // vytvorim novou bitmapu nad mask datama
+    // Create a bitmap from the mask data.
     hMask = HANDLES(CreateDIBitmap(hDC,
                                    &bi.bmiHeader,
                                    (LONG)CBM_INIT,
@@ -563,7 +561,7 @@ exitus:
     return ret;
 }
 
-// JRYFIXME - docasne pro prechod na SVG
+// JRYFIXME - temporary helper while transitioning to SVG.
 BOOL CreateGrayscaleAndMaskBitmaps_tmp(HBITMAP hSource, COLORREF transparent, COLORREF bkColorForAlpha,
                                        HBITMAP& hGrayscale, HBITMAP& hMask)
 {
@@ -575,11 +573,11 @@ BOOL CreateGrayscaleAndMaskBitmaps_tmp(HBITMAP hSource, COLORREF transparent, CO
     hMask = NULL;
     HDC hDC = HANDLES(GetDC(NULL));
 
-    // vytahnu rozmery bitmapy
+    // get the bitmap dimensions
     BITMAPINFO bi;
     memset(&bi, 0, sizeof(bi));
     bi.bmiHeader.biSize = sizeof(bi.bmiHeader);
-    bi.bmiHeader.biBitCount = 0; // nechceme paletu
+    bi.bmiHeader.biBitCount = 0; // we do not want a palette
 
     if (!GetDIBits(hDC,
                    hSource,
@@ -598,9 +596,9 @@ BOOL CreateGrayscaleAndMaskBitmaps_tmp(HBITMAP hSource, COLORREF transparent, CO
         goto exitus;
     }
 
-    // pozadovana barevna hloubka je 24 bitu
+    // Force a 24-bit color depth.
     bi.bmiHeader.biSizeImage = ((((bi.bmiHeader.biWidth * 24) + 31) & ~31) >> 3) * bi.bmiHeader.biHeight;
-    // naalokuju potrebny prostor
+    // Allocate the required storage.
     lpvBits = malloc(bi.bmiHeader.biSizeImage);
     if (lpvBits == NULL)
     {
@@ -618,7 +616,7 @@ BOOL CreateGrayscaleAndMaskBitmaps_tmp(HBITMAP hSource, COLORREF transparent, CO
     bi.bmiHeader.biBitCount = 24;
     bi.bmiHeader.biCompression = BI_RGB;
 
-    // vytahnu vlastni data
+    // Retrieve the bitmap data.
     if (!GetDIBits(hDC,
                    hSource,
                    0, bi.bmiHeader.biHeight,
@@ -630,7 +628,7 @@ BOOL CreateGrayscaleAndMaskBitmaps_tmp(HBITMAP hSource, COLORREF transparent, CO
         goto exitus;
     }
 
-    // vytahnu vlastni data pro mask
+    // Retrieve the mask data.
     if (!GetDIBits(hDC,
                    hSource,
                    0, bi.bmiHeader.biHeight,
@@ -642,7 +640,7 @@ BOOL CreateGrayscaleAndMaskBitmaps_tmp(HBITMAP hSource, COLORREF transparent, CO
         goto exitus;
     }
 
-    // prevedu na grayscale
+    // Convert the bitmap to grayscale.
     BYTE* rgb;
     BYTE* rgbMask;
     rgb = (BYTE*)lpvBits;
@@ -667,7 +665,7 @@ BOOL CreateGrayscaleAndMaskBitmaps_tmp(HBITMAP hSource, COLORREF transparent, CO
         rgbMask += 3;
     }
 
-    // vytvorim novou bitmapu nad grayscale datama
+    // Create a bitmap from the grayscale data.
     hGrayscale = HANDLES(CreateDIBitmap(hDC,
                                         &bi.bmiHeader,
                                         (LONG)CBM_INIT,
@@ -680,7 +678,7 @@ BOOL CreateGrayscaleAndMaskBitmaps_tmp(HBITMAP hSource, COLORREF transparent, CO
         goto exitus;
     }
 
-    // vytvorim novou bitmapu nad mask datama
+    // Create a bitmap from the mask data.
     hMask = HANDLES(CreateDIBitmap(hDC,
                                    &bi.bmiHeader,
                                    (LONG)CBM_INIT,
@@ -709,7 +707,7 @@ exitus:
 void RenderSVGImages(HDC hDC, int iconSize, COLORREF bkColor, const CSVGIcon* svgIcons, int svgIconsCount)
 {
     NSVGrasterizer* rast = nsvgCreateRasterizer();
-    // JRYFIXME: docasne cteme ze souboru, prejit na spolecne uloziste s toolbars
+    // JRYFIXME: temporarily reads from a file; switch to the shared toolbar storage.
     for (int i = 0; i < svgIconsCount; i++)
         if (svgIcons[i].SVGName != NULL)
             RenderSVGImage(rast, hDC, svgIcons[i].ImageIndex * iconSize, 0, svgIcons[i].SVGName, iconSize, bkColor, TRUE);
@@ -721,10 +719,9 @@ void RenderSVGImages(HDC hDC, int iconSize, COLORREF bkColor, const CSVGIcon* sv
 //
 // CreateToolbarBitmaps
 //
-// Vytahne z resID bitmapu, nakopiruje ji do nove bitmapy, ktera je
-// barevne kompatibilni s obrazovkou. Potom k teto bitmape pripoji
-// ikonky z shell32.dll. Cti transparentni barvu.
-// bkColorForAlpha udava barvu, ktera bude prosvitat pod pruhlednou casti ikon (WinXP)
+// Load a bitmap identified by resID and copy it into a new screen-compatible bitmap.
+// Then append icons from shell32.dll while honoring the transparent color.
+// bkColorForAlpha specifies the color that shows through transparent icon regions (WinXP).
 //
 
 BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, COLORREF bkColorForAlpha,
@@ -745,16 +742,15 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16); // small icon size
     int iconCount = 0;
 
-    // Windows XP a novejsi pouzivaji transparentni ikony; protoze je pomoci masky
-    // zobrazime do teto docasne bitmapy a zajistime, aby pod pruhlednou casti byla
-    // sediva barva z toolbary a ne nase fialova maskovaci
+    // Windows XP and newer use transparent icons. Render them into this temporary bitmap
+    // so the area beneath their transparent parts uses the toolbar gray instead of our purple mask color.
     HBITMAP hTmpBitmap = NULL;
     HDC hTmpMemDC = NULL;
     HBITMAP hOldTmpBitmap = NULL;
 
-    // nactu zdrojovou bitmapu
+    // Load the source bitmap.
     HBITMAP hSource;
-    if (resID == IDB_TOOLBAR_256) // dirty hack, chtelo by to detekci podle typu resourcu (RCDATA), pripadne podle PNG signatury
+    if (resID == IDB_TOOLBAR_256) // dirty hack, this should really detect the resource type (RCDATA) or the PNG signature
         hSource = LoadPNGBitmap(hInstance, MAKEINTRESOURCE(resID), 0);
     else
         hSource = HANDLES(LoadBitmap(hInstance, MAKEINTRESOURCE(resID)));
@@ -765,11 +761,11 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
     }
 
     hDC = HANDLES(GetDC(NULL));
-    // vytahnu rozmery bitmapy
+    // get the bitmap dimensions
     BITMAPINFO bi;
     memset(&bi, 0, sizeof(bi));
     bi.bmiHeader.biSize = sizeof(bi.bmiHeader);
-    bi.bmiHeader.biBitCount = 0; // nechceme paletu
+    bi.bmiHeader.biBitCount = 0; // we do not want a palette
     if (!GetDIBits(hDC,
                    hSource,
                    0, 0,
@@ -791,13 +787,13 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
                 tbbe_BMPCOUNT++;
     }
 
-    // pripravim novou bitmapu, do ktere se vejde hSource a ikonky z DLLka
-    // prodlouzim delku o ikonky z DLL
+    // prepare a new bitmap that fits hSource and the icons from the DLL
+    // extend the width by the icons pulled from the DLL
     iconCount = bi.bmiHeader.biWidth / 16 + tbbe_BMPCOUNT;
 
     //  hColorBitmap = HANDLES(CreateBitmap(width, height, bh.bV4Planes, bh.bV4BitCount, NULL));
-    //protoze je CreateBitmap() vhodne pouze pro vytvareni B&W bitmap (viz MSDN)
-    //prechazime od sal 2.5b7 na rychlou CreateCompatibleBitmap()
+    // because CreateBitmap() is suitable only for creating B&W bitmaps (see MSDN)
+    // since Salamander 2.5b7 we switched to the faster CreateCompatibleBitmap()
     hColorBitmap = HANDLES(CreateCompatibleBitmap(hDC, iconSize * iconCount, iconSize));
 
     hTgtMemDC = HANDLES(CreateCompatibleDC(NULL));
@@ -805,12 +801,12 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
     hOldTgtBitmap = (HBITMAP)SelectObject(hTgtMemDC, hColorBitmap);
     hOldSrcBitmap = (HBITMAP)SelectObject(hSrcMemDC, hSource);
 
-    // pro prenaseni icon (vcetne transparentnich)
+    // for transferring icons (including transparent ones)
     hTmpBitmap = HANDLES(CreateBitmap(iconSize, iconSize, 1, 1, NULL));
     hTmpMemDC = HANDLES(CreateCompatibleDC(NULL));
     hOldTmpBitmap = (HBITMAP)SelectObject(hTmpMemDC, hTmpBitmap);
 
-    // prenesu do nove bitmapy bitmapu puvodni
+    // copy the original bitmap into the new bitmap
     if (!StretchBlt(hTgtMemDC, 0, 0, (iconCount - tbbe_BMPCOUNT) * iconSize, iconSize,
                     hSrcMemDC, 0, 0, bi.bmiHeader.biWidth, bi.bmiHeader.biHeight,
                     SRCCOPY))
@@ -819,23 +815,23 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
         goto exitus;
     }
 
-    // zahodime zdrojovou bitmapu
+    // discard the source bitmap
     SelectObject(hSrcMemDC, hOldSrcBitmap);
     hOldSrcBitmap = NULL;
 
-    // pokud mame SVG verzi, pouzijeme ji
+    // if we have an SVG version, use it
     if (svgIcons != NULL)
     {
         RenderSVGImages(hTgtMemDC, iconSize, bkColorForAlpha, svgIcons, svgIconsCount);
     }
 
-    // pouzijeme pri BitBlt hTmpMemDC->hTgtMemDC
+    // used when BitBlt-ing from hTmpMemDC to hTgtMemDC
     //SetBkColor(hTgtMemDC, transparent);
     //SetTextColor(hTgtMemDC, bkColorForAlpha);
 
     if (appendIcons)
     {
-        // podojime shell32.dll
+        // fetch icons from shell32.dll
         HICON hIcon;
         for (i = 0; i < TBBE_TERMINATOR; i++)
         {
@@ -853,7 +849,7 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
             }
             else
             {
-                // Documents jsou od WinXP jinde
+                // Documents moved elsewhere starting with WinXP
                 if (resID2 == 21)
                     resID2 = 235;
 
@@ -865,10 +861,10 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
                 continue;
             }
 
-            // pripravime pozadi pro ikonky s alfa kanalem pod WinXP
+            // prepare the background for icons with an alpha channel on WinXP
             DrawIconEx(hTmpMemDC, 0, 0, hIcon, iconSize, iconSize, 0, 0, DI_MASK);
 
-            // pouzijeme pri BitBlt hTmpMemDC->hTgtMemDC
+            // used when BitBlt-ing from hTmpMemDC to hTgtMemDC
             SetBkColor(hTgtMemDC, transparent);
             SetTextColor(hTgtMemDC, bkColorForAlpha);
             BitBlt(hTgtMemDC, iconSize * ToolBarButtons[i].ImageIndex, 0, iconSize, iconSize,
@@ -885,9 +881,9 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
             else
             {
                 /*
-        // --- sileny patch BEGIN
-        // John: pod W2K mi neslapalo pro ikonku 21 (Documents) DrawIconEx s parametrem DI_NORMAL
-        // z neznameho duvodu saturovalo pruhledny prostor a tim zmenilo barvu 'transparent'
+        // --- crazy patch BEGIN
+        // John: under W2K DrawIconEx with DI_NORMAL did not work for icon 21 (Documents)
+        // for an unknown reason it saturated the transparent area and changed the 'transparent' color
         SetBkColor(hTgtMemDC, RGB(0, 0, 0));
         SetTextColor(hTgtMemDC, RGB(255, 255, 255));
         BitBlt(hTgtMemDC, ICON16_CX * ToolBarButtons[i].ImageIndex, 0, ICON16_CX, ICON16_CX,
@@ -898,7 +894,7 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
         BitBlt(hTgtMemDC, ICON16_CX * ToolBarButtons[i].ImageIndex, 0, ICON16_CX, ICON16_CX,
                hTmpMemDC, 0, 0,
                SRCPAINT);
-        // --- sileny patch END
+        // --- crazy patch END
         */
                 HANDLES(DestroyIcon(hIcon));
             }
@@ -944,9 +940,9 @@ exitus:
 //
 // PrepareToolTipText
 //
-// Prohleda buff na prvni vyskyt znaku '\t'. Pokud je nastavena promenna
-// stripHotKey, vlozi na jeho misto terminator a vrati se. Jinak na jeho
-// misto vlozi mezeru, zbytek posunu o znak vpravo a ozavorkuje.
+// Searches the buffer for the first occurrence of the '\t' character. If the stripHotKey variable is set,
+// it inserts a terminator in its place and returns. Otherwise it inserts a space there, shifts the rest one
+// character to the right, and wraps it in parentheses.
 //
 
 void PrepareToolTipText(char* buff, BOOL stripHotKey)
@@ -992,7 +988,7 @@ BOOL CMainToolBar::FillTII(int tbbeIndex, TLBI_ITEM_INFO2* tii, BOOL fillName)
     }
     if (ToolBarButtons[tbbeIndex].ImageIndex == 0xFFFF)
     {
-        // stara polozka, ktera v teto verzi byla zrusena
+        // old item that was removed in this version
         return FALSE;
     }
 
@@ -1047,7 +1043,7 @@ BOOL CMainToolBar::FillTII(int tbbeIndex, TLBI_ITEM_INFO2* tii, BOOL fillName)
         if (fillName)
         {
             tii->Name = LoadStr(ToolBarButtons[tbbeIndex].ToolTipResID);
-            // retezec bude orezan, proto muzeme operaci provest nad bufferem z LoadStr
+            // the string will be truncated, so we can perform the operation on the buffer from LoadStr
             PrepareToolTipText(tii->Name, TRUE);
         }
     }
@@ -1128,8 +1124,8 @@ void CMainToolBar::OnGetToolTip(LPARAM lParam)
             CFilesWindow* activePanel = MainWindow != NULL ? MainWindow->GetActivePanel() : NULL;
             BOOL activePanelIsDisk = (activePanel != NULL && activePanel->Is(ptDisk));
             if (EnablerPastePath &&
-                (!activePanelIsDisk || !EnablerPasteFiles) && // PasteFiles je prioritni
-                !EnablerPasteFilesToArcOrFS)                  // PasteFilesToArcOrFS je prioritni
+                (!activePanelIsDisk || !EnablerPasteFiles) && // PasteFiles has priority
+                !EnablerPasteFilesToArcOrFS)                  // PasteFilesToArcOrFS has priority
             {
                 char tail[50];
                 tail[0] = 0;
@@ -1164,7 +1160,7 @@ BOOL CMainToolBar::OnEnumButton(LPARAM lParam)
         break;
     }
     if (tbbeIndex == TBBE_TERMINATOR)
-        return FALSE; // vsechna tlacitka uz byla natlacena
+        return FALSE; // all buttons have already been added
     FillTII(tbbeIndex, tii, TRUE);
     return TRUE;
 }
@@ -1203,12 +1199,12 @@ void CMainToolBar::SetType(CMainToolBarType type)
 // CBottomToolBar
 //
 
-#define BOTTOMTB_TEXT_MAX 15 // maximalni delka retezce pro jednu klavesu
+#define BOTTOMTB_TEXT_MAX 15 // maximum string length for a single key
 struct CBottomTBData
 {
     DWORD Index;
-    BYTE TextLen;                 // pocet zanaku v promenne 'Text'
-    char Text[BOTTOMTB_TEXT_MAX]; // text bez terminatoru
+    BYTE TextLen;                 // number of characters in the 'Text' variable
+    char Text[BOTTOMTB_TEXT_MAX]; // text without the terminator
 };
 
 CBottomTBData BottomTBData[btbsCount][12] =
@@ -1325,14 +1321,14 @@ CBottomToolBar::CBottomToolBar(HWND hNotifyWindow, CObjectOrigin origin)
 {
     CALL_STACK_MESSAGE_NONE
     State = btbsCount;
-    Padding.ButtonIconText = 1; // pritahneme text k ikonce
-    Padding.IconLeft = 2;       // prostor pred ikonou
-    Padding.TextRight = 2;      // prostor za textem
+    Padding.ButtonIconText = 1; // pull the text toward the icon
+    Padding.IconLeft = 2;       // space before the icon
+    Padding.TextRight = 2;      // space after the text
 }
 
-// naplni v poli BottomTBData promennou 'Text', kterou vycte z resourcu
-// 'state' udava radek v poli BottomTBData a 'BottomTBData' oznacuje retezec s textama
-// texty pro jednotlive klavesy jsou oddeleny znakem ';'
+// fills the 'Text' field in the BottomTBData array with strings read from resources
+// 'state' specifies the row in the BottomTBData array and 'BottomTBData' names the string with the texts
+// the texts for individual keys are separated by the ';' character
 BOOL CBottomToolBar::InitDataResRow(CBottomTBStateEnum state, int textResID)
 {
     CALL_STACK_MESSAGE2("CBottomToolBar::InitDataResRow(, %d)", textResID);
@@ -1479,7 +1475,7 @@ BOOL CBottomToolBar::SetState(CBottomTBStateEnum state)
         TLBI_ITEM_INFO2 tii;
         tii.Mask = TLBI_MASK_TEXT | TLBI_MASK_TEXTLEN | TLBI_MASK_ID | TLBI_MASK_ENABLER |
                    TLBI_MASK_STATE | TLBI_MASK_CUSTOMDATA;
-        tii.State = 0; // povolime command - bude volano UpdateItemsState(), ktere zakaze co je treba
+        tii.State = 0; // enable the command - UpdateItemsState() will disable whatever is necessary
         char emptyBuff[] = "";
         tii.Text = empty ? emptyBuff : BottomTBData[state][i].Text;
         tii.TextLen = empty ? 0 : BottomTBData[state][i].TextLen;
@@ -1501,7 +1497,7 @@ BOOL CBottomToolBar::SetState(CBottomTBStateEnum state)
     GetCursorPos(&p);
     if (WindowFromPoint(p) == HWindow)
     {
-        // zajistime obnovu pripadneho tooltipu
+        // ensure that any tooltip is refreshed
         ScreenToClient(HWindow, &p);
         SetCurrentToolTip(NULL, 0);
         PostMessage(HWindow, WM_MOUSEMOVE, 0, MAKELPARAM(p.x, p.y));

--- a/src/toolbar5.cpp
+++ b/src/toolbar5.cpp
@@ -24,9 +24,9 @@ extern "C"
 class CUMDropTarget : public IDropTarget
 {
 private:
-    long RefCount;             // zivotnost objektu
-    IDataObject* DataObject;   // IDataObject, ktery vstoupil do dragu
-    CUserMenuBar* UserMenuBar; // bar, ke kteremu jsme asociovani
+    long RefCount;             // object lifetime
+    IDataObject* DataObject;   // IDataObject that entered the drag
+    CUserMenuBar* UserMenuBar; // bar we are associated with
     IDropTarget* DropTarget;
     char DropTargetFileName[MAX_PATH];
 
@@ -70,12 +70,12 @@ public:
         if (--RefCount == 0)
         {
             delete this;
-            return 0; // nesmime sahnout do objektu, uz neexistuje
+            return 0; // we must not touch the object, it no longer exists
         }
         return RefCount;
     }
 
-    void HitTest(POINTL pt, int& insertIndex, BOOL& after, int& pasteIndex, char* fileName, BOOL insert) // fileName buffer ma delku MAX_PATH
+    void HitTest(POINTL pt, int& insertIndex, BOOL& after, int& pasteIndex, char* fileName, BOOL insert) // fileName buffer has length MAX_PATH
     {
         POINT p;
         p.x = pt.x;
@@ -116,7 +116,7 @@ public:
         if (pasteIndex != -1)
         {
             insertIndex = -1;
-            // overim, ze jde o target
+            // Verify that the drop target is valid.
             TLBI_ITEM_INFO2 tii;
             tii.Mask = TLBI_MASK_ID;
             if (UserMenuBar->GetItemInfo2(pasteIndex, TRUE, &tii))
@@ -204,7 +204,7 @@ public:
 
         if (DataObject != NULL)
         {
-            // provedeme hittest
+            // Perform a hit test to locate the drop position.
             int insertIndex = -1;
             BOOL after;
             int pasteIndex = -1;
@@ -257,7 +257,7 @@ public:
             ImageDragMove(pt.x, pt.y);
         if (DataObject != NULL)
         {
-            // provedeme hittest
+            // Perform a hit test to locate the drop position.
             int insertIndex = -1;
             BOOL after;
             int pasteIndex = -1;
@@ -324,9 +324,9 @@ public:
             DataObject = NULL;
         }
 
-        // sestrelim insert mark
+        // Clear the insert mark.
         UserMenuBar->SetInsertMark(-1, FALSE);
-        // sestrelim hot item
+        // Clear the hot item.
         UserMenuBar->SetHotItem(-1);
 
         return E_UNEXPECTED;
@@ -342,7 +342,7 @@ public:
             ImageDragLeave();
         if (DataObject != NULL)
         {
-            // provedeme hittest
+            // Perform a hit test to resolve the drop target.
             int insertIndex = -1;
             BOOL after;
             int pasteIndex = -1;
@@ -355,7 +355,7 @@ public:
 
             if (insertIndex != -1)
             {
-                // sestrelim insert mark
+                // Clear the insert mark.
                 UserMenuBar->SetInsertMark(-1, FALSE);
 
                 if (insert)
@@ -372,11 +372,11 @@ public:
                     char tmp[MAX_PATH];
                     BOOL shell = FALSE;
 
-                    // zmenil jsem metodu CMainWindow::UserMenu tak, ze pokud nespousti pres Shell,
-                    // vola ShellExecuteEx misto CreateProcess; proto uz nejsou potreba uvozovky
+                    // I changed CMainWindow::UserMenu so that if it does not launch through the Shell,
+                    // it calls ShellExecuteEx instead of CreateProcess; therefore quotes are no longer needed
                     /*
-            // pokud se nejedna o spustitelny soubor (.exe, .com, .bat, .pif),
-            // soupnu nazev do uvozovek a spustim ho pres shell
+            // if it is not an executable file (.exe, .com, .bat, .pif),
+            // wrap the name in quotes and launch it through the shell
             char *dot = strrchr(buff, '.');
             if (dot != NULL && *(dot + 1) != 0)
             {
@@ -397,7 +397,7 @@ public:
             }
 */
 
-                    // pokud je v ceste znak $, musim ho nahradit $$
+                    // if the path contains the character $, replace it with $$
                     strcpy(tmp, buff);
                     char* iterS = tmp;
                     char* iterT = buff;
@@ -419,7 +419,7 @@ public:
                     CUserMenuItem* item = new CUserMenuItem(name, buff, emptyBuffer, fullPathBuffer, emptyBuffer,
                                                             shell, FALSE, FALSE, TRUE, umitItem, NULL);
 
-                    // vyhledame misto, kam je treba polozku vlozit
+                    // find the place where the item needs to be inserted
                     int count = 0;
                     int i;
                     for (i = 0; i < MainWindow->UserMenuItems->Count; i++)
@@ -440,12 +440,12 @@ public:
                     }
                     MainWindow->UserMenuItems->Insert(i, item);
 
-                    if (UserMenuIconBkgndReader.IsReadingIcons()) // probiha nacitani ikon = musime ho nahodit znovu, zmenil se pocet polozek v user menu (jako side-efekt to zahodi prave nactenou ikonu dropleho souboru, ale na to proste kaslu)
+                    if (UserMenuIconBkgndReader.IsReadingIcons()) // icon loading is in progress, so restart it because the user menu item count changed (as a side effect this drops the icon just read for the dropped file, but that's acceptable)
                     {
                         CUserMenuIconDataArr* bkgndReaderData = new CUserMenuIconDataArr();
                         for (int i2 = 0; i2 < MainWindow->UserMenuItems->Count; i2++)
                             MainWindow->UserMenuItems->At(i2)->GetIconHandle(bkgndReaderData, FALSE);
-                        UserMenuIconBkgndReader.StartBkgndReadingIcons(bkgndReaderData); // POZOR: uvolni 'bkgndReaderData'
+                        UserMenuIconBkgndReader.StartBkgndReadingIcons(bkgndReaderData); // WARNING: releases 'bkgndReaderData'
                     }
 
                     MainWindow->UMToolBar->CreateButtons();
@@ -513,8 +513,8 @@ CUserMenuBar::CUserMenuBar(HWND hNotifyWindow, CObjectOrigin origin)
     RemoveAllItems();
     SetStyle(TLB_STYLE_IMAGE | (Configuration.UserMenuToolbarLabels ? TLB_STYLE_TEXT : 0));
 
-    // naleju ikonky do vlastni toolbary
-    // vlozim pouze itemy a submenu z nejvyssi urovne; ostatni se bude rozbalovat jako submenu
+    // load icons into the toolbar
+    // insert only items and submenus from the top level; the rest will expand as submenus
     int level = 0;
     TLBI_ITEM_INFO2 tii;
     int i;
@@ -574,7 +574,7 @@ CUserMenuBar::CUserMenuBar(HWND hNotifyWindow, CObjectOrigin origin)
 void CUserMenuBar::ToggleLabels()
 {
     CALL_STACK_MESSAGE1("CUserMenuBar::ToggleLabels()");
-    // nastvim styl
+    // update the style
     DWORD style = GetStyle();
     if (Configuration.UserMenuToolbarLabels)
         style &= ~TLB_STYLE_TEXT;
@@ -587,7 +587,7 @@ void CUserMenuBar::ToggleLabels()
 int CUserMenuBar::GetNeededHeight()
 {
     CALL_STACK_MESSAGE_NONE
-    // i v pripade, ze nedrzime zadnou ikonu budeem vracet spravnou vysku
+    // return the correct height even when no icon is loaded
     int height = CToolBar::GetNeededHeight();
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
     int minH = 3 + iconSize + 3;
@@ -599,7 +599,7 @@ int CUserMenuBar::GetNeededHeight()
 void CUserMenuBar::Customize()
 {
     CALL_STACK_MESSAGE_NONE
-    // nechame vybalit stranku UserMenu a rozeditovat polozku index
+    // open the UserMenu page and let it edit the item at the given index
     PostMessage(MainWindow->HWindow, WM_USER_CONFIGURATION, 2, 0);
 }
 
@@ -662,7 +662,7 @@ CUserMenuBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 TRACE_E("RegisterDragDrop error.");
             }
-            dropTarget->Release(); // RegisterDragDrop volala AddRef()
+            dropTarget->Release(); // RegisterDragDrop called AddRef()
         }
         break;
     }

--- a/src/toolbar6.cpp
+++ b/src/toolbar6.cpp
@@ -24,7 +24,7 @@ CDriveBar::CDriveBar(HWND hNotifyWindow, CObjectOrigin origin)
 {
     CALL_STACK_MESSAGE_NONE
     List = NULL;
-    // tato inicializace je take ve WM_DESTROY, protoze okno se pouze zhasina a rozsveci
+    // Repeat this initialization in WM_DESTROY because the window only dims and lights up again.
     CheckedDrive[0] = 0;
     HDrivesIcons = NULL;
     HDrivesIconsGray = NULL;
@@ -55,8 +55,8 @@ BOOL CDriveBar::CreateDriveButtons(CDriveBar* copyDrivesListFrom)
     if (HWindow == NULL)
         return FALSE;
 
-    // potlacime kresleni, abychom predesli mrkani checked polozky (staci otevrit a zavrit plugins manager a mrkalo by to)
-    // take jsme mrkali pri spusteni salamandera
+    // Suppress painting to avoid the checked item blinking (opening and closing the plugins manager would make it flicker).
+    // This also prevented flicker during Salamander startup.
     SendMessage(HWindow, WM_SETREDRAW, FALSE, 0);
     RemoveAllItems();
     SetStyle(TLB_STYLE_IMAGE | TLB_STYLE_TEXT);
@@ -111,7 +111,7 @@ BOOL CDriveBar::CreateDriveButtons(CDriveBar* copyDrivesListFrom)
 int CDriveBar::GetNeededHeight()
 {
     CALL_STACK_MESSAGE_NONE
-    // i v pripade, ze nedrzime zadnou ikonu budeem vracet spravnou vysku
+    // Return the correct height even when no icon is loaded.
     int height = CToolBar::GetNeededHeight();
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
     int minH = 3 + iconSize + 3;
@@ -139,7 +139,7 @@ void CDriveBar::Execute(DWORD id)
                 panel = MainWindow->GetActivePanel();
 
             if (DriveType != drvtPluginCmd)
-                panel->TopIndexMem.Clear(); // dlouhy skok
+                panel->TopIndexMem.Clear(); // treat this as a long jump
 
             char path[MAX_PATH];
             switch (DriveType)
@@ -147,15 +147,15 @@ void CDriveBar::Execute(DWORD id)
             case drvtMyDocuments:
             case drvtGoogleDrive:
             case drvtDropbox:
-            case drvtOneDrive:    // bud primo tlacitko nebo vybrane z drop down menu
-            case drvtOneDriveBus: // bud primo tlacitko nebo vybrane z drop down menu
+            case drvtOneDrive:    // either a direct button or selected from the drop-down menu
+            case drvtOneDriveBus: // either a direct button or selected from the drop-down menu
             {
                 panel->ChangePathToDrvType(HWindow, DriveType, DriveType == drvtOneDriveBus ? (const char*)DriveTypeParam : NULL);
                 if (DriveType == drvtOneDriveBus)
                     free((char*)DriveTypeParam);
-                if ((DriveType == drvtOneDrive || DriveType == drvtOneDriveBus) &&
+        if ((DriveType == drvtOneDrive || DriveType == drvtOneDriveBus) &&
                     !fromDropDown && GetOneDriveStorages() > 1)
-                { // OneDrive by zase mel byt drop down, provedeme refresh obou Drive bar, at se updatne tlacitko
+                { // OneDrive should once again be a drop-down; refresh both drive bars so the button is updated
                     if (MainWindow != NULL && MainWindow->HWindow != NULL)
                         PostMessage(MainWindow->HWindow, WM_USER_DRIVES_CHANGE, 0, 0);
                 }
@@ -166,7 +166,7 @@ void CDriveBar::Execute(DWORD id)
                 TRACE_E("CDriveBar::Execute(): unexpected drive type: drvtOneDriveMenu");
                 return;
 
-            // jde o Network?
+            // is this Network?
             case drvtNeighborhood:
             {
                 if (GetTargetDirectory(panel->HWindow, panel->HWindow, LoadStr(IDS_CHANGEDRIVE),
@@ -192,10 +192,10 @@ void CDriveBar::Execute(DWORD id)
 
             case drvtPluginCmd:
             {
-                // kod prevzaty z fileswn3.cpp, CFilesWindow::ChangeDrive()
+                // code taken from fileswn3.cpp, CFilesWindow::ChangeDrive()
                 const char* dllName = (const char*)DriveTypeParam;
                 CPluginData* data = Plugins.GetPluginData(dllName);
-                if (data != NULL) // plug-in existuje, jdeme spustit prikaz
+                if (data != NULL) // the plug-in exists, go run the command
                     data->ExecuteChangeDriveMenuItem(panel == MainWindow->LeftPanel ? PANEL_LEFT : PANEL_RIGHT);
                 return;
             }
@@ -212,7 +212,7 @@ void CDriveBar::SetCheckedDrive(CFilesWindow* panel, BOOL force)
     if (isDiskOrArchive)
         lstrcpyn(CheckedDrive, panel->GetPath(), 3);
     else
-        CheckedDrive[0] = 0; // pro FS tato cache nefunguje
+          CheckedDrive[0] = 0; // this cache does not work for file systems
     DWORD index;
     if (List == NULL || !List->FindPanelPathIndex(panel, &index))
         index = -1;
@@ -231,7 +231,7 @@ void CDriveBar::SetCheckedDrive(CFilesWindow* panel, BOOL force)
                 if (indexInList >= CM_DRIVEBAR2_MIN && indexInList <= CM_DRIVEBAR2_MAX)
                     indexInList -= CM_DRIVEBAR2_MIN;
                 else
-                    indexInList = -2; // nemelo by se stat
+                      indexInList = -2; // should not happen
             }
             CheckItem(i, TRUE, index == indexInList);
         }
@@ -280,7 +280,7 @@ BOOL CDriveBar::OnContextMenu()
                 if (indexInList >= CM_DRIVEBAR2_MIN && indexInList <= CM_DRIVEBAR2_MAX)
                     indexInList -= CM_DRIVEBAR2_MIN;
                 else
-                    return FALSE; // nemelo by se stat
+                      return FALSE; // should not happen
             }
             CFilesWindow* panel;
             BOOL bar2 = this == MainWindow->DriveBar2;
@@ -294,13 +294,13 @@ BOOL CDriveBar::OnContextMenu()
             FromContextMenu = FALSE;
             const char* dllName = NULL;
             List->OnContextMenu(TRUE, indexInList, panel == MainWindow->LeftPanel ? PANEL_LEFT : PANEL_RIGHT, &dllName);
-            if (PostCmd != 0) // nastavuje se jen na drvtPluginFS a drvtPluginCmd, pricemz drvtPluginFS nemuze byt na Drive bare
+            if (PostCmd != 0) // set only on drvtPluginFS and drvtPluginCmd, and drvtPluginFS cannot be on the Drive bar
             {
                 UpdateWindow(MainWindow->HWindow);
 
                 CPluginData* data = Plugins.GetPluginData(dllName);
-                if (data != NULL) // plug-in existuje, jdeme spustit prikaz
-                {                 // post-cmd z kontextoveho menu polozky FS
+                if (data != NULL) // the plug-in exists, go run the command
+                {                 // post-command from the context menu of an FS item
                     data->GetPluginInterfaceForFS()->ExecuteChangeDrivePostCommand(panel == MainWindow->LeftPanel ? PANEL_LEFT : PANEL_RIGHT,
                                                                                    PostCmd, PostCmdParam);
                 }

--- a/src/toolbar7.cpp
+++ b/src/toolbar7.cpp
@@ -35,8 +35,8 @@ CHotPathsBar::CHotPathsBar(HWND hNotifyWindow, CObjectOrigin origin)
 
     SetStyle(TLB_STYLE_IMAGE | TLB_STYLE_TEXT);
 
-    // naleju ikonky do vlastni toolbary
-    // vlozim pouze itemy a submenu z nejvyssi urovne; ostatni se bude rozbalovat jako submenu
+    // Load icons into the toolbar.
+    // Insert only top-level items and submenus; the rest expand as nested submenus.
     int level = 0;
     TLBI_ITEM_INFO2 tii;
     int i;
@@ -106,7 +106,7 @@ CHotPathsBar::CHotPathsBar(HWND hNotifyWindow, CObjectOrigin origin)
 int CHotPathsBar::GetNeededHeight()
 {
     CALL_STACK_MESSAGE_NONE
-    // i v pripade, ze nedrzime zadnou ikonu budeem vracet spravnou vysku
+    // Return the correct height even when no icon is loaded.
     int height = CToolBar::GetNeededHeight();
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
     int minH = 3 + iconSize + 3;
@@ -118,7 +118,7 @@ int CHotPathsBar::GetNeededHeight()
 void CHotPathsBar::Customize()
 {
     CALL_STACK_MESSAGE_NONE
-    // nechame vybalit stranku HotPaths
+    // Open the HotPaths page.
     PostMessage(MainWindow->HWindow, WM_USER_CONFIGURATION, 1, -1);
 }
 
@@ -153,7 +153,7 @@ CHotPathsBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
           TRACE_E("RegisterDragDrop error.");
         }
-        dropTarget->Release();  // RegisterDragDrop volala AddRef()
+        dropTarget->Release();  // RegisterDragDrop called AddRef().
       }
       break;
     }

--- a/src/toolbar8.cpp
+++ b/src/toolbar8.cpp
@@ -70,7 +70,7 @@ BOOL CPluginsBar::CreatePluginButtons()
     tii.Mask = TLBI_MASK_STYLE | TLBI_MASK_IMAGEINDEX | TLBI_MASK_ID;
     tii.Style = TLBI_STYLE_WHOLEDROPDOWN | TLBI_STYLE_DROPDOWN;
     tii.ImageIndex = i;
-    tii.ID = CM_PLUGINCMD_MIN + i; // do mainwnd3 prijde jako WM_USER_TBDROPDOWN
+    tii.ID = CM_PLUGINCMD_MIN + i; // mainwnd3 receives it as WM_USER_TBDROPDOWN.
     InsertItem2(0xFFFFFFFF, TRUE, &tii);
   }
   */
@@ -81,7 +81,7 @@ BOOL CPluginsBar::CreatePluginButtons()
 int CPluginsBar::GetNeededHeight()
 {
     CALL_STACK_MESSAGE_NONE
-    // i v pripade, ze nedrzime zadnou ikonu budeem vracet spravnou vysku
+    // Return the correct height even when no icon is loaded.
     int height = CToolBar::GetNeededHeight();
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
     int minH = 3 + iconSize + 3;
@@ -93,7 +93,7 @@ int CPluginsBar::GetNeededHeight()
 void CPluginsBar::Customize()
 {
     CALL_STACK_MESSAGE_NONE
-    // zobrazim okno Plugins
+    // Open the Plugins window.
     PostMessage(MainWindow->HWindow, WM_COMMAND, CM_CUSTOMIZEPLUGINS, 0);
 }
 

--- a/src/tooltip.cpp
+++ b/src/tooltip.cpp
@@ -13,10 +13,10 @@
 // CToolTip
 //
 
-//nahrazeno metodou GetTime()
-//#define TOOLTIP_SHOWDELAY 1000  // [ms] doba pred otevrenim tool tipu pri kurzoru nad jenim ID z jendnoho okna
-//#define TOOLTIP_HIDEDELAY   80  // [ms] (krat 100) doba pred zhasnutim tool tipu, pokud ho nesejme neco jineho
-#define TOOLTIP_KILLDELAY 300 // [ms] jak dlouho vydrzime, nez prejdeme do Killed rezimu (pro prechod pres separatory)
+// Replaced by the GetTime() method.
+//#define TOOLTIP_SHOWDELAY 1000  // [ms] delay before opening the tooltip when the cursor is over a single ID from one window
+//#define TOOLTIP_HIDEDELAY   80  // [ms] (times 100) delay before the tooltip fades if nothing else dismisses it
+#define TOOLTIP_KILLDELAY 300 // [ms] how long we endure before switching to the Killed state (for crossing separators)
 
 CToolTip* ToolTip = NULL;
 
@@ -48,7 +48,7 @@ CToolTip::~CToolTip()
     CALL_STACK_MESSAGE_NONE
     if (HWindow != NULL)
     {
-        // prekrocime hranici threadu a zhazneme tooltip v threadu, ve kterem byl otevren
+        // Cross the thread boundary and shut down the tooltip in the thread where it was opened.
         SendMessage(HWindow, WM_USER_HIDETOOLTIP, 0, 0);
     }
 }
@@ -86,9 +86,9 @@ BOOL CToolTip::Create(HWND hParent)
 
     if (HWindow != NULL)
     {
-        if (IsWindowVisible(HWindow)) // pokud uz je okno skryte, nebudeme varovat, protoze jde o doruceni odlozene zpravy a nasledne by bylo okno destruovano, viz CToolTip::MessageLoop()
+        if (IsWindowVisible(HWindow)) // if the window is already hidden, do not warn because a deferred message is being delivered and the window would be destroyed afterward; see CToolTip::MessageLoop()
             TRACE_E("CToolTip::Create() Tooltip window already exists!");
-        // prekrocime hranici threadu a zhasneme tooltip v threadu, ve kterem byl otevren
+        // Cross the thread boundary and shut down the tooltip in the thread where it was opened.
         SendMessage(HWindow, WM_USER_HIDETOOLTIP, 0, 0);
     }
 
@@ -116,15 +116,15 @@ BOOL CToolTip::Create(HWND hParent)
 DWORD
 CToolTip::GetTime(BOOL init)
 {
-    // casy viz MSDN/TTM_SETDELAYTIME
+    // timings per MSDN/TTM_SETDELAYTIME
     if (init)
         return GetDoubleClickTime();
     else
         return (GetDoubleClickTime() * 10) / 100;
 }
 
-// jediny zpusob, ktery jsem vykoumal pro detekci vysky kurzoru
-// je nakresleni masky kurzoru do DIBu a nasledne prohledani bitoveho pole
+// The only method I devised for detecting cursor height
+// is drawing the cursor mask into a DIB and then scanning the bit field.
 BOOL GetCursorHeight(HCURSOR hCursor)
 {
     if (hCursor == 0)
@@ -137,7 +137,7 @@ BOOL GetCursorHeight(HCURSOR hCursor)
     bi.bmiHeader.biWidth = 32;
     bi.bmiHeader.biHeight = 32;
     bi.bmiHeader.biPlanes = 1;
-    bi.bmiHeader.biBitCount = 1; // kazdy radek bude reprezentovan 32 bity
+    bi.bmiHeader.biBitCount = 1; // each row is represented by 32 bits.
     bi.bmiHeader.biCompression = BI_RGB;
     bi.bmiHeader.biClrUsed = 0;
     bi.bmiHeader.biClrImportant = 0;
@@ -148,9 +148,9 @@ BOOL GetCursorHeight(HCURSOR hCursor)
     DrawIconEx(hMemDC, 0, 0, hCursor, 0, 0, 0, NULL, DI_MASK | DI_DEFAULTSIZE);
     SelectObject(hMemDC, hOldBitmap);
 
-    GdiFlush(); // Flush the GDI batch, so we can play with the bits
+    GdiFlush(); // Flush the GDI batch so we can work with the bits.
 
-    // bitmapa ulozena od poslendi scanline smerem k nulte
+    // The bitmap is stored from the last scanline toward the first.
     int i;
     for (i = 0; i < 32; i++)
     {
@@ -223,14 +223,14 @@ void CToolTip::MessageLoop()
     ShowWindow(HWindow, SW_HIDE);
     IsModal = FALSE;
 
-    // nase okno bylo captured, vsechny zpravy jsme dostali my
-    // ted bychom potreboali dorucit posledni zpravu adresatovi
+    // our window captured the input; we received all messages
+    // now we need to deliver the last message to the recipient
     if (msg.message == WM_LBUTTONDOWN || msg.message == WM_RBUTTONDOWN ||
         msg.message == WM_MBUTTONDOWN)
     {
         HWND hWindow = WindowFromPoint(msg.pt);
         if (hWindow != NULL && hWindow != HWindow &&
-            GetWindowThreadProcessId(hWindow, NULL) == GetCurrentThreadId()) // SendMessage(hWindow, WM_NCHITTEST do jineho threadu zpusoboval deadlock
+            GetWindowThreadProcessId(hWindow, NULL) == GetCurrentThreadId()) // SendMessage(hWindow, WM_NCHITTEST to another thread caused a deadlock
         {
             POINT p;
             p.x = GET_X_LPARAM(msg.lParam);
@@ -258,15 +258,15 @@ void CToolTip::MessageLoop()
             msg.lParam = MAKELPARAM(p.x, p.y);
             msg.hwnd = hWindow;
 
-            // dame prilezitost dialogu, aby si nastavil default push button
+            // give the dialog a chance to set its default push button
             HWND hDialog = GetTopVisibleParent(hWindow);
 
             if (hDialog != NULL)
             {
                 DWORD pid;
                 GetWindowThreadProcessId(hDialog, &pid);
-                // zpravu nesmime dorucit do jineho procesu,
-                // jinak nam padal Salamander v USER32.DLL
+                // we must not deliver the message to another process,
+                // otherwise Salamander crashed in USER32.DLL
                 if (pid == GetCurrentProcessId())
                 {
                     if (hDialog == NULL || !IsDialogMessage(hDialog, &msg))
@@ -278,10 +278,10 @@ void CToolTip::MessageLoop()
             }
         }
     }
-    //IsModal = FALSE; // zde uz je pozde, nefunguje potom preklikavani mezi dvema tooltipama, napr Config > Change Drive Menu dialog
+      //IsModal = FALSE; // too late here; switching between two tooltips stops working, e.g. Config > Change Drive Menu dialog
     HNotifyWindow = NULL;
     LastID = 0;
-    Hide(); // IsModal uze je FALSE, muzeme zavolat Hide()
+    Hide(); // IsModal is already FALSE, we can call Hide()
     if (msg.message == WM_KEYDOWN && msg.wParam == VK_TAB)
     {
         HWND hDialog = GetForegroundWindow();
@@ -303,7 +303,7 @@ BOOL CToolTip::GetText()
     }
     if (TextLen == 0)
     {
-        // neobdrzeli jsme text - zhasneme minuly tooltip a vypadneme
+        // we did not receive text - hide the previous tooltip and bail out
         if (HWindow != NULL)
             Hide();
         return FALSE;
@@ -332,12 +332,12 @@ BOOL CToolTip::Show(int x, int y, BOOL considerCursor, BOOL modal, HWND hParent)
 {
     CALL_STACK_MESSAGE1("CToolTip::Show()");
 
-    // vytahneme text z okna
+    // pull the text from the window
     TextLen = 0;
 
     if (GetText())
     {
-        // merime text
+        // measure the text
         SIZE sz;
         GetNeededWindowSize(&sz);
 
@@ -345,9 +345,9 @@ BOOL CToolTip::Show(int x, int y, BOOL considerCursor, BOOL modal, HWND hParent)
         if (considerCursor)
             y += GetCursorHeight(GetCursor());
         if (HWindow != NULL)
-            Hide(); // zhasneme predchozi tooltip
+            Hide(); // hide the previous tooltip
 
-        // zajistime viditelnost tooltipu na obrazovce
+        // ensure the tooltip remains visible on the screen
         RECT r, clipRect;
         r.left = x;
         r.right = x + 1;
@@ -359,7 +359,7 @@ BOOL CToolTip::Show(int x, int y, BOOL considerCursor, BOOL modal, HWND hParent)
         if (x + sz.cx > clipRect.right)
             x = clipRect.right - sz.cx;
         if (y + sz.cy > clipRect.bottom)
-            y = oldY - sz.cy; // tooltip umistime nad kurzor
+            y = oldY - sz.cy; // place the tooltip above the cursor
         if (x < clipRect.left)
             x = 0;
         if (y < clipRect.top)
@@ -388,7 +388,7 @@ void CToolTip::Hide()
     }
     else if (HWindow != NULL)
     {
-        // prekrocime hranici threadu a zhazneme tooltip v threadu, ve kterem byl otevren
+        // Cross the thread boundary and shut down the tooltip in the thread where it was opened.
         SendMessage(HWindow, WM_USER_HIDETOOLTIP, 0, 0);
     }
 }
@@ -423,14 +423,14 @@ void CToolTip::SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay)
 {
     CALL_STACK_MESSAGE2("CToolTip::SetCurrentToolTip(, 0x%X)", id);
     if (IsModal)
-        return; // behem modalniho tooltipu nebereme toto volani
+        return; // ignore this call during a modal tooltip
 
     HWND hOldNotifyWindow = HNotifyWindow;
     HNotifyWindow = hNotifyWindow;
     DWORD oldLastID = LastID;
     LastID = id;
 
-    // zabranime nechtenemu zobrazeni tooltipu pri prepnuti do okna
+    // prevent unwanted tooltip display when switching into a window
     POINT currentPos;
     GetCursorPos(&currentPos);
     BOOL sameCursorPos = (currentPos.x == LastCursorPos.x && currentPos.y == LastCursorPos.y);
@@ -448,7 +448,7 @@ void CToolTip::SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay)
     }
     if (hOldNotifyWindow != HNotifyWindow)
     {
-        // zmenilo se okno - sestrelim casovac a zhasnu
+        // the window changed - kill the timer and hide it
         if (WaitingMode != ttmNone)
         {
             WaitingMode = ttmNone;
@@ -467,7 +467,7 @@ void CToolTip::SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay)
         DWORD pos = GetMessagePos();
         if (Show(GET_X_LPARAM(pos), GET_Y_LPARAM(pos), TRUE, FALSE, HNotifyWindow))
         {
-            // pokud se podarilo text zobrazit, zacneme cekat na jeho zhasnuti
+            // if the text was displayed, start waiting for it to fade
             WaitingMode = ttmWaitingClose;
             MySetTimer(GetTime(FALSE));
             HideCounter = 0;
@@ -476,7 +476,7 @@ void CToolTip::SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay)
         {
             if (WaitingMode != ttmWaitingKill)
             {
-                // text nebyl dodan - nahodime cekani na KILL
+                // text was not delivered - start the wait for KILL
                 WaitingMode = ttmWaitingKill;
                 MySetTimer(TOOLTIP_KILLDELAY);
             }
@@ -486,7 +486,7 @@ void CToolTip::SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay)
     {
         if (HNotifyWindow == hOldNotifyWindow && LastID == oldLastID && WaitingMode == ttmNone)
             return;
-        // jinak nahodim (pripadne znovu nastavime) casovac
+        // otherwise start (or restart) the timer
         if (showDelay >= 0)
         {
             if (showDelay == 0)
@@ -521,7 +521,7 @@ void CToolTip::OnTimer()
     {
     case ttmNone:
     {
-        // jak je mozne, ze nam prisel timer, kdyz podle stavove promenne nema zadny bezet
+        // how could we get a timer when the state variable says none should run
         TRACE_E("WaitingMode == ttmNone");
         break;
     }
@@ -532,20 +532,20 @@ void CToolTip::OnTimer()
         POINT p;
         GetCursorPos(&p);
         HWND hWnd = WindowFromPoint(p);
-        if (hWnd == HNotifyWindow) // musime stale byt na notify oknem
+          if (hWnd == HNotifyWindow) // we must still be on the notify window
         {
-            if (HasActiveParent(hWnd)) // a jeho root musi byt aktivni
+              if (HasActiveParent(hWnd)) // and its root must be active
             {
                 if (Show(p.x, p.y, TRUE, FALSE, HNotifyWindow))
                 {
-                    // pokud se podarilo text zobrazit, zacneme cekat na jeho zhasnuti
+                      // if the text was displayed, start waiting for it to fade
                     WaitingMode = ttmWaitingClose;
                     MySetTimer(GetTime(FALSE));
                     HideCounter = 0;
                 }
                 else
                 {
-                    // text nebyl dodan - nahodime cekani na KILL
+                      // text was not delivered - start the wait for KILL
                     WaitingMode = ttmWaitingKill;
                     MySetTimer(TOOLTIP_KILLDELAY);
                 }
@@ -561,7 +561,7 @@ void CToolTip::OnTimer()
 
     case ttmWaitingClose:
     {
-        // zkontroluju, jestli neni treba zhasnout tooltip
+          // check whether it is time to hide the tooltip
         POINT p;
         GetCursorPos(&p);
         HWND hWnd = WindowFromPoint(p);
@@ -570,8 +570,8 @@ void CToolTip::OnTimer()
         if (hWnd != HNotifyWindow || HideCounter == HideCounterMax)
         {
             Hide();
-            // pokud slo o zhasnuti diky time-outu, necham timer jeste bezet
-            // po dobu, nez mys opusti okno nebo dojde k voalni SetCurrentToolTip
+              // if it was hidden due to a timeout, keep the timer running
+              // until the mouse leaves the window or SetCurrentToolTip is called
             if (hWnd != HNotifyWindow)
             {
                 WaitingMode = ttmNone;
@@ -613,11 +613,11 @@ CToolTip::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_USER_REFRESHTOOLTIP:
     {
-        // musime zachovat stavajici okenko -- pouze ho natahnem pro novy text
+        // we must keep the existing window—just stretch it for the new text
         if (GetText())
         {
             SIZE sz;
-            GetNeededWindowSize(&sz); // kaslem na osetreni vylezeni z obrazovky
+              GetNeededWindowSize(&sz); // ignore handling for climbing off the screen
             SetWindowPos(HWindow, NULL, 0, 0, sz.cx, sz.cy, SWP_NOACTIVATE | SWP_NOMOVE);
             InvalidateRect(HWindow, NULL, TRUE);
             UpdateWindow(HWindow);
@@ -627,7 +627,7 @@ CToolTip::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_ERASEBKGND:
     {
-        // podmazeme a soucasne vykreslime text
+        // fill the background and draw the text at the same time
         HDC hDC = (HDC)wParam;
         RECT r;
         GetClientRect(HWindow, &r);
@@ -646,7 +646,7 @@ CToolTip::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_PAINT:
     {
-        // nedelame nic - vse je zarizeno v WM_ERASEBKGND
+        // do nothing - everything is handled in WM_ERASEBKGND
         PAINTSTRUCT ps;
         HANDLES(BeginPaint(HWindow, &ps));
         HANDLES(EndPaint(HWindow, &ps));


### PR DESCRIPTION
## Summary
- polish CTBCustomizeDialog comments to clarify dummy values and list updates during customization
- improve toolbar bitmap processing notes for grayscale and mask generation along with temporary icon handling
- tighten drag-and-drop and tooltip lifecycle comments across toolbar components for clearer English phrasing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9baf8f5e48322a9af1316364c7f20