### PR TITLE
Review src/common/messages.h

### DIFF
--- a/src/common/messages.h
+++ b/src/common/messages.h
@@ -271,7 +271,7 @@ extern C__MessagesW __MessagesW;
 #define DMESSAGE_TQ(str, buttons) MESSAGE_TQ(str, (buttons))
 #define DMESSAGE_TQW(str, buttons) MESSAGE_TQW(str, (buttons))
 
-/// MESSAGE_TE depends on the existence of the MESSAGES_DEBUG macro
+/// MESSAGE_E depends on the existence of the MESSAGES_DEBUG macro
 #define DMESSAGE_TE(str, buttons) MESSAGE_TE(str, (buttons))
 #define DMESSAGE_TEW(str, buttons) MESSAGE_TEW(str, (buttons))
 


### PR DESCRIPTION
## Summary

- review translation update for `src/common/messages.h`
- fixes one incorrect macro reference in a dependency note

## Review

- HTML artifact: `/mnt/d/source/ostranslation/artifacts/src-common-messages-h-review-20260401/triple-diff-report.html`
- Inline review context comment includes the Czech source block and a one-line rationale