### PR TITLE
Review fixes for English comments in usermenu.h

### DIFF
--- a/src/usermenu.h
+++ b/src/usermenu.h
@@ -101,7 +101,7 @@ enum CUserMenuItemType
     umitItem,         // standard item
     umitSubmenuBegin, // marks the start of a submenu
     umitSubmenuEnd,   // marks the end of a submenu
-    umitSeparator     // marks the end of a popup
+    umitSeparator     // separator item
 };
 
 struct CUserMenuItem


### PR DESCRIPTION
This PR applies a focused review of the English comment translation in src/usermenu.h. It fixes the enum comment for umitSeparator so it matches the actual behavior in menus and toolbars: the value represents a separator item, not the end of a popup. No code was changed.