### PR TITLE
Polish toolbar translation comments

### DIFF
--- a/src/thumbnl.h
+++ b/src/thumbnl.h
@@ -27,13 +27,13 @@ public:
     CShrinkImage();
     ~CShrinkImage();
 
-    // alokuje interni data pro zmensovani a vraci TRUE v pripade upsechu
-    // pokud se alokace nepovedou, vrati FALSE
+    // Allocates internal data for shrinking and returns TRUE on success.
+    // Returns FALSE if the allocation fails.
     BOOL Alloc(DWORD origWidth, DWORD origHeight,
                WORD newWidth, WORD newHeight,
                DWORD* outBuff, BOOL processTopDown);
 
-    // destukce alokovanych bufferu a inicializace promennych
+    // Destroys allocated buffers and reinitializes member variables.
     void Destroy();
 
     void ProcessRows(DWORD* inBuff, DWORD rowCount);
@@ -47,66 +47,67 @@ protected:
 //
 // CSalamanderThumbnailMaker
 //
-// Slouzi pro zmensovani puvodniho obrazku do thumbnailu.
+// Used to shrink the original image into a thumbnail.
 //
 
 class CSalamanderThumbnailMaker : public CSalamanderThumbnailMakerAbstract
 {
 protected:
-    CFilesWindow* Window; // okno panelu, v jehoz icon-readeru fungujeme
+    CFilesWindow* Window; // Panel window whose icon reader we operate within.
 
-    DWORD* Buffer;  // vlastni buffer pro data radek od pluginu
-    int BufferSize; // velikost bufferu 'Buffer'
-    BOOL Error;     // je-li TRUE, nastala pri zpracovani thumbnailu chyba (vysledek neni pouzitelny)
-    int NextLine;   // cislo pristi zpracovavane radky
+    DWORD* Buffer;  // Dedicated buffer for image rows supplied by the plug-in.
+    int BufferSize; // Size of the 'Buffer' buffer.
+    BOOL Error;     // If TRUE, an error occurred while processing the thumbnail, so the result is unusable.
+    int NextLine;   // Index of the next row to process.
 
-    DWORD* ThumbnailBuffer;    // zmenseny obrazek
-    DWORD* AuxTransformBuffer; // pomocny buffer o stejne velikosti jako ThumbnailBuffer (slouzi pro prenos dat pri transformaci + po transformaci se buffery prohodi)
-    int ThumbnailMaxWidth;     // maximalni teoreticke rozmery thumbnailu (v bodech)
-    int ThumbnailMaxHeight;
-    int ThumbnailRealWidth;  // realne rozmery zmenseneho obrazku (v bodech)
-    int ThumbnailRealHeight; //
+    DWORD* ThumbnailBuffer;    // Buffer that holds the reduced image.
+    DWORD* AuxTransformBuffer; // Auxiliary buffer of the same size as ThumbnailBuffer.
+                               // Used to hand off data during transformations; afterwards the buffers swap roles.
+    int ThumbnailMaxWidth;     // Maximum theoretical thumbnail width (in points).
+    int ThumbnailMaxHeight;    // Maximum theoretical thumbnail height (in points).
+    int ThumbnailRealWidth;    // Actual width of the reduced image (in points).
+    int ThumbnailRealHeight;   // Actual height of the reduced image (in points).
 
-    // parametry zpracovavaneho obrazku
+    // Parameters of the image being processed.
     int OriginalWidth;
     int OriginalHeight;
     DWORD PictureFlags;
     BOOL ProcessTopDown;
 
-    CShrinkImage Shrinker; // zajistuje zmensovani obrazku
+    CShrinkImage Shrinker; // Handles the actual image shrinking.
     BOOL ShrinkImage;
 
 public:
     CSalamanderThumbnailMaker(CFilesWindow* window);
     ~CSalamanderThumbnailMaker();
 
-    // vycisteni objektu - vola se pred zpracovanim dalsiho thumbnailu nebo kdyz uz
-    // neni potreba thumbnail (at uz hotovy nebo ne) z tohoto objektu
-    // parametr 'thumbnailMaxSize' udava maximalni moznou sirku a vysku
-    // thumbnailu v bodech; pokud je roven -1, ignoruje se
+    // Cleans up the object—call before processing another thumbnail or
+    // whenever the object no longer needs one (finished or not).
+    // The 'thumbnailMaxSize' parameter specifies the maximum thumbnail width
+    // and height in points; if it equals -1, the limit is ignored.
     void Clear(int thumbnailMaxSize = -1);
 
-    // vraci TRUE pokud je v tomto objektu pripraveny cely thumbnail (povedlo se
-    // jeho ziskani od pluginu)
+    // Returns TRUE if the complete thumbnail is already available in this object
+    // (successfully obtained from the plug-in).
     BOOL ThumbnailReady();
 
-    // provede transformaci thumbnailu podle PictureFlags (SSTHUMB_MIRROR_VERT uz je hotova,
-    // zbyva provest SSTHUMB_MIRROR_HOR a SSTHUMB_ROTATE_90CW)
+    // Performs thumbnail transformations according to PictureFlags.
+    // SSTHUMB_MIRROR_VERT is already handled; SSTHUMB_MIRROR_HOR and SSTHUMB_ROTATE_90CW remain.
     void TransformThumbnail();
 
-    // konvertuje hotovy thumbnail na DDB a jeji rozmery a raw data ulozi do 'data'
+    // Converts the finished thumbnail to a DDB and stores its dimensions and raw data in 'data'.
     BOOL RenderToThumbnailData(CThumbnailData* data);
 
-    // pokud se nevytvoril cely thumbnail a nenastala chyba (viz 'Error'), doplni
-    // zbytek thumbnailu bilou barvou (aby se v nedefinovane casti thumbnailu
-    // nezobrazovaly zbytky predchoziho thumbnailu); pokud se nevytvorily ani
-    // tri radky thumbnailu, nic se nedoplnuje (thumbnail by byl stejne k nicemu)
+    // If the full thumbnail was not created and no error occurred (see 'Error'),
+    // fill the remainder of the thumbnail with white so undefined parts do not
+    // show leftovers from the previous thumbnail. If fewer than three rows
+    // were produced, leave it empty (the thumbnail would be useless anyway).
     void HandleIncompleteImages();
 
     BOOL IsOnlyPreview() { return (PictureFlags & SSTHUMB_ONLY_PREVIEW) != 0; }
 
     // *********************************************************************************
-    // metody rozhrani CSalamanderThumbnailMakerAbstract
+    // Methods of the CSalamanderThumbnailMakerAbstract interface.
     // *********************************************************************************
 
     virtual BOOL WINAPI SetParameters(int picWidth, int picHeight, DWORD flags);

--- a/src/toolbar.h
+++ b/src/toolbar.h
@@ -25,21 +25,21 @@ protected:
                     // a bitmap, only text.
     HICON HIcon;
     HICON HOverlay;
-    DWORD CustomData; // FIXME_X64 - male pro ukazatel, neni nekdy potreba?
-    int Width;        // width of item (computed if TLBI_STYLE_AUTOSIZE is set)
+    DWORD CustomData; // FIXME_X64 - too small for a pointer; do we ever need it?
+    int Width;        // Width of the item (computed if TLBI_STYLE_AUTOSIZE is set)
 
-    char* Name; // name in customize dialog (valid during custimize session)
+    char* Name; // Name shown in the Customize dialog (valid only during the customization session).
 
-    // tyto hodnoty se pouzivaji pro optimalizovany pristup ke stavum polozek
-    DWORD* Enabler; // Ukazuje na promennou, ktera ridi stav polozky.
-                    // Hodnote ruzne od nuly odpovida nulovany bit TLBI_STATE_GRAYED.
-                    // Nule odpovida nastaveny bit TLBI_STATE_GRAYED.
+    // These values are used for optimized access to item states.
+    DWORD* Enabler; // Points to the variable that controls the item state.
+                    // A non-zero value keeps TLBI_STATE_GRAYED cleared.
+                    // Zero means TLBI_STATE_GRAYED is set.
 
     // internal data
-    int Height; // height of item
-    int Offset; // position of item in whole toolbar
+    int Height; // Item height.
+    int Offset; // Item offset within the entire toolbar.
 
-    WORD IconX; // umisteni jednotlivych prvku
+    WORD IconX; // Horizontal offsets for the individual elements.
     WORD TextX;
     WORD InnerX;
     WORD OutterX;
@@ -66,62 +66,61 @@ class CToolBar : public CWindow, public CGUIToolBarAbstract
 protected:
     TIndirectArray<CToolBarItem> Items;
 
-    int Width; // rozmery celeho okna
+    int Width; // Width of the entire window.
     int Height;
     HFONT HFont;
     int FontHeight;
-    HWND HNotifyWindow; // kam budeme dorucovat notifikace
+    HWND HNotifyWindow; // Target window for notifications.
     HIMAGELIST HImageList;
     HIMAGELIST HHotImageList;
-    int ImageWidth; // rozmery jednoho obrazku z imagelistu
+    int ImageWidth; // Dimensions of a single image from the image list.
     int ImageHeight;
     DWORD Style;          // TLB_STYLE_xxx
-    BOOL DirtyItems;      // nastala operace, ktera ovlivnuje rozlozeni polozek
-                          // a je treba provest prepocet
-    CBitmap* CacheBitmap; // pres tuto bitmapu kreslime ven
-    CBitmap* MonoBitmap;  // pro grayed ikonky
-    int CacheWidth;       // rozmery bitmapy
-    int CacheHeight;
-    int HotIndex; // -1 = zadny
+    BOOL DirtyItems;      // TRUE when an operation affects item layout and a recalculation is required.
+    CBitmap* CacheBitmap; // Off-screen bitmap we render into.
+    CBitmap* MonoBitmap;  // Used to render grayed icons.
+    int CacheWidth;       // Width of the cache bitmap.
+    int CacheHeight;      // Height of the cache bitmap.
+    int HotIndex; // -1 = none.
     int DownIndex;
     BOOL DropPressed;
     BOOL MonitorCapture;
     BOOL RelayToolTip;
     TOOLBAR_PADDING Padding;
-    BOOL HasIcon;       // pokud drzi nejakou ikonu, bude funkce GetNeededSpace() pocitat s jeji vyskou
-    BOOL HasIconDirty;  // je potreba detekovat pritomnost ikony pro GetNeededSpace()?
-    BOOL Customizing;   // je prave toolbara konfigurovana
-    int InserMarkIndex; // -1 = zadny
+    BOOL HasIcon;       // TRUE when an icon is stored, so GetNeededSpace() must account for its height.
+    BOOL HasIconDirty;  // TRUE when icon presence must be re-detected for GetNeededSpace().
+    BOOL Customizing;   // Is the toolbar currently being customized?
+    int InserMarkIndex; // -1 = none.
     BOOL InserMarkAfter;
-    BOOL MouseIsTracked;  // je mys sledovana pomoci TrackMouseEvent?
-    DWORD DropDownUpTime; // cas v [ms], kdy byl odmackunt drop down, pro ochranu pred novym zamacknutim
-    BOOL HelpMode;        // Salamander je Shift+F1 (ctx help) rezimu a toolbar by mel vysvitit i disabled polozky pod kurzorem
+    BOOL MouseIsTracked;  // Is the mouse being tracked via TrackMouseEvent?
+    DWORD DropDownUpTime; // Timestamp in milliseconds when the drop-down was released to avoid immediate re-pressing.
+    BOOL HelpMode;        // Salamander is in Shift+F1 (context help) mode; highlight disabled items under the cursor.
 
 public:
     //
-    // Vlastni metody
+    // Custom methods
     //
     CToolBar(HWND hNotifyWindow, CObjectOrigin origin = ooAllocated);
     ~CToolBar();
 
     //
-    // Implementace metod CGUIToolBarAbstract
+    // Implementation of CGUIToolBarAbstract methods
     //
 
     virtual BOOL WINAPI CreateWnd(HWND hParent);
     virtual HWND WINAPI GetHWND() { return HWindow; }
 
-    virtual int WINAPI GetNeededWidth(); // vrati rozmery, ktere budou pro okno potreba
+    virtual int WINAPI GetNeededWidth(); // Returns the width the window requires.
     virtual int WINAPI GetNeededHeight();
 
     virtual void WINAPI SetFont();
-    virtual BOOL WINAPI GetItemRect(int index, RECT& r); // vrati umisteni polozky ve screen souradnicich
+    virtual BOOL WINAPI GetItemRect(int index, RECT& r); // Returns the item's rectangle in screen coordinates.
 
     virtual BOOL WINAPI CheckItem(DWORD position, BOOL byPosition, BOOL checked);
     virtual BOOL WINAPI EnableItem(DWORD position, BOOL byPosition, BOOL enabled);
 
-    // pokud je prirazen image list, vlozi do nej na odpovidajici misto ikonu
-    // promenne normal a hot urcuji, ktere imagelisty budou ovlivneny
+    // If an image list is assigned, inserts the icon at the corresponding position.
+    // The 'normal' and 'hot' flags determine which image lists are affected.
     virtual BOOL WINAPI ReplaceImage(DWORD position, BOOL byPosition, HICON hIcon, BOOL normal = TRUE, BOOL hot = FALSE);
 
     virtual int WINAPI FindItemPosition(DWORD id);
@@ -132,7 +131,7 @@ public:
     virtual void WINAPI SetHotImageList(HIMAGELIST hImageList);
     virtual HIMAGELIST WINAPI GetHotImageList();
 
-    // styl toolbary
+    // Toolbar style accessors.
     virtual void WINAPI SetStyle(DWORD style);
     virtual DWORD WINAPI GetStyle();
 
@@ -141,35 +140,34 @@ public:
 
     virtual int WINAPI GetItemCount() { return Items.Count; }
 
-    // vyvola konfiguracni dialog
+    // Opens the configuration dialog.
     virtual void WINAPI Customize();
 
     virtual void WINAPI SetPadding(const TOOLBAR_PADDING* padding);
     virtual void WINAPI GetPadding(TOOLBAR_PADDING* padding);
 
-    // obehne vsechny polozky a pokud maji nastaveny ukazatel 'EnablerData'
-    // porovna hodnoty (na kterou ukazuje) se skutecnym stavem polozky.
-    // Pokud se stav lisi, zmeni ho.
+    // Walks all items and, when 'EnablerData' is set, compares the referenced value
+    // with the actual item state; updates the state when they differ.
     virtual void WINAPI UpdateItemsState();
 
-    // pokud je bod nad nekterou z polozek (ne nad separatororem), vrati jeji index.
-    // jinak vrati zaporne cislo
+    // If the point is above an item (not a separator), returns its index;
+    // otherwise returns a negative value.
     virtual int WINAPI HitTest(int xPos, int yPos);
 
-    // vraci TRUE, pokud je na pozice na rozhrani polozky; pak take nastavi 'index'
-    // na tuto polozku a promennout 'after', ktera udava, jestli jde o levou nebo
-    // pravou stranu polozky. Pokud je pod nad nejakou polozkou, vrati FALSE.
-    // Pokud bod nelezi nad zadnou plozkou, vrati TRUE a 'index' nastavi na -1.
+    // Returns TRUE if the point lies on an item boundary; in that case it sets 'index'
+    // to that item and the 'after' flag to indicate whether it is the left or right side.
+    // Returns FALSE when the point is over an item. If the point is not above any item,
+    // it returns TRUE and sets 'index' to -1.
     virtual BOOL WINAPI InsertMarkHitTest(int xPos, int yPos, int& index, BOOL& after);
 
-    // nastavi InsertMark na pozici index (pred nebo za)
-    // pokud je index == -1, odstrani InsertMark
+    // Sets the insert mark to the given index (before or after).
+    // If index == -1, removes the insert mark.
     virtual void WINAPI SetInsertMark(int index, BOOL after);
 
     // Sets the hot item in a toolbar. Returns the index of the previous hot item, or -1 if there was no hot item.
     virtual int WINAPI SetHotItem(int index);
 
-    // mohlo dojit ke zmene barevne hloubky obrazovky; je treba prebuildit CacheBitmap
+    // Rebuild CacheBitmap when the display color depth changes.
     virtual void WINAPI OnColorsChanged();
 
     virtual BOOL WINAPI InsertItem2(DWORD position, BOOL byPosition, const TLBI_ITEM_INFO2* tii);
@@ -186,14 +184,14 @@ protected:
 
     void DrawInsertMark(HDC hDC);
 
-    // vraci TRUE, pokud je na pozici polozka; pak take nastavi 'index'
-    // jinak vraci FALSE
-    // pokud uzivatel kliknul na drop down, nastavi 'dropDown' na TRUE
+    // Returns TRUE if an item is at the position and sets 'index'.
+    // Otherwise returns FALSE.
+    // If the user clicked the drop-down, sets 'dropDown' to TRUE.
     BOOL HitTest(int xPos, int yPos, int& index, BOOL& dropDown);
 
-    // obehne vsechny polozky a napocit si k nim 'MinWidth' a 'XOffset'
-    // ridi se (a nastavuje) DirtyItems
-    // vrati TRUE, pokud doslo k prekresleni vsech polozek
+    // Iterates through every item and calculates 'MinWidth' and 'XOffset'.
+    // Controlled by (and updates) DirtyItems.
+    // Returns TRUE if all items were redrawn.
     BOOL Refresh();
 
     friend class CTBCustomizeDialog;
@@ -214,7 +212,7 @@ class CTBCustomizeDialog : public CCommonDialog
     };
 
 protected:
