### PR TITLE
Ensure PR comment guard triggers on labeled event

### DIFF
--- a/.github/workflows/pr-comments-guard.yml
+++ b/.github/workflows/pr-comments-guard.yml
@@ -10,7 +10,9 @@ permissions:
 jobs:
   comment-only:
     name: Ensure Only Comments Change (${{ matrix.mode }}) # Include active mode in job name for clearer logs.
-    if: contains(github.event.pull_request.labels.*.name, 'comments translation')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'comments translation')
+      || (github.event.action == 'labeled' && github.event.label.name == 'comments translation')
     strategy: # Expand the job to cover both evaluation modes.
       fail-fast: false # Make sure the relaxed run completes even if the strict mode fails first.
       matrix:


### PR DESCRIPTION
## Summary
- update the PR comment guard job condition to also check the current labeled event payload
- ensure the workflow runs immediately after the "comments translation" label is applied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb3fd52e908322b00030a41a0e9ade