### PR TITLE
Refine spl_zlib header

### DIFF
--- a/src/plugins/shared/spl_zlib.h
+++ b/src/plugins/shared/spl_zlib.h
@@ -45,7 +45,7 @@
 #define SAL_Z_BUF_ERROR (-5)
 #define SAL_Z_VERSION_ERROR (-6)
 
-/* Control structure associated with each de/compression task */
+/* Control structure associated with each compression/decompression task */
 struct CSalZLIB
 {
     BYTE* next_in;  /* next input byte */
@@ -60,8 +60,8 @@ struct CSalZLIB
 };
 
 /* Any function of CSalamanderZLIBAbstract can be called from any thread.
-   Single instance can be used many times, using different zlibInfo structs.
-   For usage howtos, see the comment at the top of this file. */
+   A single instance can be used many times with different zlibInfo structs.
+   For usage instructions, see the comment at the top of this file. */
 
 class CSalamanderZLIBAbstract
 {


### PR DESCRIPTION
## Summary
- refine translated comments in `src/plugins/shared/spl_zlib.h`
- materialize the approved Codex-only review run for this file
- preserve BOM and comment-only scope

## Validation
- guard: 0 violations
- artifacts: `artifacts/spl-zlib-h-run-20260325-190507`