-    TDirectArray<TLBI_ITEM_INFO2> AllItems; // vsechny dostupne polozky
+    TDirectArray<TLBI_ITEM_INFO2> AllItems; // All available items.
     CToolBar* ToolBar;
     HWND HAvailableLB;
     HWND HCurrentLB;
@@ -231,11 +229,11 @@ protected:
     virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
     void DestroyItems();
-    BOOL EnumButtons(); // pomoci notifikace WM_USER_TBENUMBUTTON2 naplni pole Items vsema tlacitkama, ktere muze toolbar drzet
+    BOOL EnumButtons(); // Uses the WM_USER_TBENUMBUTTON2 notification to list every button the toolbar can host.
 
-    BOOL PresentInToolBar(DWORD id);      // je tento command v toolbare ?
-    BOOL FindIndex(DWORD id, int* index); // vyhleda command v AllItems
-    void FillLists();                     // naplni oba listboxy
+    BOOL PresentInToolBar(DWORD id);      // Is this command present in the toolbar?
+    BOOL FindIndex(DWORD id, int* index); // Finds the command in AllItems.
+    void FillLists();                     // Populates both list boxes.
 
     void EnableControls();
     void MoveItem(int srcIndex, int tgtIndex);
@@ -250,8 +248,8 @@ protected:
 //
 // CMainToolBar
 //
