### PR TITLE
Refine spl_bzip2 header

### DIFF
--- a/src/plugins/shared/spl_bzip2.h
+++ b/src/plugins/shared/spl_bzip2.h
@@ -63,8 +63,8 @@ struct CSalBZIP2
 };
 
 /* Any function of CSalamanderBZIP2Abstract can be called from any thread.
-   Single instance can be used many times, using different bzip2Info structs.
-   For usage howtos, see the comment at the top of this file. */
+   A single instance can be used many times with different bzip2Info structs.
+   For usage instructions, see the comment at the top of this file. */
 
 class CSalamanderBZIP2Abstract
 {
@@ -76,7 +76,7 @@ public:
     virtual int WINAPI CompressEnd(CSalBZIP2* bzip2Info) = 0;
 
     /* Decompression functions */
-    /* bConserveMemory: TRUE to use less memory & decompress slower */
+    /* bConserveMemory: TRUE to use less memory and decompress more slowly */
     virtual int WINAPI DecompressInit(CSalBZIP2* bzip2Info, BOOL bConserveMemory) = 0;
     virtual int WINAPI Decompress(CSalBZIP2* bzip2Info) = 0;
     virtual int WINAPI DecompressEnd(CSalBZIP2* bzip2Info) = 0;


### PR DESCRIPTION
## Summary
- refine the approved translated comments in `src/plugins/shared/spl_bzip2.h`
- carry forward the Codex-only review run from `spl-bzip2-h-run-20260323-064137`
- preserve BOM and pass the comment guard

## Review Artifacts
- HTML: `artifacts/spl-bzip2-h-run-20260323-064137/triple-diff-report.html`
- Summary: `artifacts/spl-bzip2-h-run-20260323-064137/summary.md`

## Validation
- `guard complete: 1 files, 0 violations`