-// Toolbar, ktery jde konfigurovat, nese tlacitka s commandy. Lezi na vrsku
-// Salama a nad kazdym panelem.
+// Configurable toolbar that holds command buttons. It sits at the top of Salamander,
+// above each panel.
 //
 
 enum CMainToolBarType
@@ -273,27 +271,27 @@ public:
     BOOL Load(const char* data);
     BOOL Save(char* data);
 
-    // je treba vratit tooltip
+    // Must return a tooltip.
     void OnGetToolTip(LPARAM lParam);
-    // pri konfiguraci plni konfiguracni dialog polozkama
+    // Supplies the customization dialog with items while customizing.
     BOOL OnEnumButton(LPARAM lParam);
-    // uzivatel stisknul reset v konfiguracnim dialogu - nalejeme default sestavu
+    // The user pressed Reset in the configuration dialog—load the default layout.
     void OnReset();
 
     void SetType(CMainToolBarType type);
 
 protected:
-    // do 'tii' naplni data pro poozku 'tbbeIndex' a vrati TRUE
-    // pokud polozka neni uplna (zruseny prikaz), vrati FALSE
-    BOOL FillTII(int tbbeIndex, TLBI_ITEM_INFO2* tii, BOOL fillName); // 'buttonIndex' je z rodiny TBBE_xxxx; -1 = separator
+    // Fills 'tii' with data for the 'tbbeIndex' item and returns TRUE.
+    // Returns FALSE when the item is incomplete (command removed).
+    BOOL FillTII(int tbbeIndex, TLBI_ITEM_INFO2* tii, BOOL fillName); // 'buttonIndex' belongs to the TBBE_xxxx family; -1 = separator.
 };
 
 //*****************************************************************************
 //
 // CBottomToolBar
 //
-// toolbar ve spodni casti Salamandera - obsahuje napovedu pro F1-F12 v
-// kombinaci s Ctrl, Alt a Shift
+// Toolbar at the bottom of Salamander—shows help for F1-F12 in
+// combination with Ctrl, Alt, and Shift.
 //
 
 enum CBottomTBStateEnum
@@ -317,11 +315,11 @@ public:
 
     virtual BOOL WINAPI CreateWnd(HWND hParent);
 
-    // vola se pri kazde zmene modifikatoru (Ctrl,Alt,Shift) - obehne naplnenou
-    // toolbaru a nastavi ji texty a ID
+    // Called whenever modifier keys (Ctrl, Alt, Shift) change—iterates the populated
+    // toolbar and updates its texts and IDs.
     BOOL SetState(CBottomTBStateEnum state);
 
-    // inicializuje staticke pole, ze ktereho pak budeme toolbaru krmit
+    // Initializes the static array used to feed the toolbar.
     static BOOL InitDataFromResources();
 
     void OnGetToolTip(LPARAM lParam);
@@ -331,10 +329,10 @@ public:
 protected:
     CBottomTBStateEnum State;
 
-    // interni funkce volana z InitDataFromResources
+    // Internal helper called from InitDataFromResources.
     static BOOL InitDataResRow(CBottomTBStateEnum state, int textResID);
 
-    // pro kazde tlacitko najde nedelsi text a podle nej nastavi tlacitku sirku
+    // Finds the longest text for each button and sets the button width accordingly.
     BOOL SetMaxItemWidths();
 };
 
@@ -348,7 +346,7 @@ class CUserMenuBar : public CToolBar
 public:
     CUserMenuBar(HWND hNotifyWindow, CObjectOrigin origin = ooStatic);
 
-    // vytahne z UserMenu polozky a naleje buttony do toolbary
+    // Retrieves items from the UserMenu and populates the toolbar with buttons.
     BOOL CreateButtons();
 
     void ToggleLabels();
@@ -375,7 +373,7 @@ class CHotPathsBar : public CToolBar
 public:
     CHotPathsBar(HWND hNotifyWindow, CObjectOrigin origin = ooStatic);
 
-    // vytahne z HotPaths polozky a naleje buttony do toolbary
+    // Retrieves items from HotPaths and populates the toolbar with buttons.
     BOOL CreateButtons();
 
     void ToggleLabels();
@@ -402,7 +400,7 @@ class CDrivesList;
 class CDriveBar : public CToolBar
 {
 protected:
-    // navratove hodnoty pro List
+    // Return values for List.
     DWORD DriveType;
     DWORD_PTR DriveTypeParam;
     int PostCmd;
@@ -410,11 +408,11 @@ protected:
     BOOL FromContextMenu;
     CDrivesList* List;
 
-    // cache: obsahuje ?: nebo \\ pro UNC nebo prazdny retezec
+    // Cache: stores ?:, \\ for UNC, or an empty string.
     char CheckedDrive[3];
 
 public:
-    // ikony pluginu chceme zobrazovat cernobile, takze je musime drzet v image listech
+    // Plug-in icons are kept in image lists so we can display them in grayscale.
     HIMAGELIST HDrivesIcons;
     HIMAGELIST HDrivesIconsGray;
 
@@ -424,39 +422,39 @@ public:
 
     void DestroyImageLists();
 
-    // vyhaze existujici a naleje nova tlacitka;
-    // neni-li 'copyDrivesListFrom' NULL, maji se data o discich kopirovat misto znovu ziskavat
-    // 'copyDrivesListFrom' muze odkazovat i na volany objekt
+    // Removes existing buttons and loads new ones.
+    // If 'copyDrivesListFrom' is not NULL, copy its drive data instead of querying again.
+    // 'copyDrivesListFrom' may even point to the called object itself.
     BOOL CreateDriveButtons(CDriveBar* copyDrivesListFrom);
 
     virtual int WINAPI GetNeededHeight();
 
     void OnGetToolTip(LPARAM lParam);
 
-    // user clicknul na tlacitku s commandem id
+    // The user clicked the button with the given command id.
     void Execute(DWORD id);
 
-    // zamackne ikonku odpovidajici ceste; pokud takovou nenalezne, nebude
-    // zamackla zadna; promenna force vyradi cache
+    // Depresses the icon that corresponds to the path; if none matches, all buttons are released.
+    // The 'force' argument invalidates the cache.
     void SetCheckedDrive(CFilesWindow* panel, BOOL force = FALSE);
 
-    // pokud prijde notifikace o pridani/odstraneni disku, je treba znovu naplnit seznam;
-    // neni-li 'copyDrivesListFrom' NULL, maji se data o discich kopirovat misto znovu ziskavat
-    // 'copyDrivesListFrom' muze odkazovat i na volany objekt
+    // Rebuilds the list after a drive-add or drive-remove notification.
+    // If 'copyDrivesListFrom' is not NULL, copy its drive data instead of querying again.
+    // 'copyDrivesListFrom' may even point to the called object itself.
     void RebuildDrives(CDriveBar* copyDrivesListFrom = NULL);
 
-    // je treba vybalit context menu; poozka se urci z GetMessagePos; vrati TRUE,
-    // pokud bylo trefeno tlacitko a vybalilo se menu; jinak vrati FALSE
+    // Displays the context menu; the item is determined by GetMessagePos.
+    // Returns TRUE if a button was hit and the menu was shown; otherwise returns FALSE.
     BOOL OnContextMenu();
 
-    // vraci bitove pole disku, jak bylo ziskano pri poslednim List->BuildData()
-    // pokud BuildData() jeste neprobehlo, vraci 0
-    // lze pouzit pro rychlou detekci, zda nedoslo k nejake zmene disku
+    // Returns the bit mask of drives obtained by the last List->BuildData().
+    // Returns 0 if BuildData() has not run yet.
+    // Can be used to quickly detect whether any drive changed.
     DWORD GetCachedDrivesMask();
 
-    // vraci bitove pole dostupnych cloud storages, jak bylo ziskano pri poslednim List->BuildData()
-    // pokud BuildData() jeste neprobehlo, vraci 0
-    // lze pouzit pro rychlou detekci, zda nedoslo k nejake zmene dostupnosti cloud storages
+    // Returns the bit mask of available cloud storages obtained by the last List->BuildData().
+    // Returns 0 if BuildData() has not run yet.
+    // Can be used to quickly detect whether cloud storage availability changed.
     DWORD GetCachedCloudStoragesMask();
 
 protected:
@@ -471,7 +469,7 @@ protected:
 class CPluginsBar : public CToolBar
 {
 protected:
-    // ikonky reprezentujici pluginy, vyvorene pomoci CPlugins::CreateIconsList
+    // Icons representing plug-ins, created by CPlugins::CreateIconsList.
     HIMAGELIST HPluginsIcons;
     HIMAGELIST HPluginsIconsGray;
 
@@ -481,7 +479,7 @@ public:
 
     void DestroyImageLists();
 
-    // vyhaze existujici a naleje nova tlacitka
+    // Removes existing buttons and loads new ones.
     BOOL CreatePluginButtons();
 
     virtual int WINAPI GetNeededHeight();

--- a/src/toolbar1.cpp
+++ b/src/toolbar1.cpp
@@ -115,7 +115,7 @@ CToolBar::CToolBar(HWND hNotifyWindow, CObjectOrigin origin)
 CToolBar::~CToolBar()
 {
     CALL_STACK_MESSAGE1("CToolBar::~CToolBar()");
-    // destrukce je jeste v WM_DESTROY
+    // Cleanup also runs from WM_DESTROY.
     if (CacheBitmap != NULL)
     {
         delete CacheBitmap;
@@ -229,7 +229,7 @@ int CToolBar::GetNeededHeight()
     {
         if (HasIconDirty)
         {
-            // koukneme, jestli drzime nejakou ikonu
+            // Check whether we still hold any icon.
             HasIcon = FALSE;
             HasIconDirty = FALSE;
             int i;
@@ -361,7 +361,7 @@ BOOL CToolBar::InsertItem2(DWORD position, BOOL byPosition, const TLBI_ITEM_INFO
 {
     CALL_STACK_MESSAGE3("CToolBar::InsertItem2(0x%X, %d, )", position, byPosition);
     int newPos;
-    // vyhledame pozici, kam prijde nova polozka
+    // Find the position where the new item will go.
     if (byPosition)
     {
         if (position == -1 || position > (DWORD)Items.Count)
@@ -379,7 +379,7 @@ BOOL CToolBar::InsertItem2(DWORD position, BOOL byPosition, const TLBI_ITEM_INFO
         }
     }
 
-    // naalokujeme polozku
+    // Allocate the item.
     CToolBarItem* item = new CToolBarItem();
     if (item == NULL)
     {
@@ -387,7 +387,7 @@ BOOL CToolBar::InsertItem2(DWORD position, BOOL byPosition, const TLBI_ITEM_INFO
         return FALSE;
     }
 
-    // vlozime polozku do pole
+    // Insert the item into the array.
     Items.Insert(newPos, item);
     if (!Items.IsGood())
     {
@@ -396,7 +396,7 @@ BOOL CToolBar::InsertItem2(DWORD position, BOOL byPosition, const TLBI_ITEM_INFO
         return FALSE;
     }
 
-    // nastavime data
+    // Set the data.
     if (!SetItemInfo2(newPos, TRUE, tii))
     {
         Items.Delete(newPos);
@@ -459,7 +459,7 @@ BOOL CToolBar::SetItemInfo2(DWORD position, BOOL byPosition, const TLBI_ITEM_INF
         }
         else if (hadIcon)
         {
-            HasIconDirty = TRUE; // nevime, jestli jeste nejaka ikona zbyla - bude treba to zjistit
+            HasIconDirty = TRUE; // We do not know whether any icon remains—it has to be checked.
         }
     }
 
@@ -487,14 +487,14 @@ BOOL CToolBar::SetItemInfo2(DWORD position, BOOL byPosition, const TLBI_ITEM_INF
             tii->Mask & TLBI_MASK_IMAGEINDEX || tii->Mask & TLBI_MASK_ICON ||
             (tii->Mask & TLBI_MASK_WIDTH && item->Style & TLBI_STYLE_FIXEDWIDTH))
         {
-            // tato zmena muze mit dopad na celou toolbaru
+            // This change can affect the entire toolbar.
             DirtyItems = TRUE;
             if (HWindow != NULL)
                 InvalidateRect(HWindow, NULL, FALSE);
         }
         else
         {
-            // nechame prekreslit pouze jedno tlacitko, ktere se menilo
+            // Redraw only the button that changed.
             if ((tii->Mask & TLBI_MASK_STATE) && HWindow != NULL)
             {
                 RECT r;
@@ -752,7 +752,7 @@ void CToolBar::SetStyle(DWORD style)
     }
     DWORD oldStyle = Style;
     Style = style;
-    // pokud se zmenilo zobrazovani textu, prealokuju si
+    // If text display changed, update the font settings.
     if ((oldStyle & TLB_STYLE_TEXT) != (Style & TLB_STYLE_TEXT))
         SetFont();
     DirtyItems = TRUE;
@@ -800,7 +800,7 @@ void CToolBar::UpdateItemsState()
 
         if (item->Enabler != NULL)
         {
-            // bit TLBI_STATE_GRAYED je rizen
+            // TLBI_STATE_GRAYED is controlled externally.
             BOOL enabled = (item->State & TLBI_STATE_GRAYED) == 0;
             BOOL enabledSrc = *item->Enabler != 0;
             if (enabled != enabledSrc)
@@ -822,7 +822,7 @@ void CToolBar::UpdateItemsState()
 
 void CToolBar::OnColorsChanged()
 {
-    // pokud existuje barevna bitmapa, nechame ji prebuildit pro aktualni barevnou hloubku
+    // If a color bitmap exists, rebuild it for the current color depth.
     if (CacheBitmap != NULL)
         CacheBitmap->ReCreateForScreenDC();
 }
@@ -835,7 +835,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_DESTROY:
     {
-        // destrukce je jeste v destruktoru
+        // Destruction is also handled in the destructor.
         if (CacheBitmap != NULL)
         {
             delete CacheBitmap;
@@ -870,7 +870,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_ERASEBKGND:
     {
-        if (WindowsVistaAndLater) // pod vistou blika rebar
+        if (WindowsVistaAndLater) // Rebar flickers under Vista.
             return TRUE;
         RECT r;
         GetClientRect(HWindow, &r);
@@ -896,7 +896,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CANCELMODE:
     {
         MouseIsTracked = FALSE;
-        SetCurrentToolTip(NULL, 0); // vykopneme tooltip
+        SetCurrentToolTip(NULL, 0); // Dismiss the tooltip.
         if (!MonitorCapture)
             break;
         if (HotIndex != -1)
@@ -969,7 +969,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         if (newHotIndex != HotIndex)
         {
-            // vykreslime zmeny
+            // Draw the changes.
             int oldHotIndex = HotIndex;
             HotIndex = newHotIndex;
             if (oldHotIndex != -1)
@@ -989,19 +989,19 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_LBUTTONDOWN:
     case WM_LBUTTONDBLCLK:
     {
-        // pokud kliknuti prislo do 25ms po odmacknuti drop downu, zahodime ho, aby nedoslo
-        // ke zbytecnemu novemu zamacknuti
+        // If the click arrives within 25 ms of releasing the drop-down, ignore it
+        // to avoid an unnecessary new press.
         if (GetTickCount() - DropDownUpTime <= 25)
             break;
 
-        SetCurrentToolTip(NULL, 0); // vykopneme tooltip
+        SetCurrentToolTip(NULL, 0); // Dismiss the tooltip.
         int xPos = (short)LOWORD(lParam);
         int yPos = (short)HIWORD(lParam);
 
         int index;
         BOOL dropDown;
-        // Pokud je otevrene windows popup menu a klikneme do toolbary, prijde rovnou
-        // WM_LBUTTONDOWN takze HotIndex == -1, proto vyrazuji podminku index == HotIndex.
+        // If a Windows pop-up menu is open and we click the toolbar, WM_LBUTTONDOWN
+        // arrives immediately with HotIndex == -1, so ignore the condition index == HotIndex.
         if (HitTest(xPos, yPos, index, dropDown) /*&& index == HotIndex*/)
         {
             CToolBarItem* item = Items[index];
@@ -1040,7 +1040,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     DownIndex = -1;
                     SendMessage(HWindow, WM_MOUSEMOVE, 0, MAKELPARAM(p.x, p.y));
                     if (HotIndex == index)
-                        DrawItem(HotIndex); // pokud nedoslo ke zmene, musim prekreslit stav
+                        DrawItem(HotIndex); // If nothing changed, force a redraw of the state.
                     RelayToolTip = TRUE;
                     DropDownUpTime = GetTickCount();
                 }
@@ -1056,7 +1056,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_LBUTTONUP:
     {
-        SetCurrentToolTip(NULL, 0); // vykopneme tooltip
+        SetCurrentToolTip(NULL, 0); // Dismiss the tooltip.
         if (DownIndex != -1)
         {
             int xPos = (short)LOWORD(lParam);
@@ -1087,8 +1087,8 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 DrawItem(DownIndex);
             DownIndex = -1;
         }
-        // musim uvolnit capture, aby chodily WM_SYSCOMMAND generovane na
-        // zaklade kliknuti na tlacitko v toolbare
+        // We must release capture so WM_SYSCOMMAND generated by clicking
+        // toolbar buttons can be delivered.
         if (GetCapture() == HWindow)
             ReleaseCapture();
         break;
@@ -1096,7 +1096,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_RBUTTONUP:
     {
-        SetCurrentToolTip(NULL, 0); // vykopneme tooltip
+        SetCurrentToolTip(NULL, 0); // Dismiss the tooltip.
         NMHDR nmhdr;
         nmhdr.hwndFrom = HWindow;
         nmhdr.idFrom = (UINT_PTR)GetMenu(HWindow);
@@ -1108,13 +1108,13 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_TTGETTEXT:
     {
-        DWORD index = (DWORD)wParam; // FIXME_X64 - overit pretypovani na (DWORD)
+        DWORD index = (DWORD)wParam; // FIXME_X64 - verify the cast to (DWORD).
         char* text = (char*)lParam;
         if (index >= 0 && index < (DWORD)Items.Count)
         {
             CToolBarItem* item = Items[index];
             if (item->Style & TLBI_STYLE_SEPARATOR)
-                return 0; // separator nema tooltip
+                return 0; // Separators have no tooltip.
             TOOLBAR_TOOLTIP tt;
             tt.HToolBar = HWindow;
             tt.ID = item->ID;

--- a/src/toolbar2.cpp
+++ b/src/toolbar2.cpp
@@ -12,9 +12,9 @@
 // CToolBar
 //
 
-#define TB_SP_WIDTH 6 // sirka separatoru
+#define TB_SP_WIDTH 6 // Separator width.
 
-#define TB_ICON_TB 3 // pocet bodu nad a pod ikonou, vcetne ramecku
+#define TB_ICON_TB 3 // Number of points above and below the icon, including the border.
 #define TB_TEXT_TB 3
 
 void CToolBar::SetFont()
@@ -147,7 +147,7 @@ BOOL CToolBar::HitTest(int xPos, int yPos, int& index, BOOL& dropDown)
             else
             {
                 if (item->Style & TLBI_STYLE_SEPARATOR)
-                    item->Height = Height - 2 * Padding.ToolBarVertical; // separator nema nastavenou vysku - udelam to ted
+                    item->Height = Height - 2 * Padding.ToolBarVertical; // A separator lacks height—set it now.
                 int yOffset = (Height - item->Height) / 2;
                 if (xPos >= item->Offset && xPos < item->Offset + item->Width &&
                     yPos >= yOffset && yPos < yOffset + item->Height)
@@ -183,7 +183,7 @@ BOOL CToolBar::InsertMarkHitTest(int xPos, int yPos, int& index, BOOL& after)
         {
             item = Items[i];
             if (item->Style & TLBI_STYLE_SEPARATOR)
-                item->Height = Height - 2 * Padding.ToolBarVertical; // separator nema nastavenou vysku - udelam to ted
+                item->Height = Height - 2 * Padding.ToolBarVertical; // A separator lacks height—set it now.
             int yOffset = (Height - item->Height) / 2;
             if (xPos >= item->Offset && xPos < item->Offset + item->Width &&
                 yPos >= yOffset && yPos < yOffset + item->Height)
@@ -197,7 +197,7 @@ BOOL CToolBar::InsertMarkHitTest(int xPos, int yPos, int& index, BOOL& after)
                 {
                     if (index > 0)
                     {
-                        // prednostne vratime, ze jsem za minulou polozkou (eliminace blikani)
+                        // Prefer reporting that we are after the previous item (reduces flicker).
                         index--;
                         after = TRUE;
                     }
@@ -210,20 +210,20 @@ BOOL CToolBar::InsertMarkHitTest(int xPos, int yPos, int& index, BOOL& after)
                     after = TRUE;
                     return TRUE;
                 }
-                // bod lezi nad tlacitkem, ale ne dost u jeho okraje
+                // The point is over the button but not close enough to its edge.
                 return FALSE;
             }
         }
         if (item == NULL)
         {
-            // zadna polozka
+            // No item.
             index = -1;
             after = FALSE;
             return TRUE;
         }
         if (xPos >= item->Offset + item->Width)
         {
-            // za posledni polozkou
+            // After the last item.
             index = Items.Count - 1;
             after = TRUE;
             return TRUE;
@@ -275,7 +275,7 @@ BOOL CToolBar::Refresh()
         }
         else
         {
-            // musime urcit sirku podle obsahu
+            // We must determine the width from the content.
 
             int textWidth = 0;
 
@@ -289,7 +289,7 @@ BOOL CToolBar::Refresh()
 
             if (!vertical && (Style & TLB_STYLE_TEXT) && (item->Style & TLBI_STYLE_SHOWTEXT) && item->Text != NULL && *item->Text != 0)
             {
-                // pokud polozka obsahuje text, omerime ho
+                // If the item contains text, measure it.
                 RECT r;
                 r.left = 0;
                 r.top = 0;
@@ -308,7 +308,7 @@ BOOL CToolBar::Refresh()
             if (!vertical && (item->Style & TLBI_STYLE_SEPARATEDROPDOWN))
                 outterDropPresent = TRUE;
 
-            int width = 1; // levy okraj
+            int width = 1; // Left margin.
             int height = 0;
 
             if (iconPresent)
@@ -348,7 +348,7 @@ BOOL CToolBar::Refresh()
                 item->InnerX = width;
                 width += SVGArrowDropDown.GetWidth() + Padding.TextRight;
             }
-            width++; // pravy okraj
+            width++; // Right margin.
 
             if (outterDropPresent)
             {
@@ -358,7 +358,7 @@ BOOL CToolBar::Refresh()
                     width += 2 + SVGArrowDropDown.GetWidth() + 2;
                 }
                 else
-                    item->OutterX = width - (2 + SVGArrowDropDown.GetWidth() + 2); // ukousneme s sirky polozky
+                    item->OutterX = width - (2 + SVGArrowDropDown.GetWidth() + 2); // Steal the space from the item width.
             }
 
             if (!(item->Style & TLBI_STYLE_FIXEDWIDTH))
@@ -373,7 +373,7 @@ BOOL CToolBar::Refresh()
     if (hOldFont != NULL)
         SelectObject(CacheBitmap->HMemDC, hOldFont);
     CacheBitmap->Enlarge(maxWidth, maxHeight);
-    DirtyItems = FALSE; // musim nastavit pred paintem, aby nedoslo k rekurzi
+    DirtyItems = FALSE; // Must be cleared before painting to avoid recursion.
 
     if (HWindow != NULL)
     {
@@ -404,7 +404,7 @@ void CToolBar::DrawItem(int index)
         return;
     }
     if (Refresh())
-        return; // pokud bylo prekresleno vse, nemusime uz nic delat
+        return; // If everything was redrawn, nothing more to do.
 
     HDC hDC = HANDLES(GetDC(HWindow));
     DrawItem(hDC, index);
@@ -421,7 +421,7 @@ void CToolBar::DrawItem(HDC hDC, int index)
     }
     if (index < 0 || index >= Items.Count)
     {
-        // meli jsme nekolik padacek v CToolBar::DrawItem
+        // We previously saw a few crashes in CToolBar::DrawItem.
         TRACE_E("index=" << index << " Items.Count=" << Items.Count);
         return;
     }
@@ -438,7 +438,7 @@ void CToolBar::DrawItem(HDC hDC, int index)
 
     //  TRACE_I("TB DrawItem index:"<<index<<" x:"<<item->Offset);
 
-    // podmazu plochu podkladovou barvou
+    // Cover the area with the background color first.
     RECT r1;
     r1.left = 0;
     r1.top = 0;
@@ -518,14 +518,14 @@ void CToolBar::DrawItem(HDC hDC, int index)
         r.right = width;
         r.bottom = r.top + height;
 
-        BOOL bodyDown = FALSE; // je telo zamackle ?
-        BOOL dropDown = FALSE; // je drop down zamackly?
+        BOOL bodyDown = FALSE; // Is the button body pressed?
+        BOOL dropDown = FALSE; // Is the drop-down pressed?
         BOOL checked = FALSE;
         BOOL grayed = !Customizing && (item->State & TLBI_STATE_GRAYED);
         if (HelpMode && HotIndex == index)
-            grayed = FALSE; // v helpmode jsou i disabled polozky vysviceny
+            grayed = FALSE; // Help mode highlights disabled items as well.
 
-        // vykreslim ramecek
+        // Draw the frame.
         if (!grayed && ((HotIndex == index || item->State & TLBI_STATE_CHECKED) || (item->State & TLBI_STATE_PRESSED)))
         {
             if (outterDropPresent)
@@ -538,7 +538,7 @@ void CToolBar::DrawItem(HDC hDC, int index)
             {
                 if (HotIndex != index)
                 {
-                    // ditherovane zamackle pozadi
+                    // Dithered pressed background.
                     SetBrushOrgEx(CacheBitmap->HMemDC, 0, r.top, NULL);
                     HBRUSH hOldBrush = (HBRUSH)SelectObject(CacheBitmap->HMemDC, HDitherBrush);
                     int oldTextColor = SetTextColor(CacheBitmap->HMemDC, GetSysColor(COLOR_BTNFACE));
@@ -552,13 +552,13 @@ void CToolBar::DrawItem(HDC hDC, int index)
                 checked = TRUE;
             }
 
-            // ramecek kolem tela
+            // Frame around the button body.
             DWORD mode = bodyDown ? BDR_SUNKENOUTER : BDR_RAISEDINNER;
             DrawEdge(CacheBitmap->HMemDC, &r, mode, BF_RECT);
 
             if (HotIndex == index && outterDropPresent)
             {
-                // ramecek kolem drop down
+                // Frame around the drop-down portion.
                 r.left = r.right;
                 r.right = width;
                 mode = dropDown ? BDR_SUNKENOUTER : BDR_RAISEDINNER;
@@ -570,7 +570,7 @@ void CToolBar::DrawItem(HDC hDC, int index)
         {
             if (grayed)
             {
-                // kreslime bud s pozadim (rychlejsi) nebo v priade checked transparentne
+                // Draw either with a background (faster) or transparently when checked.
                 int offset = bodyDown ? 1 : 0;
                 int x = item->IconX + offset;
                 int y = centerOffset + (item->Height - imgH) / 2 + offset;
@@ -588,7 +588,7 @@ void CToolBar::DrawItem(HDC hDC, int index)
             }
             else
             {
-                // kreslime bud s pozadim (rychlejsi) nebo v priade checked transparentne
+                // Draw either with a background (faster) or transparently when checked.
                 int offset = bodyDown ? 1 : 0;
                 int x = item->IconX + offset;
                 int y = centerOffset + (item->Height - imgH) / 2 + offset;
@@ -657,7 +657,7 @@ void CToolBar::DrawItem(HDC hDC, int index)
                 int offset = 0;
                 if (!grayed && dropDown)
                     offset = 1;
-                // zde budeme posouvat pouze dolu - mame malo mista
+                // Only shift downward here—we have limited space.
                 DrawDropDown(CacheBitmap->HMemDC, item->OutterX, y + offset, grayed);
             }
         }
@@ -677,7 +677,7 @@ void CToolBar::DrawAllItems(HDC hDC)
         return;
     }
     if (Refresh())
-        return; // pokud bylo prekresleno vse, nemusime uz nic delat
+        return; // If everything was redrawn, nothing more to do.
 
     BOOL vertical = (Style & TLB_STYLE_VERTICAL) != 0;
 
@@ -723,7 +723,7 @@ void CToolBar::DrawAllItems(HDC hDC)
         }
         offset += length;
     }
-    // domazu zbytek na konci
+    // Clear any remaining space at the end.
     if (vertical)
     {
         if (offset < Height)
@@ -771,7 +771,7 @@ void CToolBar::DrawInsertMark(HDC hDC)
     if (InserMarkIndex == -1)
         return;
     int x = 0;
-    // urcime posizici
+    // Determine the position.
     if (InserMarkIndex >= 0 && InserMarkIndex < Items.Count)
     {
         CToolBarItem* item = Items[InserMarkIndex];
@@ -782,17 +782,17 @@ void CToolBar::DrawInsertMark(HDC hDC)
     x -= 1;
     HPEN hPen = HANDLES(CreatePen(PS_SOLID, 0, RGB(0, 0, 0)));
     HPEN hOldPen = (HPEN)SelectObject(hDC, hPen);
-    // vrchni dve vodorovne cary
+    // Top two horizontal lines.
     MoveToEx(hDC, x - 2, 0, NULL);
     LineTo(hDC, x + 4, 0);
     MoveToEx(hDC, x - 1, 1, NULL);
     LineTo(hDC, x + 3, 1);
-    // dve svisle cary
+    // Two vertical lines.
     MoveToEx(hDC, x, 2, NULL);
     LineTo(hDC, x, Height - 2);
     MoveToEx(hDC, x + 1, 2, NULL);
     LineTo(hDC, x + 1, Height - 2);
-    // spodni dve vodorovne cary
+    // Bottom two horizontal lines.
     MoveToEx(hDC, x - 1, Height - 2, NULL);
     LineTo(hDC, x + 3, Height - 2);
     MoveToEx(hDC, x - 2, Height - 1, NULL);


### PR DESCRIPTION
## Summary
- refine the thumbnail helper comments so the buffer usage and cleanup descriptions read naturally in English
- polish the toolbar header translations for item state handling, customization hooks, and drive bar behaviors
- clarify the toolbar destructor note to explain the WM_DESTROY cleanup path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9babf8a3883229d6997859a91ba24